### PR TITLE
Fix workload settings preview crash

### DIFF
--- a/AgentDeck.Core/Models/WorkloadContainerCommandSet.cs
+++ b/AgentDeck.Core/Models/WorkloadContainerCommandSet.cs
@@ -9,6 +9,7 @@ public sealed class WorkloadContainerCommandSet
     public string? BuildBaseImageCommand { get; init; }
     public required string GeneratedDockerfile { get; init; }
     public required string BuildWorkloadImageCommand { get; init; }
-    public required string StartContainerCommand { get; init; }
+    public string? StartContainerCommand { get; init; }
+    public string? StartContainerCommandMessage { get; init; }
     public required string StopContainerCommand { get; init; }
 }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -139,7 +139,7 @@
                 <button class="btn btn-accent" @onclick="BuildWorkloadImageAsync" disabled="@_containerBusy">
                     Build Workload Image
                 </button>
-                <button class="btn btn-primary" @onclick="StartContainerAsync" disabled="@_containerBusy">
+                <button class="btn btn-primary" @onclick="StartContainerAsync" disabled="@(_containerBusy || commandSet.StartContainerCommand is null)">
                     Start Container
                 </button>
                 <button class="btn btn-danger" @onclick="StopContainerAsync" disabled="@_containerBusy">
@@ -209,7 +209,14 @@
                 </div>
                 <div class="workload-command-card">
                     <h3>Start Container</h3>
-                    <pre class="command-preview">@commandSet.StartContainerCommand</pre>
+                    @if (commandSet.StartContainerCommand is null)
+                    {
+                        <p>@commandSet.StartContainerCommandMessage</p>
+                    }
+                    else
+                    {
+                        <pre class="command-preview">@commandSet.StartContainerCommand</pre>
+                    }
                 </div>
                 <div class="workload-command-card">
                     <h3>Stop Container</h3>

--- a/AgentDeck.Core/Services/WorkloadContainerCommandService.cs
+++ b/AgentDeck.Core/Services/WorkloadContainerCommandService.cs
@@ -27,6 +27,8 @@ public sealed class WorkloadContainerCommandService : IWorkloadContainerCommandS
             : $"docker build -t {Quote(baseImageTag)} -f {Quote(Path.Combine(machine.RunnerSourcePath, "AgentDeck.Runner", "Dockerfile"))} {Quote(machine.RunnerSourcePath)}";
 
         var generatedDockerfile = GenerateDockerfile(workload);
+        var (startContainerCommand, startContainerCommandMessage) =
+            TryGenerateStartCommand(machine, workload, containerName, workloadImageTag);
 
         return new WorkloadContainerCommandSet
         {
@@ -36,7 +38,8 @@ public sealed class WorkloadContainerCommandService : IWorkloadContainerCommandS
             BuildBaseImageCommand = buildBaseImageCommand,
             GeneratedDockerfile = generatedDockerfile,
             BuildWorkloadImageCommand = $"docker build -t {Quote(workloadImageTag)} -f Dockerfile.generated .",
-            StartContainerCommand = GenerateStartCommand(machine, workload, containerName, workloadImageTag),
+            StartContainerCommand = startContainerCommand,
+            StartContainerCommandMessage = startContainerCommandMessage,
             StopContainerCommand = $"docker rm -f {Quote(containerName)}",
         };
     }
@@ -120,12 +123,18 @@ public sealed class WorkloadContainerCommandService : IWorkloadContainerCommandS
         return builder.ToString().TrimEnd();
     }
 
-    private static string GenerateStartCommand(RunnerMachineSettings machine, WorkloadDefinition workload, string containerName, string workloadImageTag)
+    private static (string? Command, string? Message) TryGenerateStartCommand(
+        RunnerMachineSettings machine,
+        WorkloadDefinition workload,
+        string containerName,
+        string workloadImageTag)
     {
         if (string.IsNullOrWhiteSpace(machine.DockerWorkspacePath))
-            throw new InvalidOperationException("A host workspace path is required before generating the start command.");
+            return (null, "Set a host workspace path before generating the start command.");
 
-        var runnerUrl = new Uri(machine.RunnerUrl);
+        if (!Uri.TryCreate(machine.RunnerUrl, UriKind.Absolute, out var runnerUrl))
+            return (null, "Set a valid runner URL before generating the start command.");
+
         var port = runnerUrl.Port;
         var parts = new List<string>
         {
@@ -147,7 +156,7 @@ public sealed class WorkloadContainerCommandService : IWorkloadContainerCommandS
             parts.Add($"-v {Quote(GetNamedVolumeName(workload, mount.Name))}:{Quote(mount.TargetPath)}");
 
         parts.Add(Quote(workloadImageTag));
-        return string.Join(" ", parts);
+        return (string.Join(" ", parts), null);
     }
 
     private static string GetNamedVolumeName(WorkloadDefinition workload, string mountName)


### PR DESCRIPTION
## Summary
- stop treating an empty host workspace path as a fatal error during workload command preview generation
- let the Settings page render guidance and disable Start Container until the machine config is complete
- keep runtime start validation in place when the user actually launches a container

Closes #45