### PR TITLE
Add workload runtime flow and fix terminal commands

### DIFF
--- a/AgentDeck.Core/Components/NewTerminalDialog.razor
+++ b/AgentDeck.Core/Components/NewTerminalDialog.razor
@@ -47,11 +47,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Command</label>
-                    <input class="form-input" type="text" @bind="_command" placeholder="e.g. pwsh, bash, cmd" />
-                </div>
-                <div class="form-group">
-                    <label class="form-label">Arguments (space-separated)</label>
-                    <input class="form-input" type="text" @bind="_argsText" placeholder="e.g. -NoExit -Command" />
+                    <input class="form-input" type="text" @bind="_command" placeholder="e.g. dotnet test --filter MyTests" />
                 </div>
             }
 
@@ -78,7 +74,6 @@
     private string _name = "";
     private string _workingDir = "";
     private string _command = "";
-    private string _argsText = "";
     private string _error = "";
     private bool _yoloMode = false;
     private bool _wasOpen = false;
@@ -106,7 +101,6 @@
     {
         _selectedPreset = preset;
         _command = preset.Command;
-        _argsText = string.Join(" ", preset.Args);
     }
 
     private async Task Create()
@@ -118,30 +112,41 @@
             return;
         }
 
-        var cmd = _selectedPreset?.Name == "Custom" ? _command : (_selectedPreset?.Command ?? "");
+        var cmd = ResolveCommandText();
         if (string.IsNullOrWhiteSpace(cmd))
         {
             _error = "Command is required.";
             return;
         }
 
-        IReadOnlyList<string> args;
-        if (_selectedPreset?.Name == "Custom")
-            args = _argsText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        else if (_selectedPreset?.Name == "GitHub Copilot" && _yoloMode)
-            args = ["--yolo"];
-        else
-            args = _selectedPreset?.Args ?? [];
-
         var req = new CreateTerminalRequest
         {
             Name = _name.Trim(),
             WorkingDirectory = _workingDir,
             Command = cmd.Trim(),
-            Arguments = args,
+            Arguments = ResolveArguments(),
         };
 
         await OnCreate.InvokeAsync(req);
+    }
+
+    private string ResolveCommandText()
+    {
+        if (_selectedPreset?.Name == "Custom")
+            return _command;
+
+        if (_selectedPreset?.Name == "GitHub Copilot" && _yoloMode)
+            return "copilot --yolo";
+
+        return _selectedPreset?.Command ?? "";
+    }
+
+    private IReadOnlyList<string> ResolveArguments()
+    {
+        if (_selectedPreset?.Name is "Custom" or "GitHub Copilot")
+            return [];
+
+        return _selectedPreset?.Args ?? [];
     }
 
     private async Task Cancel() => await OnClose.InvokeAsync();

