### PR TITLE
Use a self-contained Linux runner publish

### DIFF
--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -12,7 +12,9 @@ COPY . .
 RUN dotnet publish "AgentDeck.Runner/AgentDeck.Runner.csproj" \
     -c Release \
     -o /app/publish \
-    /p:UseAppHost=false
+    -r linux-x64 \
+    --self-contained true \
+    /p:PublishSingleFile=true
 
 FROM debian:12-slim AS final
 WORKDIR /app
@@ -21,11 +23,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
-    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb \
-    && dpkg -i /tmp/packages-microsoft-prod.deb \
-    && rm /tmp/packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends aspnetcore-runtime-10.0 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000
@@ -37,4 +34,4 @@ VOLUME ["/workspace"]
 COPY --from=build /app/publish .
 
 USER root
-ENTRYPOINT ["dotnet", "AgentDeck.Runner.dll"]
+ENTRYPOINT ["./AgentDeck.Runner"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker run --rm \
 
 The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
 
-The checked-in runner image now uses a Debian-based final stage instead of the stock minimal ASP.NET runtime image so the container behaves like a normal package-manager-capable Linux machine.
+The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image so the container behaves like a normal package-manager-capable Linux machine without needing the ASP.NET runtime preinstalled in the final image.
 
 If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 


### PR DESCRIPTION
## Summary\n- switch the runner Docker build to a self-contained linux-x64 publish\n- keep the Debian-based final image but remove the need to install the ASP.NET runtime in the final stage\n- use the published AgentDeck.Runner executable directly as the container entrypoint\n- document the image as a Debian-based self-contained final stage\n\n## Investigation result\n- self-contained publish succeeded\n- native AOT is not being adopted here because the publish failed with Cross-OS native compilation is not supported in this Windows environment and the runner's SignalR usage emitted RequiresDynamicCode warnings during AOT publish\n\n## Validation\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-selfcontained-final\n- Docker smoke test remains blocked in this environment because the Docker daemon is unavailable\n\nCloses #59