### PR TITLE
Detect machine capabilities from runner

### DIFF
--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -100,6 +100,60 @@
 @if (SelectedMachine is not null)
 {
     <div class="settings-card">
+        <div class="settings-card__header">
+            <h2>Machine Capabilities: @SelectedMachine.Name</h2>
+            <div class="form-actions">
+                <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
+                    Refresh Capabilities
+                </button>
+            </div>
+        </div>
+
+        @if (_capabilitiesErrorMessage is not null)
+        {
+            <p class="error-message">@_capabilitiesErrorMessage</p>
+        }
+        else if (_capabilitiesBusy)
+        {
+            <p>Detecting supported tools on this machine...</p>
+        }
+        else if (_machineCapabilities is null)
+        {
+            <p>Refresh capabilities to inspect which supported CLIs and SDKs are installed on this machine.</p>
+        }
+        else
+        {
+            <div class="capability-grid">
+                @foreach (var capability in _machineCapabilities.Capabilities.OrderBy(capability => capability.Category).ThenBy(capability => capability.Name))
+                {
+                    <article class="capability-card">
+                        <div class="capability-card__header">
+                            <div>
+                                <h3>@capability.Name</h3>
+                                <p>@capability.Category.ToUpperInvariant()</p>
+                            </div>
+                            <span class="capability-status capability-status--@GetCapabilityStatusClass(capability)">
+                                @capability.Status
+                            </span>
+                        </div>
+
+                        @if (!string.IsNullOrWhiteSpace(capability.Version))
+                        {
+                            <p><strong>Version:</strong> <code>@capability.Version</code></p>
+                        }
+
+                        @if (!string.IsNullOrWhiteSpace(capability.Message))
+                        {
+                            <p class="capability-card__message">@capability.Message</p>
+                        }
+                    </article>
+                }
+            </div>
+            <p class="machine-capabilities__timestamp">Last checked @(_machineCapabilities.CapturedAt.ToLocalTime().ToString("g"))</p>
+        }
+    </div>
+
+    <div class="settings-card">
         <h2>Container Orchestration: @SelectedMachine.Name</h2>
 
         <div class="form-field">
@@ -344,6 +398,9 @@
     private WorkloadContainerStatus? _containerStatus;
     private WorkloadContainerExecutionResult? _lastContainerResult;
     private string? _containerErrorMessage;
+    private MachineCapabilitiesSnapshot? _machineCapabilities;
+    private bool _capabilitiesBusy;
+    private string? _capabilitiesErrorMessage;
     private string? _selectedMachineId;
 
     private RunnerMachineSettings? SelectedMachine => _settings.FindMachine(_selectedMachineId);
@@ -353,6 +410,7 @@
         _settings = await SettingsService.LoadAsync();
         _selectedMachineId = _settings.PreferredMachineId;
         await LoadWorkloadsAsync();
+        await RefreshMachineCapabilitiesIfPossibleAsync();
         await RefreshContainerStatusIfPossibleAsync();
         Connections.ConnectionStateChanged += OnConnectionStateChanged;
     }
@@ -403,9 +461,12 @@
     private void SelectMachine(string machineId)
     {
         _selectedMachineId = machineId;
+        _machineCapabilities = null;
+        _capabilitiesErrorMessage = null;
         _containerStatus = null;
         _lastContainerResult = null;
         _containerErrorMessage = null;
+        _ = InvokeAsync(RefreshMachineCapabilitiesIfPossibleAsync);
         _ = InvokeAsync(RefreshContainerStatusIfPossibleAsync);
     }
 
