### PR TITLE
Recenter settings on machine setup

### DIFF
--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -101,13 +101,17 @@
 {
     <div class="settings-card">
         <div class="settings-card__header">
-            <h2>Machine Capabilities: @SelectedMachine.Name</h2>
+            <h2>Machine Setup: @SelectedMachine.Name</h2>
             <div class="form-actions">
                 <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
                     Refresh Capabilities
                 </button>
             </div>
         </div>
+
+        <p class="settings-card__description">
+            AgentDeck now treats each runner target as a machine to inspect and prepare in place. Detect which supported tools are already installed and install missing ones directly on this machine.
+        </p>
 
         @if (_capabilitiesErrorMessage is not null)
         {
@@ -123,6 +127,21 @@
         }
         else
         {
+            <div class="setup-summary">
+                <div class="setup-summary__item">
+                    <span class="setup-summary__label">Installed</span>
+                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Installed)</strong>
+                </div>
+                <div class="setup-summary__item">
+                    <span class="setup-summary__label">Missing</span>
+                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Missing)</strong>
+                </div>
+                <div class="setup-summary__item">
+                    <span class="setup-summary__label">Errors</span>
+                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Error)</strong>
+                </div>
+            </div>
+
             <div class="capability-grid">
                 @foreach (var capability in _machineCapabilities.Capabilities.OrderBy(capability => capability.Category).ThenBy(capability => capability.Name))
                 {
@@ -193,8 +212,13 @@
         }
     </div>
 
-    <div class="settings-card">
-        <h2>Container Orchestration: @SelectedMachine.Name</h2>
+    <details class="settings-card legacy-settings">
+        <summary class="legacy-settings__summary">
+            <div>
+                <h2>Legacy workload and container setup</h2>
+                <p>These controls are kept temporarily for migration, but the main product path is now machine setup and tool installation.</p>
+            </div>
+        </summary>
 
         <div class="form-field">
             <label for="selected-workload">Selected Workload</label>
@@ -339,7 +363,7 @@
         {
             <p class="error-message">@selectionError</p>
         }
-    </div>
+    </details>
 
     <div class="settings-card">
         <h2>Connection Status: @SelectedMachine.Name</h2>
@@ -348,8 +372,13 @@
     </div>
 }
 
-<div class="settings-card">
-    <h2>Workload Catalog</h2>
+<details class="settings-card legacy-settings">
+    <summary class="legacy-settings__summary">
+        <div>
+            <h2>Legacy workload catalog</h2>
+            <p>Workload definitions are still available during migration, but they are no longer the primary setup model.</p>
+        </div>
+    </summary>
 
     <div class="workload-toolbar">
         <p>Create custom workloads here or clone a built-in template as a starting point.</p>
@@ -409,11 +438,11 @@
             }
         </div>
     }
-</div>
+</details>
 
 @if (_editingWorkload is not null)
 {
-    <div class="settings-card">
+    <div class="settings-card legacy-settings">
         <WorkloadEditor Workload="_editingWorkload"
                         Title="@_editorTitle"
                         EditorKey="@_editorKey"
@@ -947,6 +976,9 @@
         MachineCapabilityStatus.Missing => "missing",
         _ => "error"
     };
+
+    private int GetCapabilityCount(MachineCapabilityStatus status) =>
+        _machineCapabilities?.Capabilities.Count(capability => capability.Status == status) ?? 0;
 
     private bool TryGetSelectedWorkload(RunnerMachineSettings machine, out WorkloadDefinition workload, out string? error)
     {

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -378,6 +378,7 @@ main {
 }
 
 .settings-card h2 { font-size: 0.9rem; font-weight: 600; margin-bottom: 1rem; color: var(--color-text); }
+.settings-card__description { margin: 0 0 1rem; color: var(--color-subtext); font-size: 0.85rem; }
 
 .form-field { margin-bottom: 1rem; }
 .form-field label { display: block; font-size: 0.8rem; color: var(--color-subtext); margin-bottom: 0.3rem; }
@@ -518,6 +519,28 @@ main {
     gap: 0.9rem;
 }
 
+.setup-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.setup-summary__item {
+    min-width: 120px;
+    padding: 0.75rem 0.9rem;
+    border-radius: 8px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+}
+
+.setup-summary__label {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--color-subtext);
+    font-size: 0.76rem;
+}
+
 .capability-card {
     background: var(--color-base);
     border: 1px solid rgba(255,255,255,0.08);
@@ -589,6 +612,34 @@ main {
 
 .capability-install-result h3 {
     margin: 0 0 0.75rem;
+}
+
+.legacy-settings {
+    border-style: dashed;
+    border-color: rgba(255,255,255,0.14);
+}
+
+.legacy-settings__summary {
+    list-style: none;
+    cursor: pointer;
+}
+
+.legacy-settings__summary::-webkit-details-marker {
+    display: none;
+}
+
+.legacy-settings__summary h2 {
+    margin-bottom: 0.35rem;
+}
+
+.legacy-settings__summary p {
+    margin: 0;
+    color: var(--color-subtext);
+    font-size: 0.82rem;
+}
+
+.legacy-settings[open] .legacy-settings__summary {
+    margin-bottom: 1rem;
 }
 
 .workload-list {


### PR DESCRIPTION
## Summary
- promote machine setup and capability status as the primary settings workflow
- add setup summaries and explanatory copy around the machine-based model
- move workload/container controls into clearly labeled legacy panels during migration

Closes #50