### PR TITLE
Add runner container support and workload catalog foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin/
+**/obj/
+.git/
+.vs/
+.idea/
+TestResults/

--- a/AgentDeck.Core/AgentDeck.Core.csproj
+++ b/AgentDeck.Core/AgentDeck.Core.csproj
@@ -12,4 +12,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AgentDeck.Shared\AgentDeck.Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Workloads\Examples\*.json" />
+  </ItemGroup>
 </Project>

--- a/AgentDeck.Core/Models/WorkloadCliInstallers.cs
+++ b/AgentDeck.Core/Models/WorkloadCliInstallers.cs
@@ -1,0 +1,10 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Optional installer hints for workload tooling.</summary>
+public sealed class WorkloadCliInstallers
+{
+    public List<string> AptPackages { get; set; } = [];
+    public List<string> NpmGlobalPackages { get; set; } = [];
+    public List<string> PipxPackages { get; set; } = [];
+    public List<string> DotNetTools { get; set; } = [];
+}

--- a/AgentDeck.Core/Models/WorkloadDefinition.cs
+++ b/AgentDeck.Core/Models/WorkloadDefinition.cs
@@ -1,0 +1,21 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Describes a container workload for the runner and companion app.</summary>
+public sealed class WorkloadDefinition
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string BaseImage { get; set; } = "agentdeck-runner:base";
+    public string WorkspaceMountPath { get; set; } = "/workspace";
+    public string HomeDirectory { get; set; } = "/agent-home";
+    public List<string> SupportedCliCommands { get; set; } = [];
+    public Dictionary<string, string> SdkVersions { get; set; } = [];
+    public WorkloadCliInstallers CliInstallers { get; set; } = new();
+    public Dictionary<string, string> EnvironmentVariables { get; set; } = [];
+    public List<WorkloadMount> AuthMounts { get; set; } = [];
+    public List<WorkloadMount> CacheMounts { get; set; } = [];
+    public List<WorkloadSecret> Secrets { get; set; } = [];
+    public List<string> BootstrapCommands { get; set; } = [];
+    public bool IsBuiltIn { get; set; }
+}

--- a/AgentDeck.Core/Models/WorkloadMount.cs
+++ b/AgentDeck.Core/Models/WorkloadMount.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Describes a persistent container mount used by a workload.</summary>
+public sealed class WorkloadMount
+{
+    public required string Name { get; set; }
+    public required string TargetPath { get; set; }
+    public string Description { get; set; } = string.Empty;
+}

