### PR TITLE
Install ICU in the Linux runner image

### DIFF
--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        libicu72 \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker run --rm \
 
 The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
 
-The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image so the container behaves like a normal package-manager-capable Linux machine without needing the ASP.NET runtime preinstalled in the final image.
+The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, and it includes the native ICU dependency that .NET needs at runtime.
 
 If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 


### PR DESCRIPTION
## Summary\n- install the Debian ICU runtime package in the self-contained Linux runner image\n- keep the self-contained publish model unchanged\n- update the Docker documentation to mention the native ICU dependency\n\n## Validation\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-issue62\n\nCloses #62