### PR TITLE
Document host machine setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ docker run --rm \
   agentdeck-runner
 ```
 
-The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable. If you want to launch tools like GitHub Copilot inside the container, install them in a derived image.
+The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
+
+If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 
 ### Running the Companion App (Windows)
 
@@ -97,66 +99,62 @@ Runner configuration (`AgentDeck.Runner/appsettings.json`):
 
 ---
 
-## Workload-Driven Runner Containers
+## Machine Setup Model
 
-The companion app can now manage **workloads** that describe how a runner container should be built and started for a specific development stack.
+AgentDeck now centers setup around **machines**, not workload-generated Docker images.
 
-Each workload can define:
-- the base runner image
-- SDK versions such as Python, Node, and .NET
-- CLI installers such as apt packages, npm globals, pipx packages, and .NET tools
-- environment variables and bootstrap commands
-- persistent auth mounts and cache mounts
-- runtime secrets that are injected from host environment variables
+A machine can be:
+- your local runner
+- a remote runner on another host
+- a Linux Docker container running `AgentDeck.Runner`
 
-### Built-in Example Workloads
+The companion app treats all of them the same way: connect to the runner, inspect the environment, and install missing tools in place.
 
-Built-in workload templates live under `AgentDeck.Core/Workloads/Examples/` and currently include:
+### Managing Multiple Machines
 
-| Workload | Purpose |
-|---------|---------|
-| `github-cli` | Minimal GitHub CLI environment with persistent auth state |
-| `copilot-gh` | GitHub CLI plus agent-oriented tooling |
-| `python-gh` | Python development with GitHub CLI and pip cache mounts |
-| `node-gh` | Node development with GitHub CLI and npm cache mounts |
-| `dotnet-gh` | .NET development with GitHub CLI and NuGet cache mounts |
-| `python-node-gh` | Polyglot Python + Node workload |
-| `fullstack-gh` | Python + Node + .NET starter workload |
+The companion app supports multiple named runner machines.
 
-### Custom Workloads in the Companion App
+In **Settings** you can:
+- add and name machines
+- set a default machine for new terminals
+- connect and disconnect each machine independently
+- inspect the connection status and hub URL for the selected machine
 
-The **Settings** page lets you:
-- view the built-in workload catalog
-- clone built-in workloads into editable custom workloads
-- create, edit, duplicate, and delete custom workloads
-- choose the active workload used for Docker command generation and execution
+When you create a new terminal, you choose which machine it should run on.
 
-Custom workloads are stored in the companion app data directory, separately from the built-in templates, so updating the app does not overwrite them.
+### Machine Capabilities
 
-### Container Orchestration in the Companion App
+The **Machine Setup** section can detect whether the selected machine has these supported tools available:
 
-For the selected workload, the **Settings** page can now:
-- generate the workload Dockerfile
-- build the base runner image
-- build the workload image
-- start and stop the runner container
-- inspect local Docker, image, and container status
-- show the last Docker command output
+| Tool | Capability ID |
+|------|---------------|
+| GitHub CLI | `gh` |
+| GitHub Copilot CLI | `copilot` |
+| Node.js | `node` |
+| Python | `python` |
+| .NET SDK | `dotnet` |
 
-This orchestration currently assumes a local Docker installation reachable from the companion app host.
+For each capability, AgentDeck shows whether it is installed, missing, or errored, plus version information when available.
 
-### Authentication and Cache Persistence
+### Installing Missing Tools
 
-Auth and cache persistence are handled through **named Docker volumes**, not by baking credentials into images.
+From **Settings -> Machine Setup**, you can trigger install actions for missing tools directly through the runner.
 
-Workloads can define:
-- **auth mounts** for home/config locations such as `/agent-home`
-- **cache mounts** for package-manager caches such as npm, pip, and NuGet
-- **runtime secrets** like `GITHUB_TOKEN`
+Current first-pass install support:
+- **Windows:** `winget`-based installs where supported
+- **Linux:** `apt-get`-based installs where supported
+- **Copilot CLI:** installed through `npm install -g @github/copilot` when Node/npm is already available
 
-At container start:
-- auth and cache mounts are attached as named volumes, so state survives container recreation
-- required secrets are read from the host environment and passed through to the container at runtime
-- secret values are **not** stored in app settings or workload files
+Install output is shown in the companion app so you can see the exact command, standard output, and standard error.
 
-This means flows like `gh auth login` can persist across sessions when the workload mounts the CLI home/config directory, and package caches can be reused between runs.
+### Docker Deployment Guidance
+
+You do **not** need to decide a workload ahead of time to run a runner in Docker.
+
+Recommended flow:
+1. Build and run the base `AgentDeck.Runner` image.
+2. Mount a workspace into the container.
+3. Register that runner in the companion app as a machine.
+4. Use **Machine Setup** to detect and install the tools that machine needs.
+
+This keeps Docker containers, VMs, and local hosts on the same setup path.


### PR DESCRIPTION
## Summary\n- replace the removed workload/container orchestration docs with the machine setup model\n- document how multi-machine setup works in the companion app\n- clarify that Docker is just one way to host a runner and tools are installed inside the machine\n\nCloses #52