--- a/AgentDeck.Core/Models/WorkloadSecret.cs
+++ b/AgentDeck.Core/Models/WorkloadSecret.cs
@@ -1,0 +1,10 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Describes a runtime secret that may be injected for a workload.</summary>
+public sealed class WorkloadSecret
+{
+    public required string Name { get; set; }
+    public required string EnvironmentVariable { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public bool IsRequired { get; set; }
+}

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -1,5 +1,6 @@
 @page "/settings"
 @inject IConnectionSettingsService SettingsService
+@inject IWorkloadCatalogService WorkloadCatalog
 @inject IAgentDeckClient Client
 @inject ILogger<Settings> Logger
 @implements IDisposable
@@ -54,16 +55,65 @@
     <p>Hub URL: <code>@HubUrl</code></p>
 </div>
 
+<div class="settings-card">
+    <h2>Workload Catalog</h2>
+
+    @if (_workloadErrorMessage is not null)
+    {
+        <p class="error-message">@_workloadErrorMessage</p>
+    }
+    else if (_workloads.Count == 0)
+    {
+        <p>No workloads available.</p>
+    }
+    else
+    {
+        <div class="workload-list">
+            @foreach (var workload in _workloads)
+            {
+                <article class="workload-card">
+                    <div class="workload-card__header">
+                        <div>
+                            <h3>@workload.Name</h3>
+                            <p>@workload.Description</p>
+                        </div>
+                        <span class="workload-badge @(workload.IsBuiltIn ? "workload-badge--builtin" : "workload-badge--custom")">
+                            @(workload.IsBuiltIn ? "Built-in" : "Custom")
+                        </span>
+                    </div>
+                    <div class="workload-card__meta">
+                        <span><strong>Image:</strong> <code>@workload.BaseImage</code></span>
+                        <span><strong>Workspace:</strong> <code>@workload.WorkspaceMountPath</code></span>
+                        <span><strong>Home:</strong> <code>@workload.HomeDirectory</code></span>
+                    </div>
+                    <div class="workload-card__meta">
+                        <span><strong>SDKs:</strong> @FormatSdkVersions(workload)</span>
+                        <span><strong>CLIs:</strong> @FormatCliCommands(workload)</span>
+                    </div>
+                    <div class="workload-card__meta">
+                        <span><strong>Auth mounts:</strong> @workload.AuthMounts.Count</span>
+                        <span><strong>Cache mounts:</strong> @workload.CacheMounts.Count</span>
+                        <span><strong>Secrets:</strong> @workload.Secrets.Count</span>
+                    </div>
+                </article>
+            }
+        </div>
+    }
+</div>
+
 @code {
     private ConnectionSettings _settings = new();
+    private IReadOnlyList<WorkloadDefinition> _workloads = [];
     private bool _saving;
     private string? _errorMessage;
+    private string? _workloadErrorMessage;
 
     private string HubUrl => $"{_settings.RunnerUrl.TrimEnd('/')}/hubs/agent";
 
     protected override async Task OnInitializedAsync()
     {
         _settings = await SettingsService.LoadAsync();
+        await LoadWorkloadsAsync();
         Client.ConnectionStateChanged += OnConnectionStateChanged;
     }
 
@@ -96,6 +146,37 @@
         HubConnectionState.Connecting or HubConnectionState.Reconnecting => "connecting",
         _ => "disconnected"
     };
+
+    private async Task LoadWorkloadsAsync()
+    {
+        _workloadErrorMessage = null;
+
+        try
+        {
+            _workloads = await WorkloadCatalog.GetAllAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load workload catalog");
+            _workloadErrorMessage = $"Failed to load workloads: {ex.Message}";
+        }
+    }
+
+    private static string FormatSdkVersions(WorkloadDefinition workload)
+    {
+        if (workload.SdkVersions.Count == 0)
+            return "None";
+
+        return string.Join(", ", workload.SdkVersions.Select(pair => $"{pair.Key} {pair.Value}"));
+    }
+
+    private static string FormatCliCommands(WorkloadDefinition workload)
+    {
+        if (workload.SupportedCliCommands.Count == 0)
+            return "None";
+
+        return string.Join(", ", workload.SupportedCliCommands);
+    }
 
     public void Dispose() => Client.ConnectionStateChanged -= OnConnectionStateChanged;
 }

--- a/AgentDeck.Core/Services/CoreServiceExtensions.cs
+++ b/AgentDeck.Core/Services/CoreServiceExtensions.cs
@@ -10,6 +10,7 @@ public static class CoreServiceExtensions
         services.AddSingleton<IAgentDeckClient, AgentDeckClient>();
         services.AddSingleton<ISessionStateService, SessionStateService>();
         services.AddSingleton<IConnectionSettingsService, ConnectionSettingsService>();
+        services.AddSingleton<IWorkloadCatalogService, WorkloadCatalogService>();
         services.AddSingleton<AppInitializer>();
         services.AddScoped<TerminalInterop>();
         services.AddSingleton<ICliPresetService, CliPresetService>();