--- a/AgentDeck.Core/Components/WorkloadEditor.razor
+++ b/AgentDeck.Core/Components/WorkloadEditor.razor
@@ -1,0 +1,406 @@
+@if (Workload is not null)
+{
+    <div class="workload-editor">
+        <div class="workload-editor__header">
+            <div>
+                <h3>@Title</h3>
+                <p>Configure SDKs, tool installers, auth mounts, cache mounts, and runtime settings for this workload.</p>
+            </div>
+            <div class="workload-editor__actions">
+                <button class="btn btn-accent" type="button" @onclick="CancelAsync">Cancel</button>
+                @if (AllowDelete)
+                {
+                    <button class="btn btn-danger" type="button" @onclick="DeleteAsync">Delete</button>
+                }
+                <button class="btn btn-primary" type="button" @onclick="SaveAsync">Save Workload</button>
+            </div>
+        </div>
+
+        @if (_errorMessage is not null)
+        {
+            <p class="error-message">@_errorMessage</p>
+        }
+
+        <div class="workload-editor__grid">
+            <div class="form-field">
+                <label for="workload-id">Workload ID</label>
+                <input id="workload-id" class="input" @bind="_model.Id" placeholder="python-node-gh" />
+            </div>
+            <div class="form-field">
+                <label for="workload-name">Display Name</label>
+                <input id="workload-name" class="input" @bind="_model.Name" placeholder="Python + Node + GitHub CLI" />
+            </div>
+            <div class="form-field workload-editor__full">
+                <label for="workload-description">Description</label>
+                <textarea id="workload-description" class="input input--multiline" rows="2" @bind="_model.Description"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-image">Base Image</label>
+                <input id="workload-image" class="input" @bind="_model.BaseImage" placeholder="agentdeck-runner:base" />
+            </div>
+            <div class="form-field">
+                <label for="workload-home">Home Directory</label>
+                <input id="workload-home" class="input" @bind="_model.HomeDirectory" placeholder="/agent-home" />
+            </div>
+            <div class="form-field workload-editor__full">
+                <label for="workload-workspace">Workspace Mount Path</label>
+                <input id="workload-workspace" class="input" @bind="_model.WorkspaceMountPath" placeholder="/workspace" />
+            </div>
+        </div>
+
+        <div class="workload-editor__grid">
+            <div class="form-field">
+                <label for="workload-clis">Supported CLI Commands</label>
+                <textarea id="workload-clis" class="input input--multiline" rows="4" @bind="_model.SupportedCliCommands" placeholder="gh&#10;copilot"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-sdks">SDK Versions</label>
+                <textarea id="workload-sdks" class="input input--multiline" rows="4" @bind="_model.SdkVersions" placeholder="python=3.12&#10;node=22&#10;dotnet=10.0"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-env">Environment Variables</label>
+                <textarea id="workload-env" class="input input--multiline" rows="4" @bind="_model.EnvironmentVariables" placeholder="HOME=/agent-home&#10;AGENTDECK_WORKSPACE=/workspace"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-bootstrap">Bootstrap Commands</label>
+                <textarea id="workload-bootstrap" class="input input--multiline" rows="4" @bind="_model.BootstrapCommands" placeholder="npm install&#10;pip install -r requirements.txt"></textarea>
+            </div>
+        </div>
+
+        <div class="workload-editor__grid">
+            <div class="form-field">
+                <label for="workload-apt">APT Packages</label>
+                <textarea id="workload-apt" class="input input--multiline" rows="4" @bind="_model.AptPackages" placeholder="gh&#10;git&#10;curl"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-npm">Global npm Packages</label>
+                <textarea id="workload-npm" class="input input--multiline" rows="4" @bind="_model.NpmGlobalPackages" placeholder="@@github/copilot"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-pipx">pipx Packages</label>
+                <textarea id="workload-pipx" class="input input--multiline" rows="4" @bind="_model.PipxPackages" placeholder="poetry"></textarea>
+            </div>
+            <div class="form-field">
+                <label for="workload-dotnet-tools">.NET Tools</label>
+                <textarea id="workload-dotnet-tools" class="input input--multiline" rows="4" @bind="_model.DotNetTools" placeholder="dotnet-ef"></textarea>
+            </div>
+        </div>
+
+        <div class="workload-editor__section">
+            <div class="workload-editor__section-header">
+                <h4>Auth Mounts</h4>
+                <button class="btn btn-accent" type="button" @onclick="AddAuthMount">Add Mount</button>
+            </div>
+            @foreach (var mount in _model.AuthMounts)
+            {
+                <div class="workload-entry-row">
+                    <input class="input" @bind="mount.Name" placeholder="agent-home" />
+                    <input class="input" @bind="mount.TargetPath" placeholder="/agent-home" />
+                    <input class="input" @bind="mount.Description" placeholder="Persist CLI auth and config state" />
+                    <button class="btn btn-danger" type="button" @onclick="() => RemoveAuthMount(mount)">Remove</button>
+                </div>
+            }
+        </div>
+
+        <div class="workload-editor__section">
+            <div class="workload-editor__section-header">
+                <h4>Cache Mounts</h4>
+                <button class="btn btn-accent" type="button" @onclick="AddCacheMount">Add Mount</button>
+            </div>
+            @foreach (var mount in _model.CacheMounts)
+            {
+                <div class="workload-entry-row">
+                    <input class="input" @bind="mount.Name" placeholder="npm-cache" />
+                    <input class="input" @bind="mount.TargetPath" placeholder="/agent-home/.npm" />
+                    <input class="input" @bind="mount.Description" placeholder="Persist package downloads between sessions" />
+                    <button class="btn btn-danger" type="button" @onclick="() => RemoveCacheMount(mount)">Remove</button>
+                </div>
+            }
+        </div>
+
+        <div class="workload-editor__section">
+            <div class="workload-editor__section-header">
+                <h4>Runtime Secrets</h4>
+                <button class="btn btn-accent" type="button" @onclick="AddSecret">Add Secret</button>
+            </div>
+            @foreach (var secret in _model.Secrets)
+            {
+                <div class="workload-secret-row">
+                    <input class="input" @bind="secret.Name" placeholder="github-token" />
+                    <input class="input" @bind="secret.EnvironmentVariable" placeholder="GITHUB_TOKEN" />
+                    <input class="input" @bind="secret.Description" placeholder="Optional token for headless auth" />
+                    <label class="checkbox-label workload-secret-row__checkbox">
+                        <input type="checkbox" @bind="secret.IsRequired" />
+                        Required
+                    </label>
+                    <button class="btn btn-danger" type="button" @onclick="() => RemoveSecret(secret)">Remove</button>
+                </div>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public WorkloadDefinition? Workload { get; set; }
+    [Parameter] public string Title { get; set; } = "Edit Workload";
+    [Parameter] public int EditorKey { get; set; }
+    [Parameter] public bool AllowDelete { get; set; }
+    [Parameter] public EventCallback<WorkloadDefinition> OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public EventCallback<string> OnDelete { get; set; }
+
+    private readonly EditorModel _model = new();
+    private int _loadedEditorKey = -1;
+    private string? _errorMessage;
+
+    protected override void OnParametersSet()
+    {
+        if (Workload is null || _loadedEditorKey == EditorKey)
+            return;
+
+        _loadedEditorKey = EditorKey;
+        _errorMessage = null;
+        _model.LoadFrom(Workload);
+    }
+
+    private void AddAuthMount() => _model.AuthMounts.Add(new EditorMount());
+    private void RemoveAuthMount(EditorMount mount) => _model.AuthMounts.Remove(mount);
+    private void AddCacheMount() => _model.CacheMounts.Add(new EditorMount());
+    private void RemoveCacheMount(EditorMount mount) => _model.CacheMounts.Remove(mount);
+    private void AddSecret() => _model.Secrets.Add(new EditorSecret());
+    private void RemoveSecret(EditorSecret secret) => _model.Secrets.Remove(secret);
+
+    private async Task SaveAsync()
+    {
+        try
+        {
+            _errorMessage = null;
+            await OnSave.InvokeAsync(_model.ToWorkload());
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            _errorMessage = ex.Message;
+        }
+    }
+
+    private async Task DeleteAsync()
+    {
+        if (Workload is null)
+            return;
+
+        await OnDelete.InvokeAsync(Workload.Id);
+    }
+
+    private async Task CancelAsync()
+    {
+        _errorMessage = null;
+        await OnCancel.InvokeAsync();
+    }
+
+    private sealed class EditorModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string BaseImage { get; set; } = "agentdeck-runner:base";
+        public string WorkspaceMountPath { get; set; } = "/workspace";
+        public string HomeDirectory { get; set; } = "/agent-home";
+        public string SupportedCliCommands { get; set; } = string.Empty;
+        public string SdkVersions { get; set; } = string.Empty;
+        public string EnvironmentVariables { get; set; } = string.Empty;
+        public string BootstrapCommands { get; set; } = string.Empty;
+        public string AptPackages { get; set; } = string.Empty;
+        public string NpmGlobalPackages { get; set; } = string.Empty;
+        public string PipxPackages { get; set; } = string.Empty;
+        public string DotNetTools { get; set; } = string.Empty;
+        public List<EditorMount> AuthMounts { get; } = [];
+        public List<EditorMount> CacheMounts { get; } = [];
+        public List<EditorSecret> Secrets { get; } = [];
+
+        public void LoadFrom(WorkloadDefinition workload)
+        {
+            Id = workload.IsBuiltIn ? $"{workload.Id}-custom" : workload.Id;
+            Name = workload.IsBuiltIn ? $"{workload.Name} Copy" : workload.Name;
+            Description = workload.Description;
+            BaseImage = workload.BaseImage;
+            WorkspaceMountPath = workload.WorkspaceMountPath;
+            HomeDirectory = workload.HomeDirectory;
+            SupportedCliCommands = string.Join(Environment.NewLine, workload.SupportedCliCommands);
+            SdkVersions = string.Join(Environment.NewLine, workload.SdkVersions.Select(pair => $"{pair.Key}={pair.Value}"));
+            EnvironmentVariables = string.Join(Environment.NewLine, workload.EnvironmentVariables.Select(pair => $"{pair.Key}={pair.Value}"));
+            BootstrapCommands = string.Join(Environment.NewLine, workload.BootstrapCommands);
+            AptPackages = string.Join(Environment.NewLine, workload.CliInstallers.AptPackages);
+            NpmGlobalPackages = string.Join(Environment.NewLine, workload.CliInstallers.NpmGlobalPackages);
+            PipxPackages = string.Join(Environment.NewLine, workload.CliInstallers.PipxPackages);
+            DotNetTools = string.Join(Environment.NewLine, workload.CliInstallers.DotNetTools);
+
+            AuthMounts.Clear();
+            AuthMounts.AddRange(workload.AuthMounts.Select(mount => new EditorMount(mount)));
+
+            CacheMounts.Clear();
+            CacheMounts.AddRange(workload.CacheMounts.Select(mount => new EditorMount(mount)));
+
+            Secrets.Clear();
+            Secrets.AddRange(workload.Secrets.Select(secret => new EditorSecret(secret)));
+        }
+
+        public WorkloadDefinition ToWorkload()
+        {
+            var name = Required("Workload name", Name);
+            var baseImage = Required("Base image", BaseImage);
+            var workspaceMountPath = Required("Workspace mount path", WorkspaceMountPath);
+            var homeDirectory = Required("Home directory", HomeDirectory);
+
+            return new WorkloadDefinition
+            {
+                Id = Id.Trim(),
+                Name = name,
+                Description = Description.Trim(),
+                BaseImage = baseImage,
+                WorkspaceMountPath = workspaceMountPath,
+                HomeDirectory = homeDirectory,
+                SupportedCliCommands = ParseStringList(SupportedCliCommands),
+                SdkVersions = ParseKeyValueLines("SDK versions", SdkVersions),
+                EnvironmentVariables = ParseKeyValueLines("Environment variables", EnvironmentVariables),
+                BootstrapCommands = ParseStringList(BootstrapCommands),
+                CliInstallers = new WorkloadCliInstallers
+                {
+                    AptPackages = ParseStringList(AptPackages),
+                    NpmGlobalPackages = ParseStringList(NpmGlobalPackages),
+                    PipxPackages = ParseStringList(PipxPackages),
+                    DotNetTools = ParseStringList(DotNetTools)
+                },
+                AuthMounts = ParseMounts("Auth mounts", AuthMounts),
+                CacheMounts = ParseMounts("Cache mounts", CacheMounts),
+                Secrets = ParseSecrets(Secrets),
+                IsBuiltIn = false
+            };
+        }
+
+        private static string Required(string label, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new InvalidOperationException($"{label} is required.");
+
+            return value.Trim();
+        }
+
+        private static List<string> ParseStringList(string value)
+        {
+            return value
+                .Split(['\r', '\n', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static Dictionary<string, string> ParseKeyValueLines(string label, string value)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var lines = value.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var line in lines)
+            {
+                var separatorIndex = line.IndexOf('=');
+                if (separatorIndex <= 0 || separatorIndex == line.Length - 1)
+                    throw new InvalidOperationException($"{label} entries must use key=value format. Invalid entry: '{line}'.");
+
+                var key = line[..separatorIndex].Trim();
+                var parsedValue = line[(separatorIndex + 1)..].Trim();
+                if (key.Length == 0 || parsedValue.Length == 0)
+                    throw new InvalidOperationException($"{label} entries must use key=value format. Invalid entry: '{line}'.");
+
+                result[key] = parsedValue;
+            }
+
+            return result;
+        }
+
+        private static List<WorkloadMount> ParseMounts(string label, IEnumerable<EditorMount> mounts)
+        {
+            var result = new List<WorkloadMount>();
+
+            foreach (var mount in mounts)
+            {
+                if (string.IsNullOrWhiteSpace(mount.Name) &&
+                    string.IsNullOrWhiteSpace(mount.TargetPath) &&
+                    string.IsNullOrWhiteSpace(mount.Description))
+                {
+                    continue;
+                }
+
+                result.Add(new WorkloadMount
+                {
+                    Name = Required($"{label} name", mount.Name),
+                    TargetPath = Required($"{label} target path", mount.TargetPath),
+                    Description = mount.Description.Trim()
+                });
+            }
+
+            return result;
+        }
+
+        private static List<WorkloadSecret> ParseSecrets(IEnumerable<EditorSecret> secrets)
+        {
+            var result = new List<WorkloadSecret>();
+
+            foreach (var secret in secrets)
+            {
+                if (string.IsNullOrWhiteSpace(secret.Name) &&
+                    string.IsNullOrWhiteSpace(secret.EnvironmentVariable) &&
+                    string.IsNullOrWhiteSpace(secret.Description) &&
+                    !secret.IsRequired)
+                {
+                    continue;
+                }
+
+                result.Add(new WorkloadSecret
+                {
+                    Name = Required("Secret name", secret.Name),
+                    EnvironmentVariable = Required("Secret environment variable", secret.EnvironmentVariable),
+                    Description = secret.Description.Trim(),
+                    IsRequired = secret.IsRequired
+                });
+            }
+
+            return result;
+        }
+    }
+
+    private sealed class EditorMount
+    {
+        public EditorMount()
+        {
+        }
+
+        public EditorMount(WorkloadMount mount)
+        {
+            Name = mount.Name;
+            TargetPath = mount.TargetPath;
+            Description = mount.Description;
+        }
+
+        public string Name { get; set; } = string.Empty;
+        public string TargetPath { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+    }
+
+    private sealed class EditorSecret
+    {
+        public EditorSecret()
+        {
+        }
+
+        public EditorSecret(WorkloadSecret secret)
+        {
+            Name = secret.Name;
+            EnvironmentVariable = secret.EnvironmentVariable;
+            Description = secret.Description;
+            IsRequired = secret.IsRequired;
+        }
+
+        public string Name { get; set; } = string.Empty;
+        public string EnvironmentVariable { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public bool IsRequired { get; set; }
+    }
+}

--- a/AgentDeck.Core/Models/ConnectionSettings.cs
+++ b/AgentDeck.Core/Models/ConnectionSettings.cs
@@ -8,4 +8,13 @@ public sealed class ConnectionSettings
 
     /// <summary>Whether to automatically connect to the runner on app start.</summary>
     public bool AutoConnect { get; set; } = true;
+
+    /// <summary>Selected workload definition used when generating runner container commands.</summary>
+    public string? SelectedWorkloadId { get; set; }
+
+    /// <summary>Host path mounted into the runner container as the workspace root.</summary>
+    public string DockerWorkspacePath { get; set; } = string.Empty;
+
+    /// <summary>Local repository path that contains AgentDeck.Runner/Dockerfile for base image builds.</summary>
+    public string RunnerSourcePath { get; set; } = string.Empty;
 }

--- a/AgentDeck.Core/Models/WorkloadContainerCommandSet.cs
+++ b/AgentDeck.Core/Models/WorkloadContainerCommandSet.cs
@@ -1,0 +1,14 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Resolved Docker commands for building and running a workload container.</summary>
+public sealed class WorkloadContainerCommandSet
+{
+    public required string BaseImageTag { get; init; }
+    public required string WorkloadImageTag { get; init; }
+    public required string ContainerName { get; init; }
+    public string? BuildBaseImageCommand { get; init; }
+    public required string GeneratedDockerfile { get; init; }
+    public required string BuildWorkloadImageCommand { get; init; }
+    public required string StartContainerCommand { get; init; }
+    public required string StopContainerCommand { get; init; }
+}

--- a/AgentDeck.Core/Models/WorkloadContainerExecutionResult.cs
+++ b/AgentDeck.Core/Models/WorkloadContainerExecutionResult.cs
@@ -1,0 +1,11 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Result of a Docker operation triggered for a workload.</summary>
+public sealed class WorkloadContainerExecutionResult
+{
+    public required bool Succeeded { get; init; }
+    public required int ExitCode { get; init; }
+    public required string CommandText { get; init; }
+    public string StandardOutput { get; init; } = string.Empty;
+    public string StandardError { get; init; } = string.Empty;
+}

--- a/AgentDeck.Core/Models/WorkloadContainerStatus.cs
+++ b/AgentDeck.Core/Models/WorkloadContainerStatus.cs
@@ -1,0 +1,17 @@
+namespace AgentDeck.Core.Models;
+
+/// <summary>Observed local Docker state for a selected workload.</summary>
+public sealed class WorkloadContainerStatus
+{
+    public bool DockerAvailable { get; init; }
+    public string DockerVersion { get; init; } = string.Empty;
+    public bool BaseImageExists { get; init; }
+    public bool WorkloadImageExists { get; init; }
+    public bool ContainerExists { get; init; }
+    public string ContainerState { get; init; } = "not-created";
+    public string ContainerId { get; init; } = string.Empty;
+    public string ErrorMessage { get; init; } = string.Empty;
+    public IReadOnlyDictionary<string, bool> AuthVolumeExists { get; init; } = new Dictionary<string, bool>();
+    public IReadOnlyDictionary<string, bool> CacheVolumeExists { get; init; } = new Dictionary<string, bool>();
+    public IReadOnlyDictionary<string, bool> SecretAvailability { get; init; } = new Dictionary<string, bool>();
+}

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -1,7 +1,10 @@
 @page "/settings"
 @inject IConnectionSettingsService SettingsService
 @inject IWorkloadCatalogService WorkloadCatalog
+@inject IWorkloadContainerCommandService WorkloadContainerCommands
+@inject IWorkloadContainerRuntimeService WorkloadContainerRuntime
 @inject IAgentDeckClient Client
+@inject IToastService ToastService
 @inject ILogger<Settings> Logger
 @implements IDisposable
 
@@ -50,6 +53,147 @@
 </div>
 
 <div class="settings-card">
+    <h2>Container Orchestration</h2>
+
+    <div class="form-field">
+        <label for="selected-workload">Selected Workload</label>
+        <select id="selected-workload" class="input" @bind="_settings.SelectedWorkloadId">
+            <option value="">Choose a workload…</option>
+            @foreach (var workload in _workloads)
+            {
+                <option value="@workload.Id">@workload.Name</option>
+            }
+        </select>
+    </div>
+
+    <div class="form-field">
+        <label for="docker-workspace">Host Workspace Path</label>
+        <input id="docker-workspace" type="text" class="input" @bind="_settings.DockerWorkspacePath"
+               placeholder="C:\Projects\Mick\AgentDeck" />
+    </div>
+
+    <div class="form-field">
+        <label for="runner-source-path">Runner Source Path</label>
+        <input id="runner-source-path" type="text" class="input" @bind="_settings.RunnerSourcePath"
+               placeholder="C:\Projects\Mick\AgentDeck" />
+    </div>
+
+    @if (TryGetSelectedWorkload(out var selectedWorkload, out var selectionError))
+    {
+        var commandSet = WorkloadContainerCommands.Resolve(_settings, selectedWorkload);
+
+        <div class="workload-runtime-toolbar">
+            <button class="btn btn-accent" @onclick="RefreshContainerStatusAsync" disabled="@_containerBusy">
+                Refresh Status
+            </button>
+            <button class="btn btn-accent" @onclick="BuildBaseImageAsync" disabled="@_containerBusy">
+                Build Base Image
+            </button>
+            <button class="btn btn-accent" @onclick="BuildWorkloadImageAsync" disabled="@_containerBusy">
+                Build Workload Image
+            </button>
+            <button class="btn btn-primary" @onclick="StartContainerAsync" disabled="@_containerBusy">
+                Start Container
+            </button>
+            <button class="btn btn-danger" @onclick="StopContainerAsync" disabled="@_containerBusy">
+                Stop Container
+            </button>
+        </div>
+
+        @if (_containerErrorMessage is not null)
+        {
+            <p class="error-message">@_containerErrorMessage</p>
+        }
+
+        <div class="workload-command-grid">
+            <div class="workload-command-card">
+                <h3>Local Docker Status</h3>
+                @if (_containerBusy)
+                {
+                    <p>Running container action…</p>
+                }
+                else if (_containerStatus is null)
+                {
+                    <p>Refresh status to inspect the local Docker state.</p>
+                }
+                else if (!_containerStatus.DockerAvailable)
+                {
+                    <p class="error-message">@_containerStatus.ErrorMessage</p>
+                }
+                else
+                {
+                    <p><strong>Docker:</strong> <code>@_containerStatus.DockerVersion</code></p>
+                    <p><strong>Base image:</strong> @(_containerStatus.BaseImageExists ? "present" : "missing")</p>
+                    <p><strong>Workload image:</strong> @(_containerStatus.WorkloadImageExists ? "present" : "missing")</p>
+                    <p><strong>Container:</strong> @(_containerStatus.ContainerExists ? _containerStatus.ContainerState : "not created")</p>
+                    <p><strong>Auth volumes:</strong> @FormatAvailability(_containerStatus.AuthVolumeExists)</p>
+                    <p><strong>Cache volumes:</strong> @FormatAvailability(_containerStatus.CacheVolumeExists)</p>
+                    <p><strong>Secrets:</strong> @FormatAvailability(_containerStatus.SecretAvailability)</p>
+                    @if (!string.IsNullOrWhiteSpace(_containerStatus.ContainerId))
+                    {
+                        <p><strong>Container ID:</strong> <code>@_containerStatus.ContainerId</code></p>
+                    }
+                }
+            </div>
+            <div class="workload-command-card">
+                <h3>Resolved Names</h3>
+                <p><strong>Base image:</strong> <code>@commandSet.BaseImageTag</code></p>
+                <p><strong>Workload image:</strong> <code>@commandSet.WorkloadImageTag</code></p>
+                <p><strong>Container:</strong> <code>@commandSet.ContainerName</code></p>
+            </div>
+            <div class="workload-command-card">
+                <h3>Build Base Image</h3>
+                @if (commandSet.BuildBaseImageCommand is null)
+                {
+                    <p>Set a runner source path to generate the base image build command.</p>
+                }
+                else
+                {
+                    <pre class="command-preview">@commandSet.BuildBaseImageCommand</pre>
+                }
+            </div>
+            <div class="workload-command-card">
+                <h3>Generated Workload Dockerfile</h3>
+                <pre class="command-preview">@commandSet.GeneratedDockerfile</pre>
+            </div>
+            <div class="workload-command-card">
+                <h3>Build Workload Image</h3>
+                <pre class="command-preview">@commandSet.BuildWorkloadImageCommand</pre>
+            </div>
+            <div class="workload-command-card">
+                <h3>Start Container</h3>
+                <pre class="command-preview">@commandSet.StartContainerCommand</pre>
+            </div>
+            <div class="workload-command-card">
+                <h3>Stop Container</h3>
+                <pre class="command-preview">@commandSet.StopContainerCommand</pre>
+            </div>
+            @if (_lastContainerResult is not null)
+            {
+                <div class="workload-command-card workload-command-card--full">
+                    <h3>Last Docker Command</h3>
+                    <pre class="command-preview">@_lastContainerResult.CommandText</pre>
+                    @if (!string.IsNullOrWhiteSpace(_lastContainerResult.StandardOutput))
+                    {
+                        <h3>Standard Output</h3>
+                        <pre class="command-preview">@_lastContainerResult.StandardOutput</pre>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(_lastContainerResult.StandardError))
+                    {
+                        <h3>Standard Error</h3>
+                        <pre class="command-preview">@_lastContainerResult.StandardError</pre>
+                    }
+                </div>
+            }
+        </div>
+    }
+    else if (selectionError is not null)
+    {
+        <p class="error-message">@selectionError</p>
+    }
+</div>
+
+<div class="settings-card">
     <h2>Connection Status</h2>
     <p>State: <strong class="status-text-@GetStatusClass()">@Client.ConnectionState</strong></p>
     <p>Hub URL: <code>@HubUrl</code></p>
@@ -57,6 +201,11 @@
 
 <div class="settings-card">
     <h2>Workload Catalog</h2>
+
+    <div class="workload-toolbar">
+        <p>Create custom workloads here or clone a built-in template as a starting point.</p>
+        <button class="btn btn-primary" @onclick="CreateCustomWorkload">New Custom Workload</button>
+    </div>
 
     @if (_workloadErrorMessage is not null)
     {
@@ -95,18 +244,51 @@
                         <span><strong>Cache mounts:</strong> @workload.CacheMounts.Count</span>
                         <span><strong>Secrets:</strong> @workload.Secrets.Count</span>
                     </div>
+                    <div class="workload-card__actions">
+                        @if (workload.IsBuiltIn)
+                        {
+                            <button class="btn btn-accent" @onclick="() => CloneWorkload(workload)">Clone as Custom</button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-accent" @onclick="() => EditCustomWorkload(workload)">Edit</button>
+                            <button class="btn btn-accent" @onclick="() => DuplicateCustomWorkload(workload)">Duplicate</button>
+                            <button class="btn btn-danger" @onclick="() => DeleteCustomWorkloadAsync(workload.Id)">Delete</button>
+                        }
+                    </div>
                 </article>
             }
         </div>
     }
 </div>
 
+@if (_editingWorkload is not null)
+{
+    <div class="settings-card">
+        <WorkloadEditor Workload="_editingWorkload"
+                        Title="@_editorTitle"
+                        EditorKey="@_editorKey"
+                        AllowDelete="@(!_editingWorkload.IsBuiltIn)"
+                        OnSave="SaveWorkloadAsync"
+                        OnCancel="CloseEditorAsync"
+                        OnDelete="DeleteCustomWorkloadAsync" />
+    </div>
+}
+
 @code {
     private ConnectionSettings _settings = new();
     private IReadOnlyList<WorkloadDefinition> _workloads = [];
+    private WorkloadDefinition? _editingWorkload;
+    private string? _editingOriginalId;
+    private string _editorTitle = "Edit Workload";
+    private int _editorKey;
     private bool _saving;
     private string? _errorMessage;
     private string? _workloadErrorMessage;
+    private bool _containerBusy;
+    private WorkloadContainerStatus? _containerStatus;
+    private WorkloadContainerExecutionResult? _lastContainerResult;
+    private string? _containerErrorMessage;
 
     private string HubUrl => $"{_settings.RunnerUrl.TrimEnd('/')}/hubs/agent";
 
@@ -114,6 +296,7 @@
     {
         _settings = await SettingsService.LoadAsync();
         await LoadWorkloadsAsync();
+        await RefreshContainerStatusIfPossibleAsync();
         Client.ConnectionStateChanged += OnConnectionStateChanged;
     }
 
@@ -162,6 +345,225 @@
         }
     }
 