@@ -446,6 +507,7 @@
         try
         {
             await Connections.ConnectAsync(machine);
+            await RefreshMachineCapabilitiesAsync();
         }
         catch (Exception ex)
         {
@@ -490,6 +552,48 @@
         {
             Logger.LogError(ex, "Failed to load workload catalog");
             _workloadErrorMessage = $"Failed to load workloads: {ex.Message}";
+        }
+    }
+
+    private Task RefreshMachineCapabilitiesIfPossibleAsync()
+    {
+        if (SelectedMachine is null)
+        {
+            _machineCapabilities = null;
+            return Task.CompletedTask;
+        }
+
+        return RefreshMachineCapabilitiesAsync();
+    }
+
+    private async Task RefreshMachineCapabilitiesAsync()
+    {
+        if (SelectedMachine is null)
+        {
+            _machineCapabilities = null;
+            return;
+        }
+
+        _capabilitiesBusy = true;
+        _capabilitiesErrorMessage = null;
+
+        try
+        {
+            _machineCapabilities = await Connections.GetMachineCapabilitiesAsync(SelectedMachine);
+            if (_machineCapabilities is null)
+            {
+                _capabilitiesErrorMessage = "The runner did not return machine capability data.";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to detect capabilities for machine {MachineId}", SelectedMachine.Id);
+            _capabilitiesErrorMessage = $"Failed to detect capabilities: {ex.Message}";
+            _machineCapabilities = null;
+        }
+        finally
+        {
+            _capabilitiesBusy = false;
         }
     }
 
@@ -750,6 +854,13 @@
 
         return string.Join(", ", values.Select(pair => $"{pair.Key}={(pair.Value ? "ready" : "missing")}"));
     }
+
+    private static string GetCapabilityStatusClass(MachineCapability capability) => capability.Status switch
+    {
+        MachineCapabilityStatus.Installed => "installed",
+        MachineCapabilityStatus.Missing => "missing",
+        _ => "error"
+    };
 
     private bool TryGetSelectedWorkload(RunnerMachineSettings machine, out WorkloadDefinition workload, out string? error)
     {

--- a/AgentDeck.Core/Services/AgentDeckClient.cs
+++ b/AgentDeck.Core/Services/AgentDeckClient.cs
@@ -150,6 +150,20 @@ public sealed class AgentDeckClient : IAgentDeckClient, IAsyncDisposable
         }
     }
 
+    public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(CancellationToken ct = default)
+    {
+        if (_http.BaseAddress is null) return null;
+        try
+        {
+            return await _http.GetFromJsonAsync<MachineCapabilitiesSnapshot>("/api/capabilities", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "GetMachineCapabilitiesAsync failed");
+            return null;
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_connection is not null)

--- a/AgentDeck.Core/Services/IAgentDeckClient.cs
+++ b/AgentDeck.Core/Services/IAgentDeckClient.cs
@@ -61,4 +61,7 @@ public interface IAgentDeckClient
 
     /// <summary>Get workspace information from the runner via REST.</summary>
     Task<WorkspaceInfo?> GetWorkspaceAsync(CancellationToken ct = default);
+
+    /// <summary>Get supported CLI/SDK detection results from the runner via REST.</summary>
+    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(CancellationToken ct = default);
 }

--- a/AgentDeck.Core/Services/IRunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/IRunnerConnectionManager.cs
@@ -25,4 +25,5 @@ public interface IRunnerConnectionManager
     Task CloseSessionAsync(string sessionId);
     Task<IReadOnlyList<TerminalSession>> GetSessionsAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
     Task<WorkspaceInfo?> GetWorkspaceAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
+    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Core/Services/RunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/RunnerConnectionManager.cs
@@ -148,6 +148,17 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
         return await entry.Client.GetWorkspaceAsync(cancellationToken);
     }
 