--- a/AgentDeck.Core/Services/IWorkloadCatalogService.cs
+++ b/AgentDeck.Core/Services/IWorkloadCatalogService.cs
@@ -1,0 +1,13 @@
+using AgentDeck.Core.Models;
+
+namespace AgentDeck.Core.Services;
+
+/// <summary>Loads built-in workloads and persists custom workloads for the companion app.</summary>
+public interface IWorkloadCatalogService
+{
+    Task<IReadOnlyList<WorkloadDefinition>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkloadDefinition>> GetBuiltInAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkloadDefinition>> GetCustomAsync(CancellationToken cancellationToken = default);
+    Task SaveCustomAsync(WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task DeleteCustomAsync(string workloadId, CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Core/Services/WorkloadCatalogService.cs
+++ b/AgentDeck.Core/Services/WorkloadCatalogService.cs
@@ -1,0 +1,159 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using AgentDeck.Core.Models;
+
+namespace AgentDeck.Core.Services;
+
+/// <inheritdoc />
+public sealed class WorkloadCatalogService : IWorkloadCatalogService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private static readonly Regex IdSanitizer = new("[^a-z0-9]+", RegexOptions.Compiled);
+
+    private readonly string _filePath;
+    private readonly IReadOnlyList<WorkloadDefinition> _builtInWorkloads;
+
+    public WorkloadCatalogService(IAppDataDirectory appData)
+    {
+        _filePath = Path.Combine(appData.Path, "workloads", "custom-workloads.json");
+        _builtInWorkloads = LoadBuiltInWorkloads();
+    }
+
+    public async Task<IReadOnlyList<WorkloadDefinition>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var builtIns = await GetBuiltInAsync(cancellationToken);
+        var customs = await GetCustomAsync(cancellationToken);
+
+        return builtIns
+            .Concat(customs)
+            .OrderBy(workload => workload.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public Task<IReadOnlyList<WorkloadDefinition>> GetBuiltInAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<WorkloadDefinition>>(_builtInWorkloads.Select(Clone).ToList());
+    }
+
+    public async Task<IReadOnlyList<WorkloadDefinition>> GetCustomAsync(CancellationToken cancellationToken = default)
+    {
+        var customWorkloads = await LoadCustomWorkloadsAsync(cancellationToken);
+        return customWorkloads
+            .OrderBy(workload => workload.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(Clone)
+            .ToList();
+    }
+
+    public async Task SaveCustomAsync(WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(workload);
+
+        var customWorkloads = await LoadCustomWorkloadsAsync(cancellationToken);
+        var normalizedId = NormalizeId(workload.Id, workload.Name);
+
+        if (_builtInWorkloads.Any(existing => existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Cannot save custom workload '{normalizedId}' because it conflicts with a built-in workload.");
+        }
+
+        var toSave = Clone(workload);
+        toSave.Id = normalizedId;
+        toSave.IsBuiltIn = false;
+
+        customWorkloads.RemoveAll(existing => existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase));
+        customWorkloads.Add(toSave);
+
+        await SaveCustomWorkloadsAsync(customWorkloads, cancellationToken);
+    }
+
+    public async Task DeleteCustomAsync(string workloadId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workloadId);
+
+        var customWorkloads = await LoadCustomWorkloadsAsync(cancellationToken);
+        if (customWorkloads.RemoveAll(existing => existing.Id.Equals(workloadId, StringComparison.OrdinalIgnoreCase)) == 0)
+            return;
+
+        await SaveCustomWorkloadsAsync(customWorkloads, cancellationToken);
+    }
+
+    private async Task<List<WorkloadDefinition>> LoadCustomWorkloadsAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+            return [];
+
+        await using var stream = File.OpenRead(_filePath);
+        var workloads = await JsonSerializer.DeserializeAsync<List<WorkloadDefinition>>(stream, JsonOptions, cancellationToken);
+        return workloads ?? [];
+    }
+
+    private async Task SaveCustomWorkloadsAsync(List<WorkloadDefinition> workloads, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+
+        await using var stream = File.Create(_filePath);
+        await JsonSerializer.SerializeAsync(
+            stream,
+            workloads.OrderBy(workload => workload.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+            JsonOptions,
+            cancellationToken);
+    }
+
+    private static IReadOnlyList<WorkloadDefinition> LoadBuiltInWorkloads()
+    {
+        var assembly = typeof(WorkloadCatalogService).Assembly;
+        var resourceNames = assembly.GetManifestResourceNames()
+            .Where(name => name.StartsWith("AgentDeck.Core.Workloads.Examples.", StringComparison.Ordinal))
+            .Where(name => name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        if (resourceNames.Count == 0)
+            throw new InvalidOperationException("No built-in workload resources were found.");
+
+        var workloads = new List<WorkloadDefinition>(resourceNames.Count);
+        foreach (var resourceName in resourceNames)
+        {
+            using var stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Missing built-in workload resource '{resourceName}'.");
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            var workload = JsonSerializer.Deserialize<WorkloadDefinition>(json, JsonOptions)
+                ?? throw new InvalidOperationException($"Built-in workload '{resourceName}' could not be parsed.");
+
+            workload.IsBuiltIn = true;
+            workloads.Add(workload);
+        }
+
+        return workloads
+            .OrderBy(workload => workload.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static WorkloadDefinition Clone(WorkloadDefinition workload)
+    {
+        return JsonSerializer.Deserialize<WorkloadDefinition>(
+            JsonSerializer.Serialize(workload, JsonOptions),
+            JsonOptions)
+            ?? throw new InvalidOperationException($"Failed to clone workload '{workload.Id}'.");
+    }
+
+    private static string NormalizeId(string? workloadId, string workloadName)
+    {
+        var candidate = string.IsNullOrWhiteSpace(workloadId) ? workloadName : workloadId;
+        var normalized = IdSanitizer.Replace(candidate.Trim().ToLowerInvariant(), "-").Trim('-');
+
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new InvalidOperationException("Workload id cannot be empty.");
+
+        return normalized;
+    }
+}

--- a/AgentDeck.Core/Workloads/Examples/copilot-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/copilot-gh.json
@@ -1,0 +1,50 @@
+{
+  "id": "copilot-gh",
+  "name": "Copilot + GitHub CLI",
+  "description": "Runner workload for GitHub CLI and Copilot CLI sessions with shared auth state.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh",
+    "copilot"
+  ],
+  "sdkVersions": {
+    "node": "22"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub and agent CLI auth/config state."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "npm-cache",
+      "targetPath": "/agent-home/.npm",
+      "description": "Persist npm package downloads used by agent tooling."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/dotnet-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/dotnet-gh.json
@@ -1,0 +1,50 @@
+{
+  "id": "dotnet-gh",
+  "name": ".NET + GitHub CLI",
+  "description": ".NET development workload with GitHub CLI, auth persistence, and NuGet caches.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {
+    "dotnet": "10.0"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home",
+    "NUGET_PACKAGES": "/agent-home/.nuget/packages"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and .NET tool state."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "nuget-cache",
+      "targetPath": "/agent-home/.nuget/packages",
+      "description": "Persist NuGet packages between sessions."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/fullstack-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/fullstack-gh.json
@@ -1,0 +1,62 @@
+{
+  "id": "fullstack-gh",
+  "name": "Full Stack + GitHub CLI",
+  "description": "Full-stack starter workload for .NET, Node, and Python projects with shared auth and caches.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {
+    "dotnet": "10.0",
+    "node": "22",
+    "python": "3.12"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home",
+    "NUGET_PACKAGES": "/agent-home/.nuget/packages"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and shared tool config."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "nuget-cache",
+      "targetPath": "/agent-home/.nuget/packages",
+      "description": "Persist NuGet packages between sessions."
+    },
+    {
+      "name": "npm-cache",
+      "targetPath": "/agent-home/.npm",
+      "description": "Persist npm package downloads between sessions."
+    },
+    {
+      "name": "pip-cache",
+      "targetPath": "/agent-home/.cache/pip",
+      "description": "Persist pip downloads between sessions."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/github-cli.json
+++ b/AgentDeck.Core/Workloads/Examples/github-cli.json
@@ -1,0 +1,41 @@
+{
+  "id": "github-cli",
+  "name": "GitHub CLI",
+  "description": "Minimal workload for GitHub CLI sessions with persistent auth state.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {},
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and shared CLI state."
+    }
+  ],
+  "cacheMounts": [],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub CLI auth.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/node-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/node-gh.json
@@ -1,0 +1,49 @@
+{
+  "id": "node-gh",
+  "name": "Node + GitHub CLI",
+  "description": "Node development workload with GitHub CLI, auth persistence, and npm caches.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {
+    "node": "22"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and Node tool config."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "npm-cache",
+      "targetPath": "/agent-home/.npm",
+      "description": "Persist npm package downloads between sessions."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/python-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/python-gh.json
@@ -1,0 +1,49 @@
+{
+  "id": "python-gh",
+  "name": "Python + GitHub CLI",
+  "description": "Python development workload with GitHub CLI, auth persistence, and pip caches.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {
+    "python": "3.12"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and Python tool config."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "pip-cache",
+      "targetPath": "/agent-home/.cache/pip",
+      "description": "Persist pip downloads between sessions."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/Workloads/Examples/python-node-gh.json
+++ b/AgentDeck.Core/Workloads/Examples/python-node-gh.json
@@ -1,0 +1,55 @@
+{
+  "id": "python-node-gh",
+  "name": "Python + Node + GitHub CLI",
+  "description": "Polyglot workload for Python and Node projects with shared auth state and package caches.",
+  "baseImage": "agentdeck-runner:base",
+  "workspaceMountPath": "/workspace",
+  "homeDirectory": "/agent-home",
+  "supportedCliCommands": [
+    "gh"
+  ],
+  "sdkVersions": {
+    "python": "3.12",
+    "node": "22"
+  },
+  "cliInstallers": {
+    "aptPackages": [
+      "gh"
+    ],
+    "npmGlobalPackages": [],
+    "pipxPackages": [],
+    "dotNetTools": []
+  },
+  "environmentVariables": {
+    "AGENTDECK_WORKSPACE": "/workspace",
+    "HOME": "/agent-home"
+  },
+  "authMounts": [
+    {
+      "name": "agent-home",
+      "targetPath": "/agent-home",
+      "description": "Persist GitHub CLI auth and shared language-tool state."
+    }
+  ],
+  "cacheMounts": [
+    {
+      "name": "npm-cache",
+      "targetPath": "/agent-home/.npm",
+      "description": "Persist npm package downloads between sessions."
+    },
+    {
+      "name": "pip-cache",
+      "targetPath": "/agent-home/.cache/pip",
+      "description": "Persist pip downloads between sessions."
+    }
+  ],
+  "secrets": [
+    {
+      "name": "github-token",
+      "environmentVariable": "GITHUB_TOKEN",
+      "description": "Optional token for non-interactive GitHub auth flows.",
+      "isRequired": false
+    }
+  ],
+  "bootstrapCommands": []
+}

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -406,6 +406,69 @@ main {
 .status-text-connecting  { color: var(--color-yellow); }
 .status-text-disconnected { color: var(--color-subtext); }
 
+.workload-list {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.workload-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.workload-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.workload-card__header h3 {
+    margin: 0 0 0.25rem 0;
+    font-size: 0.95rem;
+}
+
+.workload-card__header p {
+    margin: 0;
+    color: var(--color-subtext);
+    font-size: 0.8rem;
+}
+
+.workload-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem 1.2rem;
+    font-size: 0.8rem;
+    color: var(--color-subtext);
+    margin-top: 0.5rem;
+}
+
+.workload-card__meta code {
+    background: rgba(0,0,0,0.2);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+}
+
+.workload-badge {
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.workload-badge--builtin {
+    background: rgba(137,180,250,0.15);
+    color: var(--color-accent);
+}
+
+.workload-badge--custom {
+    background: rgba(166,227,161,0.15);
+    color: var(--color-green);
+}
+
 /* ========== Badges ========== */
 .badge {
     font-size: 0.75rem;

--- a/AgentDeck.Runner/Configuration/RunnerOptions.cs
+++ b/AgentDeck.Runner/Configuration/RunnerOptions.cs
@@ -4,6 +4,9 @@ namespace AgentDeck.Runner.Configuration;
 public sealed class RunnerOptions
 {
     public const string SectionName = "Runner";
+    public const string WorkspaceEnvironmentVariable = "AGENTDECK_WORKSPACE";
+    public const string PortEnvironmentVariable = "AGENTDECK_PORT";
+    public const string DefaultShellEnvironmentVariable = "AGENTDECK_DEFAULT_SHELL";
 
     /// <summary>Root directory under which new project directories are created. Defaults to ~/AgentDeck if not set.</summary>
     public string WorkspaceRoot { get; set; } =
@@ -17,4 +20,27 @@ public sealed class RunnerOptions
 
     /// <summary>Default shell command when no command is specified in CreateTerminalRequest. Auto-detected from OS if null.</summary>
     public string? DefaultShell { get; set; }
+
+    public static void ApplyEnvironmentOverrides(RunnerOptions options)
+    {
+        var workspaceRoot = Environment.GetEnvironmentVariable(WorkspaceEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(workspaceRoot))
+            options.WorkspaceRoot = workspaceRoot;
+
+        var portValue = Environment.GetEnvironmentVariable(PortEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(portValue))
+        {
+            if (!int.TryParse(portValue, out var port) || port is < 1 or > 65535)
+            {
+                throw new InvalidOperationException(
+                    $"{PortEnvironmentVariable} must be an integer between 1 and 65535.");
+            }
+
+            options.Port = port;
+        }
+
+        var defaultShell = Environment.GetEnvironmentVariable(DefaultShellEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(defaultShell))
+            options.DefaultShell = defaultShell;
+    }
 }

--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["Directory.Build.props", "./"]
+COPY ["AgentDeck.Shared/AgentDeck.Shared.csproj", "AgentDeck.Shared/"]
+COPY ["AgentDeck.Runner/AgentDeck.Runner.csproj", "AgentDeck.Runner/"]
+
+RUN dotnet restore "AgentDeck.Runner/AgentDeck.Runner.csproj"
+
+COPY . .
+
+RUN dotnet publish "AgentDeck.Runner/AgentDeck.Runner.csproj" \
+    -c Release \
+    -o /app/publish \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:5000
+ENV AGENTDECK_WORKSPACE=/workspace
+
+EXPOSE 5000
+VOLUME ["/workspace"]
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "AgentDeck.Runner.dll"]

--- a/AgentDeck.Runner/Hubs/AgentHub.cs
+++ b/AgentDeck.Runner/Hubs/AgentHub.cs
@@ -123,6 +123,9 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
         if (!string.IsNullOrWhiteSpace(_options.DefaultShell))
             return _options.DefaultShell;
 
-        return OperatingSystem.IsWindows() ? "powershell.exe" : "/bin/bash";
+        if (OperatingSystem.IsWindows())
+            return "powershell.exe";
+
+        return File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
     }
 }

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -4,12 +4,15 @@ using AgentDeck.Runner.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.Configure<RunnerOptions>(
-    builder.Configuration.GetSection(RunnerOptions.SectionName));
-
 var runnerOptions = builder.Configuration
     .GetSection(RunnerOptions.SectionName)
     .Get<RunnerOptions>() ?? new RunnerOptions();
+
+RunnerOptions.ApplyEnvironmentOverrides(runnerOptions);
+
+builder.Services.AddOptions<RunnerOptions>()
+    .Bind(builder.Configuration.GetSection(RunnerOptions.SectionName))
+    .Configure(RunnerOptions.ApplyEnvironmentOverrides);
 
 builder.WebHost.UseUrls($"http://0.0.0.0:{runnerOptions.Port}");
 

--- a/AgentDeck.Runner/Services/WorkspaceService.cs
+++ b/AgentDeck.Runner/Services/WorkspaceService.cs
@@ -7,6 +7,9 @@ namespace AgentDeck.Runner.Services;
 /// <inheritdoc />
 public sealed class WorkspaceService : IWorkspaceService
 {
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
     private readonly string _root;
 
     public WorkspaceService(IOptions<RunnerOptions> options)
@@ -49,8 +52,8 @@ public sealed class WorkspaceService : IWorkspaceService
         var rootWithSep = _root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                           + Path.DirectorySeparatorChar;
 
-        if (!fullPath.Equals(_root, StringComparison.OrdinalIgnoreCase) &&
-            !fullPath.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase))
+        if (!fullPath.Equals(_root, PathComparison) &&
+            !fullPath.StartsWith(rootWithSep, PathComparison))
         {
             throw new InvalidOperationException(
                 $"Path '{fullPath}' is outside the workspace root '{_root}'.");

--- a/README.md
+++ b/README.md
@@ -46,7 +46,31 @@ cd AgentDeck.Runner
 dotnet run
 ```
 
-The runner starts on `http://localhost:5000` by default. Set `AGENTDECK_WORKSPACE` to configure the workspace root (defaults to `~/AgentDeck`).
+The runner starts on `http://localhost:5000` by default. Use these environment variables to override its runtime defaults:
+
+- `AGENTDECK_WORKSPACE` sets the workspace root (defaults to `~/AgentDeck`)
+- `AGENTDECK_PORT` sets the HTTP port (defaults to `5000`)
+- `AGENTDECK_DEFAULT_SHELL` sets the default shell command
+
+### Running the Runner in Docker (Linux)
+
+Build the image from the repository root:
+
+```bash
+docker build -t agentdeck-runner -f AgentDeck.Runner/Dockerfile .
+```
+
+Run the container with a mounted workspace:
+
+```bash
+docker run --rm \
+  -p 5000:5000 \
+  -e AGENTDECK_WORKSPACE=/workspace \
+  -v "$(pwd):/workspace" \
+  agentdeck-runner
+```
+
+The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable. If you want to launch tools like GitHub Copilot inside the container, install them in a derived image.
 
 ### Running the Companion App (Windows)
 
@@ -64,7 +88,7 @@ Runner configuration (`AgentDeck.Runner/appsettings.json`):
 ```json
 {
   "Runner": {
-    "WorkspaceRoot": "C:/AgentDeck/workspace",
+    "WorkspaceRoot": "/workspace",
     "Port": 5000,
     "AllowedOrigins": ["*"]
   }


### PR DESCRIPTION
## Summary
- add Linux-friendly runner container support with Docker packaging and env-based overrides
- add typed workload config models, built-in workload templates, and custom workload persistence in the companion app
- surface the workload catalog in Settings as the first step toward companion-managed workloads

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj -nologo
- dotnet publish AgentDeck.Runner/AgentDeck.Runner.csproj -nologo -c Release -o temp -p:UseAppHost=false
- dotnet build AgentDeck/AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o temp

## Related issues
- closes #35
- refs #36
- refs #40