+    private async Task RefreshContainerStatusIfPossibleAsync()
+    {
+        if (!TryGetSelectedWorkload(out _, out _))
+            return;
+
+        await RefreshContainerStatusAsync();
+    }
+
+    private void CreateCustomWorkload()
+    {
+        OpenEditor(new WorkloadDefinition
+        {
+            Id = string.Empty,
+            Name = string.Empty,
+            Description = string.Empty,
+            BaseImage = "agentdeck-runner:base",
+            WorkspaceMountPath = "/workspace",
+            HomeDirectory = "/agent-home",
+            IsBuiltIn = false
+        }, "New Custom Workload", null);
+    }
+
+    private void CloneWorkload(WorkloadDefinition workload)
+    {
+        var copy = CloneWorkloadDefinition(workload);
+        copy.IsBuiltIn = false;
+        OpenEditor(copy, $"Clone {workload.Name}", null);
+    }
+
+    private void EditCustomWorkload(WorkloadDefinition workload)
+    {
+        OpenEditor(CloneWorkloadDefinition(workload), $"Edit {workload.Name}", workload.Id);
+    }
+
+    private void DuplicateCustomWorkload(WorkloadDefinition workload)
+    {
+        var copy = CloneWorkloadDefinition(workload);
+        copy.Id = $"{workload.Id}-copy";
+        copy.Name = $"{workload.Name} Copy";
+        copy.IsBuiltIn = false;
+        OpenEditor(copy, $"Duplicate {workload.Name}", null);
+    }
+
+    private async Task SaveWorkloadAsync(WorkloadDefinition workload)
+    {
+        try
+        {
+            _workloadErrorMessage = null;
+            await WorkloadCatalog.SaveCustomAsync(workload, _editingOriginalId);
+            await LoadWorkloadsAsync();
+            if (_settings.SelectedWorkloadId == _editingOriginalId || string.IsNullOrWhiteSpace(_settings.SelectedWorkloadId))
+                _settings.SelectedWorkloadId = workload.Id;
+            await CloseEditorAsync();
+            await RefreshContainerStatusIfPossibleAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save workload {WorkloadId}", workload.Id);
+            _workloadErrorMessage = $"Failed to save workload: {ex.Message}";
+        }
+    }
+
+    private async Task DeleteCustomWorkloadAsync(string workloadId)
+    {
+        try
+        {
+            _workloadErrorMessage = null;
+            await WorkloadCatalog.DeleteCustomAsync(workloadId);
+            await LoadWorkloadsAsync();
+
+            if (_editingOriginalId?.Equals(workloadId, StringComparison.OrdinalIgnoreCase) == true)
+                await CloseEditorAsync();
+
+            if (_settings.SelectedWorkloadId?.Equals(workloadId, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                _settings.SelectedWorkloadId = null;
+                _containerStatus = null;
+                _lastContainerResult = null;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to delete workload {WorkloadId}", workloadId);
+            _workloadErrorMessage = $"Failed to delete workload: {ex.Message}";
+        }
+    }
+
+    private Task CloseEditorAsync()
+    {
+        _editingWorkload = null;
+        _editingOriginalId = null;
+        _editorTitle = "Edit Workload";
+        return Task.CompletedTask;
+    }
+
+    private void OpenEditor(WorkloadDefinition workload, string title, string? originalId)
+    {
+        _editingWorkload = workload;
+        _editingOriginalId = originalId;
+        _editorTitle = title;
+        _editorKey++;
+    }
+
+    private async Task BuildBaseImageAsync()
+    {
+        await ExecuteContainerActionAsync(
+            "Built base image",
+            (settings, workload, token) => WorkloadContainerRuntime.BuildBaseImageAsync(settings, workload, token));
+    }
+
+    private async Task BuildWorkloadImageAsync()
+    {
+        await ExecuteContainerActionAsync(
+            "Built workload image",
+            (settings, workload, token) => WorkloadContainerRuntime.BuildWorkloadImageAsync(settings, workload, token));
+    }
+
+    private async Task StartContainerAsync()
+    {
+        await ExecuteContainerActionAsync(
+            "Started runner container",
+            async (settings, workload, token) =>
+            {
+                var result = await WorkloadContainerRuntime.StartContainerAsync(settings, workload, token);
+                if (result.Succeeded)
+                {
+                    await SettingsService.SaveAsync(_settings);
+                    await ConnectAsync();
+                }
+
+                return result;
+            });
+    }
+
+    private async Task StopContainerAsync()
+    {
+        await ExecuteContainerActionAsync(
+            "Stopped runner container",
+            async (settings, workload, token) =>
+            {
+                var result = await WorkloadContainerRuntime.StopContainerAsync(settings, workload, token);
+                if (result.Succeeded && Client.ConnectionState == HubConnectionState.Connected)
+                    await DisconnectAsync();
+
+                return result;
+            });
+    }
+
+    private async Task RefreshContainerStatusAsync()
+    {
+        if (!TryGetSelectedWorkload(out var workload, out var error))
+        {
+            _containerErrorMessage = error;
+            _containerStatus = null;
+            return;
+        }
+
+        _containerBusy = true;
+        _containerErrorMessage = null;
+
+        try
+        {
+            _containerStatus = await WorkloadContainerRuntime.GetStatusAsync(_settings, workload);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to refresh Docker status for workload {WorkloadId}", workload.Id);
+            _containerErrorMessage = $"Failed to refresh Docker status: {ex.Message}";
+            _containerStatus = null;
+        }
+        finally
+        {
+            _containerBusy = false;
+        }
+    }
+
+    private async Task ExecuteContainerActionAsync(
+        string successMessage,
+        Func<ConnectionSettings, WorkloadDefinition, CancellationToken, Task<WorkloadContainerExecutionResult>> action)
+    {
+        if (!TryGetSelectedWorkload(out var workload, out var error))
+        {
+            _containerErrorMessage = error;
+            return;
+        }
+
+        _containerBusy = true;
+        _containerErrorMessage = null;
+
+        try
+        {
+            var result = await action(_settings, workload, CancellationToken.None);
+            _lastContainerResult = result;
+
+            if (result.Succeeded)
+            {
+                ToastService.Show(successMessage, ToastKind.Success);
+                await RefreshContainerStatusAsync();
+            }
+            else
+            {
+                _containerErrorMessage = string.IsNullOrWhiteSpace(result.StandardError)
+                    ? $"Docker command failed with exit code {result.ExitCode}."
+                    : result.StandardError;
+                ToastService.Show("Docker command failed", ToastKind.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Docker action failed for workload {WorkloadId}", workload.Id);
+            _containerErrorMessage = ex.Message;
+            ToastService.Show("Docker action failed", ToastKind.Error);
+        }
+        finally
+        {
+            _containerBusy = false;
+        }
+    }
+
     private static string FormatSdkVersions(WorkloadDefinition workload)
     {
         if (workload.SdkVersions.Count == 0)
@@ -176,6 +578,87 @@
             return "None";
 
         return string.Join(", ", workload.SupportedCliCommands);
+    }
+
+    private static string FormatAvailability(IReadOnlyDictionary<string, bool> values)
+    {
+        if (values.Count == 0)
+            return "None";
+
+        return string.Join(", ", values.Select(pair => $"{pair.Key}={(pair.Value ? "ready" : "missing")}"));
+    }
+
+    private bool TryGetSelectedWorkload(out WorkloadDefinition workload, out string? error)
+    {
+        workload = default!;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(_settings.SelectedWorkloadId))
+        {
+            error = "Choose a workload to generate Docker commands.";
+            return false;
+        }
+
+        workload = _workloads.FirstOrDefault(item =>
+            item.Id.Equals(_settings.SelectedWorkloadId, StringComparison.OrdinalIgnoreCase))!;
+
+        if (workload is null)
+        {
+            error = $"The selected workload '{_settings.SelectedWorkloadId}' is no longer available.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static WorkloadDefinition CloneWorkloadDefinition(WorkloadDefinition workload)
+    {
+        return new WorkloadDefinition
+        {
+            Id = workload.Id,
+            Name = workload.Name,
+            Description = workload.Description,
+            BaseImage = workload.BaseImage,
+            WorkspaceMountPath = workload.WorkspaceMountPath,
+            HomeDirectory = workload.HomeDirectory,
+            SupportedCliCommands = [.. workload.SupportedCliCommands],
+            SdkVersions = workload.SdkVersions.ToDictionary(pair => pair.Key, pair => pair.Value),
+            CliInstallers = new WorkloadCliInstallers
+            {
+                AptPackages = [.. workload.CliInstallers.AptPackages],
+                NpmGlobalPackages = [.. workload.CliInstallers.NpmGlobalPackages],
+                PipxPackages = [.. workload.CliInstallers.PipxPackages],
+                DotNetTools = [.. workload.CliInstallers.DotNetTools]
+            },
+            EnvironmentVariables = workload.EnvironmentVariables.ToDictionary(pair => pair.Key, pair => pair.Value),
+            AuthMounts = workload.AuthMounts
+                .Select(mount => new WorkloadMount
+                {
+                    Name = mount.Name,
+                    TargetPath = mount.TargetPath,
+                    Description = mount.Description
+                })
+                .ToList(),
+            CacheMounts = workload.CacheMounts
+                .Select(mount => new WorkloadMount
+                {
+                    Name = mount.Name,
+                    TargetPath = mount.TargetPath,
+                    Description = mount.Description
+                })
+                .ToList(),
+            Secrets = workload.Secrets
+                .Select(secret => new WorkloadSecret
+                {
+                    Name = secret.Name,
+                    EnvironmentVariable = secret.EnvironmentVariable,
+                    Description = secret.Description,
+                    IsRequired = secret.IsRequired
+                })
+                .ToList(),
+            BootstrapCommands = [.. workload.BootstrapCommands],
+            IsBuiltIn = workload.IsBuiltIn
+        };
     }
 
     public void Dispose() => Client.ConnectionStateChanged -= OnConnectionStateChanged;

--- a/AgentDeck.Core/Services/CoreServiceExtensions.cs
+++ b/AgentDeck.Core/Services/CoreServiceExtensions.cs
@@ -11,6 +11,7 @@ public static class CoreServiceExtensions
         services.AddSingleton<ISessionStateService, SessionStateService>();
         services.AddSingleton<IConnectionSettingsService, ConnectionSettingsService>();
         services.AddSingleton<IWorkloadCatalogService, WorkloadCatalogService>();
+        services.AddSingleton<IWorkloadContainerCommandService, WorkloadContainerCommandService>();
         services.AddSingleton<AppInitializer>();
         services.AddScoped<TerminalInterop>();
         services.AddSingleton<ICliPresetService, CliPresetService>();

--- a/AgentDeck.Core/Services/IWorkloadCatalogService.cs
+++ b/AgentDeck.Core/Services/IWorkloadCatalogService.cs
@@ -8,6 +8,6 @@ public interface IWorkloadCatalogService
     Task<IReadOnlyList<WorkloadDefinition>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<WorkloadDefinition>> GetBuiltInAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<WorkloadDefinition>> GetCustomAsync(CancellationToken cancellationToken = default);
-    Task SaveCustomAsync(WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task SaveCustomAsync(WorkloadDefinition workload, string? previousWorkloadId = null, CancellationToken cancellationToken = default);
     Task DeleteCustomAsync(string workloadId, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Core/Services/IWorkloadContainerCommandService.cs
+++ b/AgentDeck.Core/Services/IWorkloadContainerCommandService.cs
@@ -1,0 +1,9 @@
+using AgentDeck.Core.Models;
+
+namespace AgentDeck.Core.Services;
+
+/// <summary>Resolves Docker build and run commands from workload definitions.</summary>
+public interface IWorkloadContainerCommandService
+{
+    WorkloadContainerCommandSet Resolve(ConnectionSettings settings, WorkloadDefinition workload);
+}

--- a/AgentDeck.Core/Services/IWorkloadContainerRuntimeService.cs
+++ b/AgentDeck.Core/Services/IWorkloadContainerRuntimeService.cs
@@ -1,0 +1,13 @@
+using AgentDeck.Core.Models;
+
+namespace AgentDeck.Core.Services;
+
+/// <summary>Executes local Docker lifecycle operations for workload-driven runner containers.</summary>
+public interface IWorkloadContainerRuntimeService
+{
+    Task<WorkloadContainerStatus> GetStatusAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task<WorkloadContainerExecutionResult> BuildBaseImageAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task<WorkloadContainerExecutionResult> BuildWorkloadImageAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task<WorkloadContainerExecutionResult> StartContainerAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default);
+    Task<WorkloadContainerExecutionResult> StopContainerAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Core/Services/WorkloadCatalogService.cs
+++ b/AgentDeck.Core/Services/WorkloadCatalogService.cs
@@ -51,12 +51,15 @@ public sealed class WorkloadCatalogService : IWorkloadCatalogService
             .ToList();
     }
 
-    public async Task SaveCustomAsync(WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    public async Task SaveCustomAsync(WorkloadDefinition workload, string? previousWorkloadId = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(workload);
 
         var customWorkloads = await LoadCustomWorkloadsAsync(cancellationToken);
         var normalizedId = NormalizeId(workload.Id, workload.Name);
+        var normalizedPreviousId = string.IsNullOrWhiteSpace(previousWorkloadId)
+            ? null
+            : NormalizeId(previousWorkloadId, previousWorkloadId);
 
         if (_builtInWorkloads.Any(existing => existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase)))
         {
@@ -64,11 +67,31 @@ public sealed class WorkloadCatalogService : IWorkloadCatalogService
                 $"Cannot save custom workload '{normalizedId}' because it conflicts with a built-in workload.");
         }
 
+        var conflictingCustom = customWorkloads.FirstOrDefault(existing =>
+            existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase));
+
+        if (conflictingCustom is not null &&
+            !conflictingCustom.Id.Equals(normalizedPreviousId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Cannot save custom workload '{normalizedId}' because another custom workload already uses that id.");
+        }
+
         var toSave = Clone(workload);
         toSave.Id = normalizedId;
         toSave.IsBuiltIn = false;
 
-        customWorkloads.RemoveAll(existing => existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(normalizedPreviousId))
+        {
+            customWorkloads.RemoveAll(existing =>
+                existing.Id.Equals(normalizedPreviousId, StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            customWorkloads.RemoveAll(existing =>
+                existing.Id.Equals(normalizedId, StringComparison.OrdinalIgnoreCase));
+        }
+
         customWorkloads.Add(toSave);
 
         await SaveCustomWorkloadsAsync(customWorkloads, cancellationToken);

--- a/AgentDeck.Core/Services/WorkloadContainerCommandService.cs
+++ b/AgentDeck.Core/Services/WorkloadContainerCommandService.cs
@@ -1,0 +1,159 @@
+using System.Text;
+using AgentDeck.Core.Models;
+
+namespace AgentDeck.Core.Services;
+
+/// <inheritdoc />
+public sealed class WorkloadContainerCommandService : IWorkloadContainerCommandService
+{
+    public WorkloadContainerCommandSet Resolve(ConnectionSettings settings, WorkloadDefinition workload)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(workload);
+
+        var normalizedWorkloadId = workload.Id.Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(normalizedWorkloadId))
+            throw new InvalidOperationException("A workload must have a valid id before container commands can be generated.");
+
+        var baseImageTag = workload.BaseImage.Trim();
+        if (string.IsNullOrWhiteSpace(baseImageTag))
+            throw new InvalidOperationException("The workload base image is required.");
+
+        var workloadImageTag = $"agentdeck-workload-{normalizedWorkloadId}";
+        var containerName = $"agentdeck-runner-{normalizedWorkloadId}";
+        var buildBaseImageCommand = string.IsNullOrWhiteSpace(settings.RunnerSourcePath)
+            ? null
+            : $"docker build -t {Quote(baseImageTag)} -f {Quote(Path.Combine(settings.RunnerSourcePath, "AgentDeck.Runner", "Dockerfile"))} {Quote(settings.RunnerSourcePath)}";
+
+        var generatedDockerfile = GenerateDockerfile(workload);
+
+        return new WorkloadContainerCommandSet
+        {
+            BaseImageTag = baseImageTag,
+            WorkloadImageTag = workloadImageTag,
+            ContainerName = containerName,
+            BuildBaseImageCommand = buildBaseImageCommand,
+            GeneratedDockerfile = generatedDockerfile,
+            BuildWorkloadImageCommand = $"docker build -t {Quote(workloadImageTag)} -f Dockerfile.generated .",
+            StartContainerCommand = GenerateStartCommand(settings, workload, containerName, workloadImageTag),
+            StopContainerCommand = $"docker rm -f {Quote(containerName)}",
+        };
+    }
+
+    private static string GenerateDockerfile(WorkloadDefinition workload)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"FROM {workload.BaseImage}");
+        builder.AppendLine("USER root");
+        builder.AppendLine("ENV DEBIAN_FRONTEND=noninteractive");
+
+        var aptPackages = new HashSet<string>(workload.CliInstallers.AptPackages, StringComparer.OrdinalIgnoreCase);
+        var installNode = workload.SdkVersions.ContainsKey("node");
+        var installPython = workload.SdkVersions.ContainsKey("python");
+        var installDotNet = workload.SdkVersions.ContainsKey("dotnet");
+
+        if (installNode || installPython || installDotNet || aptPackages.Count > 0)
+        {
+            builder.AppendLine("RUN apt-get update && apt-get install -y \\");
+            builder.AppendLine("    ca-certificates \\");
+            builder.AppendLine("    curl \\");
+            builder.AppendLine("    gnupg \\");
+            builder.AppendLine("    wget \\");
+            builder.AppendLine("    && rm -rf /var/lib/apt/lists/*");
+        }
+
+        if (installNode)
+        {
+            var nodeMajor = workload.SdkVersions["node"].Split('.')[0];
+            builder.AppendLine("RUN mkdir -p /etc/apt/keyrings \\");
+            builder.AppendLine("    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \\");
+            builder.AppendLine($"    && echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{nodeMajor}.x nodistro main\" > /etc/apt/sources.list.d/nodesource.list \\");
+            builder.AppendLine("    && apt-get update \\");
+            builder.AppendLine("    && apt-get install -y nodejs \\");
+            builder.AppendLine("    && rm -rf /var/lib/apt/lists/*");
+        }
+
+        if (installPython)
+        {
+            builder.AppendLine("RUN apt-get update \\");
+            builder.AppendLine("    && apt-get install -y python3 python3-pip python3-venv pipx \\");
+            builder.AppendLine("    && rm -rf /var/lib/apt/lists/*");
+        }
+
+        if (installDotNet)
+        {
+            var dotnetMajorMinor = workload.SdkVersions["dotnet"];
+            builder.AppendLine("RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \\");
+            builder.AppendLine("    && dpkg -i packages-microsoft-prod.deb \\");
+            builder.AppendLine("    && rm packages-microsoft-prod.deb \\");
+            builder.AppendLine("    && apt-get update \\");
+            builder.AppendLine($"    && apt-get install -y dotnet-sdk-{dotnetMajorMinor} \\");
+            builder.AppendLine("    && rm -rf /var/lib/apt/lists/*");
+        }
+
+        if (aptPackages.Count > 0)
+        {
+            builder.AppendLine("RUN apt-get update \\");
+            builder.AppendLine($"    && apt-get install -y {string.Join(' ', aptPackages.OrderBy(package => package, StringComparer.OrdinalIgnoreCase))} \\");
+            builder.AppendLine("    && rm -rf /var/lib/apt/lists/*");
+        }
+
+        if (workload.CliInstallers.NpmGlobalPackages.Count > 0)
+            builder.AppendLine($"RUN npm install -g {string.Join(' ', workload.CliInstallers.NpmGlobalPackages)}");
+
+        if (workload.CliInstallers.PipxPackages.Count > 0)
+            builder.AppendLine($"RUN pipx install {string.Join(' ', workload.CliInstallers.PipxPackages)}");
+
+        if (workload.CliInstallers.DotNetTools.Count > 0)
+        {
+            foreach (var tool in workload.CliInstallers.DotNetTools)
+                builder.AppendLine($"RUN dotnet tool install --tool-path /usr/local/bin {tool}");
+        }
+
+        foreach (var pair in workload.EnvironmentVariables.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            builder.AppendLine($"ENV {pair.Key}={QuoteDockerValue(pair.Value)}");
+
+        if (workload.BootstrapCommands.Count > 0)
+            builder.AppendLine($"RUN {string.Join(" && ", workload.BootstrapCommands)}");
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string GenerateStartCommand(ConnectionSettings settings, WorkloadDefinition workload, string containerName, string workloadImageTag)
+    {
+        if (string.IsNullOrWhiteSpace(settings.DockerWorkspacePath))
+            throw new InvalidOperationException("A host workspace path is required before generating the start command.");
+
+        var runnerUrl = new Uri(settings.RunnerUrl);
+        var port = runnerUrl.Port;
+        var parts = new List<string>
+        {
+            "docker run -d --restart unless-stopped",
+            $"--name {Quote(containerName)}",
+            $"-p {port}:{port}",
+            $"-e AGENTDECK_PORT={port}"
+        };
+
+        foreach (var pair in workload.EnvironmentVariables.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            parts.Add($"-e {pair.Key}={Quote(pair.Value)}");
+
+        parts.Add($"-v {Quote(settings.DockerWorkspacePath)}:{Quote(workload.WorkspaceMountPath)}");
+
+        foreach (var mount in workload.AuthMounts)
+            parts.Add($"-v {Quote(GetNamedVolumeName(workload, mount.Name))}:{Quote(mount.TargetPath)}");
+
+        foreach (var mount in workload.CacheMounts)
+            parts.Add($"-v {Quote(GetNamedVolumeName(workload, mount.Name))}:{Quote(mount.TargetPath)}");
+
+        parts.Add(Quote(workloadImageTag));
+        return string.Join(" ", parts);
+    }
+
+    private static string GetNamedVolumeName(WorkloadDefinition workload, string mountName)
+    {
+        return $"agentdeck-{workload.Id.ToLowerInvariant()}-{mountName.Trim().ToLowerInvariant().Replace(' ', '-')}";
+    }
+
+    private static string Quote(string value) => $"\"{value.Replace("\"", "\\\"")}\"";
+    private static string QuoteDockerValue(string value) => $"\"{value.Replace("\"", "\\\"")}\"";
+}

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -382,6 +382,12 @@ main {
 
 .form-actions { display: flex; gap: 0.75rem; margin-top: 1.25rem; }
 
+.input--multiline {
+    min-height: 5.5rem;
+    resize: vertical;
+    font-family: inherit;
+}
+
 .btn {
     padding: 0.5rem 1.25rem;
     border: none;
@@ -409,6 +415,20 @@ main {
 .workload-list {
     display: grid;
     gap: 0.9rem;
+}
+
+.workload-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.workload-toolbar p {
+    margin: 0;
+    color: var(--color-subtext);
+    font-size: 0.85rem;
 }
 
 .workload-card {
@@ -452,6 +472,13 @@ main {
     border-radius: 4px;
 }
 
+.workload-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
 .workload-badge {
     border-radius: 999px;
     padding: 0.2rem 0.6rem;
@@ -467,6 +494,150 @@ main {
 .workload-badge--custom {
     background: rgba(166,227,161,0.15);
     color: var(--color-green);
+}
+
+.workload-command-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.workload-runtime-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.workload-command-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.workload-command-card h3 {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.9rem;
+}
+
+.workload-command-card p {
+    margin: 0.35rem 0;
+    color: var(--color-subtext);
+    font-size: 0.82rem;
+}
+
+.workload-command-card--full {
+    grid-column: 1 / -1;
+}
+
+.command-preview {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: rgba(0,0,0,0.25);
+    color: var(--color-text);
+    padding: 0.75rem;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    font-family: Consolas, "Courier New", monospace;
+}
+
+.workload-editor {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.workload-editor__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.workload-editor__header h3 {
+    margin: 0 0 0.25rem 0;
+}
+
+.workload-editor__header p {
+    margin: 0;
+    color: var(--color-subtext);
+    font-size: 0.85rem;
+}
+
+.workload-editor__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.workload-editor__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem 1.25rem;
+}
+
+.workload-editor__full {
+    grid-column: 1 / -1;
+}
+
+.workload-editor__section {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.workload-editor__section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.workload-editor__section-header h4 {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.workload-entry-row,
+.workload-secret-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 2fr auto;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.workload-secret-row {
+    grid-template-columns: 1fr 1fr 2fr auto auto;
+}
+
+.workload-secret-row__checkbox {
+    white-space: nowrap;
+}
+
+@media (max-width: 980px) {
+    .workload-toolbar,
+    .workload-runtime-toolbar,
+    .workload-editor__header,
+    .workload-editor__section-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .workload-editor__grid,
+    .workload-command-grid,
+    .workload-entry-row,
+    .workload-secret-row {
+        grid-template-columns: 1fr;
+    }
+
+    .workload-editor__full {
+        grid-column: auto;
+    }
+
+    .workload-command-card--full {
+        grid-column: auto;
+    }
 }
 
 /* ========== Badges ========== */

--- a/AgentDeck.Runner/Hubs/AgentHub.cs
+++ b/AgentDeck.Runner/Hubs/AgentHub.cs
@@ -58,6 +58,8 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
         var sessionId = Guid.NewGuid().ToString("N");
         var workingDir = ResolveWorkingDirectory(request.WorkingDirectory);
         var command = ResolveCommand(request.Command);
+        var arguments = request.Arguments;
+        var (launchCommand, launchArguments) = ResolveLaunch(command, arguments, workingDir, !string.IsNullOrWhiteSpace(request.Command));
 
         var session = new TerminalSession
         {
@@ -65,7 +67,7 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
             Name = request.Name,
             WorkingDirectory = workingDir,
             Command = command,
-            Arguments = request.Arguments,
+            Arguments = arguments,
             Status = TerminalStatus.Running
         };
 
@@ -73,7 +75,7 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
 
         try
         {
-            await _ptyManager.StartAsync(sessionId, command, request.Arguments, workingDir, request.Cols, request.Rows);
+            await _ptyManager.StartAsync(sessionId, launchCommand, launchArguments, workingDir, request.Cols, request.Rows);
         }
         catch (Exception ex)
         {
@@ -127,5 +129,61 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
             return "powershell.exe";
 
         return File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
+    }
+
+    private static (string Command, IReadOnlyList<string> Arguments) ResolveLaunch(
+        string command,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        bool commandWasSpecified)
+    {
+        if (!commandWasSpecified || IsShellCommand(command))
+            return (command, arguments);
+
+        if (OperatingSystem.IsWindows())
+        {
+            return ("powershell.exe",
+            [
+                "-NoExit",
+                "-Command",
+                $"Set-Location -LiteralPath {QuotePowerShell(workingDirectory)}; {BuildShellCommand(command, arguments)}"
+            ]);
+        }
+
+        var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
+        return (shellPath,
+        [
+            "-lc",
+            $"cd {QuotePosix(workingDirectory)} && {BuildShellCommand(command, arguments)}; exec {shellPath}"
+        ]);
+    }
+
+    private static bool IsShellCommand(string command)
+    {
+        var commandName = Path.GetFileNameWithoutExtension(command.Trim()).ToLowerInvariant();
+        return commandName is "pwsh" or "powershell" or "bash" or "sh" or "cmd";
+    }
+
+    private static string BuildShellCommand(string command, IReadOnlyList<string> arguments)
+    {
+        if (arguments.Count == 0)
+            return command;
+
+        if (OperatingSystem.IsWindows())
+        {
+            return $"& {QuotePowerShell(command)} {string.Join(" ", arguments.Select(QuotePowerShell))}";
+        }
+
+        return $"{QuotePosix(command)} {string.Join(" ", arguments.Select(QuotePosix))}";
+    }
+
+    private static string QuotePowerShell(string value)
+    {
+        return $"'{value.Replace("'", "''")}'";
+    }
+
+    private static string QuotePosix(string value)
+    {
+        return $"'{value.Replace("'", "'\"'\"'")}'";
     }
 }

--- a/AgentDeck/MauiProgram.cs
+++ b/AgentDeck/MauiProgram.cs
@@ -17,6 +17,7 @@ public static class MauiProgram
 
         builder.Services.AddMauiBlazorWebView();
         builder.Services.AddSingleton<IAppDataDirectory, AgentDeck.Services.MauiAppDataDirectory>();
+        builder.Services.AddSingleton<IWorkloadContainerRuntimeService, AgentDeck.Services.LocalDockerWorkloadRuntimeService>();
         builder.Services.AddAgentDeckCore();
 
 #if DEBUG

--- a/AgentDeck/Services/LocalDockerWorkloadRuntimeService.cs
+++ b/AgentDeck/Services/LocalDockerWorkloadRuntimeService.cs
@@ -1,0 +1,235 @@
+using System.Diagnostics;
+using AgentDeck.Core.Models;
+using AgentDeck.Core.Services;
+
+namespace AgentDeck.Services;
+
+/// <inheritdoc />
+public sealed class LocalDockerWorkloadRuntimeService : IWorkloadContainerRuntimeService
+{
+    private readonly IAppDataDirectory _appDataDirectory;
+    private readonly IWorkloadContainerCommandService _commandService;
+
+    public LocalDockerWorkloadRuntimeService(IAppDataDirectory appDataDirectory, IWorkloadContainerCommandService commandService)
+    {
+        _appDataDirectory = appDataDirectory;
+        _commandService = commandService;
+    }
+
+    public async Task<WorkloadContainerStatus> GetStatusAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        var commandSet = _commandService.Resolve(settings, workload);
+        var dockerVersion = await RunDockerAsync(["version", "--format", "{{.Server.Version}}"], cancellationToken);
+        if (!dockerVersion.Succeeded)
+        {
+            return new WorkloadContainerStatus
+            {
+                DockerAvailable = false,
+                ErrorMessage = FirstMeaningfulLine(dockerVersion.StandardError, dockerVersion.StandardOutput)
+            };
+        }
+
+        var baseImageExists = await RunDockerAsync(["image", "inspect", commandSet.BaseImageTag, "--format", "{{.Id}}"], cancellationToken);
+        var workloadImageExists = await RunDockerAsync(["image", "inspect", commandSet.WorkloadImageTag, "--format", "{{.Id}}"], cancellationToken);
+        var containerState = await RunDockerAsync(["container", "inspect", commandSet.ContainerName, "--format", "{{.State.Status}}"], cancellationToken);
+        var containerId = await RunDockerAsync(["container", "inspect", commandSet.ContainerName, "--format", "{{.Id}}"], cancellationToken);
+        var authVolumeExists = await GetVolumeStateAsync(workload, workload.AuthMounts, cancellationToken);
+        var cacheVolumeExists = await GetVolumeStateAsync(workload, workload.CacheMounts, cancellationToken);
+        var secretAvailability = workload.Secrets.ToDictionary(
+            secret => secret.EnvironmentVariable,
+            secret => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(secret.EnvironmentVariable)),
+            StringComparer.OrdinalIgnoreCase);
+
+        return new WorkloadContainerStatus
+        {
+            DockerAvailable = true,
+            DockerVersion = dockerVersion.StandardOutput.Trim(),
+            BaseImageExists = baseImageExists.Succeeded,
+            WorkloadImageExists = workloadImageExists.Succeeded,
+            ContainerExists = containerState.Succeeded,
+            ContainerState = containerState.Succeeded ? containerState.StandardOutput.Trim() : "not-created",
+            ContainerId = containerId.Succeeded ? containerId.StandardOutput.Trim() : string.Empty,
+            AuthVolumeExists = authVolumeExists,
+            CacheVolumeExists = cacheVolumeExists,
+            SecretAvailability = secretAvailability
+        };
+    }
+
+    public async Task<WorkloadContainerExecutionResult> BuildBaseImageAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        var commandSet = _commandService.Resolve(settings, workload);
+        if (string.IsNullOrWhiteSpace(commandSet.BuildBaseImageCommand))
+        {
+            throw new InvalidOperationException("Set the runner source path before building the base image.");
+        }
+
+        return await RunDockerAsync(
+            ["build", "-t", commandSet.BaseImageTag, "-f", Path.Combine(settings.RunnerSourcePath, "AgentDeck.Runner", "Dockerfile"), settings.RunnerSourcePath],
+            cancellationToken);
+    }
+
+    public async Task<WorkloadContainerExecutionResult> BuildWorkloadImageAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        var commandSet = _commandService.Resolve(settings, workload);
+        var buildDirectory = PrepareGeneratedBuildContext(commandSet);
+
+        return await RunDockerAsync(
+            ["build", "-t", commandSet.WorkloadImageTag, "-f", "Dockerfile.generated", "."],
+            cancellationToken,
+            buildDirectory);
+    }
+
+    public async Task<WorkloadContainerExecutionResult> StartContainerAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(settings.DockerWorkspacePath))
+            throw new InvalidOperationException("Set the host workspace path before starting the container.");
+
+        var commandSet = _commandService.Resolve(settings, workload);
+        await RunDockerAsync(["rm", "-f", commandSet.ContainerName], cancellationToken);
+
+        var args = new List<string>
+        {
+            "run", "-d", "--restart", "unless-stopped",
+            "--name", commandSet.ContainerName
+        };
+
+        var runnerUrl = new Uri(settings.RunnerUrl);
+        args.AddRange(["-p", $"{runnerUrl.Port}:{runnerUrl.Port}"]);
+        args.AddRange(["-e", $"AGENTDECK_PORT={runnerUrl.Port}"]);
+
+        foreach (var pair in workload.EnvironmentVariables.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            args.AddRange(["-e", $"{pair.Key}={pair.Value}"]);
+
+        foreach (var secret in workload.Secrets.OrderBy(secret => secret.EnvironmentVariable, StringComparer.OrdinalIgnoreCase))
+        {
+            var secretValue = Environment.GetEnvironmentVariable(secret.EnvironmentVariable);
+            if (string.IsNullOrWhiteSpace(secretValue))
+            {
+                if (secret.IsRequired)
+                {
+                    throw new InvalidOperationException(
+                        $"The required environment variable '{secret.EnvironmentVariable}' is not set on the host.");
+                }
+
+                continue;
+            }
+
+            args.AddRange(["-e", $"{secret.EnvironmentVariable}={secretValue}"]);
+        }
+
+        args.AddRange(["-v", $"{settings.DockerWorkspacePath}:{workload.WorkspaceMountPath}"]);
+
+        foreach (var mount in workload.AuthMounts)
+            args.AddRange(["-v", $"{GetNamedVolumeName(workload, mount.Name)}:{mount.TargetPath}"]);
+
+        foreach (var mount in workload.CacheMounts)
+            args.AddRange(["-v", $"{GetNamedVolumeName(workload, mount.Name)}:{mount.TargetPath}"]);
+
+        args.Add(commandSet.WorkloadImageTag);
+        return await RunDockerAsync(args, cancellationToken);
+    }
+
+    public Task<WorkloadContainerExecutionResult> StopContainerAsync(ConnectionSettings settings, WorkloadDefinition workload, CancellationToken cancellationToken = default)
+    {
+        var commandSet = _commandService.Resolve(settings, workload);
+        return RunDockerAsync(["rm", "-f", commandSet.ContainerName], cancellationToken);
+    }
+
+    private string PrepareGeneratedBuildContext(WorkloadContainerCommandSet commandSet)
+    {
+        var workdir = Path.Combine(_appDataDirectory.Path, "docker", commandSet.ContainerName);
+        Directory.CreateDirectory(workdir);
+        File.WriteAllText(Path.Combine(workdir, "Dockerfile.generated"), commandSet.GeneratedDockerfile);
+        return workdir;
+    }
+
+    private static string GetNamedVolumeName(WorkloadDefinition workload, string mountName)
+    {
+        return $"agentdeck-{workload.Id.ToLowerInvariant()}-{mountName.Trim().ToLowerInvariant().Replace(' ', '-')}";
+    }
+
+    private static async Task<IReadOnlyDictionary<string, bool>> GetVolumeStateAsync(
+        WorkloadDefinition workload,
+        IEnumerable<WorkloadMount> mounts,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var mount in mounts)
+        {
+            var volumeName = GetNamedVolumeName(workload, mount.Name);
+            var inspect = await RunDockerAsync(["volume", "inspect", volumeName], cancellationToken);
+            result[mount.Name] = inspect.Succeeded;
+        }
+
+        return result;
+    }
+
+    private static string FirstMeaningfulLine(string primary, string secondary)
+    {
+        foreach (var candidate in new[] { primary, secondary })
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                continue;
+
+            var line = candidate.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(line))
+                return line;
+        }
+
+        return "Docker is unavailable.";
+    }
+
+    private static async Task<WorkloadContainerExecutionResult> RunDockerAsync(
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken,
+        string? workingDirectory = null)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "docker",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+            startInfo.WorkingDirectory = workingDirectory;
+
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            return new WorkloadContainerExecutionResult
+            {
+                Succeeded = false,
+                ExitCode = -1,
+                CommandText = $"docker {string.Join(' ', arguments)}",
+                StandardError = ex.Message
+            };
+        }
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new WorkloadContainerExecutionResult
+        {
+            Succeeded = process.ExitCode == 0,
+            ExitCode = process.ExitCode,
+            CommandText = $"docker {string.Join(' ', arguments)}",
+            StandardOutput = await stdOutTask,
+            StandardError = await stdErrTask
+        };
+    }
+}