+    public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default)
+    {
+        var entry = GetOrCreateEntry(machine);
+        if (entry.Client.ConnectionState != HubConnectionState.Connected)
+        {
+            await entry.Client.ConnectAsync(BuildHubUrl(machine.RunnerUrl), cancellationToken);
+        }
+
+        return await entry.Client.GetMachineCapabilitiesAsync(cancellationToken);
+    }
+
     public async ValueTask DisposeAsync()
     {
         IAgentDeckClient[] clients;

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -512,6 +512,69 @@ main {
     color: var(--color-subtext);
 }
 
+.capability-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.9rem;
+}
+
+.capability-card {
+    background: var(--color-base);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+}
+
+.capability-card__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: flex-start;
+    margin-bottom: 0.75rem;
+}
+
+.capability-card__header h3 {
+    margin: 0 0 0.2rem;
+    font-size: 0.9rem;
+}
+
+.capability-card__header p,
+.capability-card__message {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--color-subtext);
+}
+
+.capability-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 600;
+}
+
+.capability-status--installed {
+    background: rgba(166,227,161,0.15);
+    color: var(--color-green);
+}
+
+.capability-status--missing {
+    background: rgba(249,226,175,0.15);
+    color: var(--color-yellow);
+}
+
+.capability-status--error {
+    background: rgba(243,139,168,0.15);
+    color: var(--color-red);
+}
+
+.machine-capabilities__timestamp {
+    margin-top: 0.85rem;
+    font-size: 0.75rem;
+    color: var(--color-subtext);
+}
+
 .workload-list {
     display: grid;
     gap: 0.9rem;

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddSignalR(opts =>
 
 builder.Services.AddSingleton<IAgentSessionStore, AgentSessionStore>();
 builder.Services.AddSingleton<IWorkspaceService, WorkspaceService>();
+builder.Services.AddSingleton<IMachineCapabilityService, MachineCapabilityService>();
 builder.Services.AddSingleton<IPtyProcessManager, PtyProcessManager>();
 builder.Services.AddHostedService<HubOutputForwarder>();
 
@@ -59,6 +60,9 @@ app.MapDelete("/api/sessions/{id}", async (string id, IAgentSessionStore store, 
 
 app.MapGet("/api/workspace", (IWorkspaceService workspace) =>
     Results.Ok(workspace.GetWorkspaceInfo()));
+
+app.MapGet("/api/capabilities", async (IMachineCapabilityService capabilities, CancellationToken cancellationToken) =>
+    Results.Ok(await capabilities.GetSnapshotAsync(cancellationToken)));
 
 app.MapHub<AgentHub>("/hubs/agent");
 

--- a/AgentDeck.Runner/Services/IMachineCapabilityService.cs
+++ b/AgentDeck.Runner/Services/IMachineCapabilityService.cs
@@ -1,0 +1,9 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <summary>Detects supported CLIs and SDKs available on the runner machine.</summary>
+public interface IMachineCapabilityService
+{
+    Task<MachineCapabilitiesSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Runner/Services/MachineCapabilityService.cs
+++ b/AgentDeck.Runner/Services/MachineCapabilityService.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <inheritdoc />
+public sealed partial class MachineCapabilityService : IMachineCapabilityService
+{
+    private readonly ILogger<MachineCapabilityService> _logger;
+
+    private static readonly CapabilityProbe[] Probes =
+    [
+        new("gh", "GitHub CLI", "cli", [new ProbeCommand("gh", ["--version"])], ParseFirstLineVersion),
+        new("copilot", "GitHub Copilot CLI", "cli", [new ProbeCommand("copilot", ["--version"])], ParseFirstLineVersion),
+        new("node", "Node.js", "sdk", [new ProbeCommand("node", ["--version"])], ParseTrimmedOutput),
+        new("python", "Python", "sdk", [new ProbeCommand("python", ["--version"]), new ProbeCommand("python3", ["--version"])], ParseTrimmedOutput),
+        new("dotnet", ".NET SDK", "sdk", [new ProbeCommand("dotnet", ["--version"])], ParseTrimmedOutput)
+    ];
+
+    public MachineCapabilityService(ILogger<MachineCapabilityService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<MachineCapabilitiesSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var capabilities = new List<MachineCapability>(Probes.Length);
+
+        foreach (var probe in Probes)
+        {
+            capabilities.Add(await DetectAsync(probe, cancellationToken));
+        }
+
+        return new MachineCapabilitiesSnapshot
+        {
+            CapturedAt = DateTimeOffset.UtcNow,
+            Capabilities = capabilities
+        };
+    }
+
+    private async Task<MachineCapability> DetectAsync(CapabilityProbe probe, CancellationToken cancellationToken)
+    {
+        string? lastError = null;
+
+        foreach (var command in probe.Commands)
+        {
+            var result = await RunCommandAsync(command.FileName, command.Arguments, cancellationToken);
+            if (result.StartFailed)
+            {
+                lastError = result.ErrorMessage;
+                continue;
+            }
+
+            if (!result.Succeeded)
+            {
+                return new MachineCapability
+                {
+                    Id = probe.Id,
+                    Name = probe.Name,
+                    Category = probe.Category,
+                    Status = MachineCapabilityStatus.Error,
+                    Message = FirstMeaningfulLine(result.StandardError, result.StandardOutput) ?? "Detection failed."
+                };
+            }
+
+            return new MachineCapability
+            {
+                Id = probe.Id,
+                Name = probe.Name,
+                Category = probe.Category,
+                Status = MachineCapabilityStatus.Installed,
+                Version = probe.VersionParser(result.StandardOutput, result.StandardError),
+                Message = $"Detected via {command.FileName}"
+            };
+        }
+
+        return new MachineCapability
+        {
+            Id = probe.Id,
+            Name = probe.Name,
+            Category = probe.Category,
+            Status = MachineCapabilityStatus.Missing,
+            Message = lastError ?? "Not installed."
+        };
+    }
+
+    private async Task<ProbeResult> RunCommandAsync(string fileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            return new ProbeResult
+            {
+                StartFailed = true,
+                ErrorMessage = ex.Message
+            };
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        var standardOutput = await standardOutputTask;
+        var standardError = await standardErrorTask;
+
+        if (process.ExitCode != 0)
+        {
+            _logger.LogDebug("Capability probe {FileName} exited with {ExitCode}: {Error}", fileName, process.ExitCode, standardError);
+        }
+
+        return new ProbeResult
+        {
+            Succeeded = process.ExitCode == 0,
+            StandardOutput = standardOutput,
+            StandardError = standardError
+        };
+    }
+
+    private static string? ParseFirstLineVersion(string standardOutput, string standardError)
+    {
+        var line = FirstMeaningfulLine(standardOutput, standardError);
+        return line;
+    }
+
+    private static string? ParseTrimmedOutput(string standardOutput, string standardError)
+    {
+        var line = FirstMeaningfulLine(standardOutput, standardError);
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        var match = VersionPattern().Match(line);
+        return match.Success ? match.Value : line;
+    }
+
+    private static string? FirstMeaningfulLine(params string[] values)
+    {
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var line = value.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                return line;
+            }
+        }
+
+        return null;
+    }
+
+    [GeneratedRegex(@"\d+(\.\d+)+")]
+    private static partial Regex VersionPattern();
+
+    private sealed record CapabilityProbe(
+        string Id,
+        string Name,
+        string Category,
+        IReadOnlyList<ProbeCommand> Commands,
+        Func<string, string, string?> VersionParser);
+
+    private sealed record ProbeCommand(string FileName, IReadOnlyList<string> Arguments);
+
+    private sealed class ProbeResult
+    {
+        public bool Succeeded { get; init; }
+        public bool StartFailed { get; init; }
+        public string StandardOutput { get; init; } = string.Empty;
+        public string StandardError { get; init; } = string.Empty;
+        public string? ErrorMessage { get; init; }
+    }
+}

--- a/AgentDeck.Shared/Enums/MachineCapabilityStatus.cs
+++ b/AgentDeck.Shared/Enums/MachineCapabilityStatus.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Detection status for a supported machine capability.</summary>
+public enum MachineCapabilityStatus
+{
+    Installed,
+    Missing,
+    Error
+}

--- a/AgentDeck.Shared/Models/MachineCapabilitiesSnapshot.cs
+++ b/AgentDeck.Shared/Models/MachineCapabilitiesSnapshot.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Snapshot of supported tool detection results for a runner machine.</summary>
+public sealed class MachineCapabilitiesSnapshot
+{
+    public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
+    public IReadOnlyList<MachineCapability> Capabilities { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/MachineCapability.cs
+++ b/AgentDeck.Shared/Models/MachineCapability.cs
@@ -1,0 +1,14 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Describes whether a supported tool is available on a runner machine.</summary>
+public sealed class MachineCapability
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public required string Category { get; init; }
+    public required MachineCapabilityStatus Status { get; init; }
+    public string? Version { get; init; }
+    public string? Message { get; init; }
+}


### PR DESCRIPTION
## Summary
- add runner-side capability detection for supported CLIs and SDKs
- expose capability snapshots through the companion's machine connection services
- show per-machine capability status in Settings for GitHub CLI, Copilot CLI, Node.js, Python, and .NET SDK

Closes #48