### PR TITLE
Use a Debian-based Linux runner image

### DIFF
--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -14,8 +14,19 @@ RUN dotnet publish "AgentDeck.Runner/AgentDeck.Runner.csproj" \
     -o /app/publish \
     /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+FROM debian:12-slim AS final
 WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb \
+    && dpkg -i /tmp/packages-microsoft-prod.deb \
+    && rm /tmp/packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends aspnetcore-runtime-10.0 \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000
 ENV AGENTDECK_WORKSPACE=/workspace
@@ -25,4 +36,5 @@ VOLUME ["/workspace"]
 
 COPY --from=build /app/publish .
 
+USER root
 ENTRYPOINT ["dotnet", "AgentDeck.Runner.dll"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ docker run --rm \
 
 The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
 
+The checked-in runner image now uses a Debian-based final stage instead of the stock minimal ASP.NET runtime image so the container behaves like a normal package-manager-capable Linux machine.
+
 If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 
 ### Running the Companion App (Windows)


### PR DESCRIPTION
## Summary\n- replace the stock ASP.NET runtime final image with a Debian-based final stage\n- install the ASP.NET runtime explicitly in the image so the runner still starts cleanly\n- run the container as root so package-manager-based machine setup actions can work inside the runner container\n- update the Docker deployment docs to match the new image model\n\n## Validation\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-issue58 -p:UseAppHost=false\n- attempted Docker smoke test, but Docker is unavailable in this environment (dockerDesktopLinuxEngine pipe missing)\n\nCloses #58