--- a/README.md
+++ b/README.md
@@ -94,3 +94,69 @@ Runner configuration (`AgentDeck.Runner/appsettings.json`):
   }
 }
 ```
+
+---
+
+## Workload-Driven Runner Containers
+
+The companion app can now manage **workloads** that describe how a runner container should be built and started for a specific development stack.
+
+Each workload can define:
+- the base runner image
+- SDK versions such as Python, Node, and .NET
+- CLI installers such as apt packages, npm globals, pipx packages, and .NET tools
+- environment variables and bootstrap commands
+- persistent auth mounts and cache mounts
+- runtime secrets that are injected from host environment variables
+
+### Built-in Example Workloads
+
+Built-in workload templates live under `AgentDeck.Core/Workloads/Examples/` and currently include:
+
+| Workload | Purpose |
+|---------|---------|
+| `github-cli` | Minimal GitHub CLI environment with persistent auth state |
+| `copilot-gh` | GitHub CLI plus agent-oriented tooling |
+| `python-gh` | Python development with GitHub CLI and pip cache mounts |
+| `node-gh` | Node development with GitHub CLI and npm cache mounts |
+| `dotnet-gh` | .NET development with GitHub CLI and NuGet cache mounts |
+| `python-node-gh` | Polyglot Python + Node workload |
+| `fullstack-gh` | Python + Node + .NET starter workload |
+
+### Custom Workloads in the Companion App
+
+The **Settings** page lets you:
+- view the built-in workload catalog
+- clone built-in workloads into editable custom workloads
+- create, edit, duplicate, and delete custom workloads
+- choose the active workload used for Docker command generation and execution
+
+Custom workloads are stored in the companion app data directory, separately from the built-in templates, so updating the app does not overwrite them.
+
+### Container Orchestration in the Companion App
+
+For the selected workload, the **Settings** page can now:
+- generate the workload Dockerfile
+- build the base runner image
+- build the workload image
+- start and stop the runner container
+- inspect local Docker, image, and container status
+- show the last Docker command output
+
+This orchestration currently assumes a local Docker installation reachable from the companion app host.
+
+### Authentication and Cache Persistence
+
+Auth and cache persistence are handled through **named Docker volumes**, not by baking credentials into images.
+
+Workloads can define:
+- **auth mounts** for home/config locations such as `/agent-home`
+- **cache mounts** for package-manager caches such as npm, pip, and NuGet
+- **runtime secrets** like `GITHUB_TOKEN`
+
+At container start:
+- auth and cache mounts are attached as named volumes, so state survives container recreation
+- required secrets are read from the host environment and passed through to the container at runtime
+- secret values are **not** stored in app settings or workload files
+
+This means flows like `gh auth login` can persist across sessions when the workload mounts the CLI home/config directory, and package caches can be reused between runs.


### PR DESCRIPTION
## Summary
- add the companion workload runtime flow for Docker status, build/start/stop actions, and auth/cache visibility
- add workload editing and documentation updates that were still pending locally
- fix terminal command launching so custom commands are entered as a single full command, Copilot yolo launches as copilot --yolo, and explicit commands run from the selected workspace

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj -nologo
- dotnet publish AgentDeck.Runner/AgentDeck.Runner.csproj -nologo -c Release -o temp -p:UseAppHost=false
- dotnet build AgentDeck/AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o temp

## Notes
- keeps the local-only AgentDeck.Runner/appsettings.json override out of the PR