### PR TITLE
Fix Linux runner container setup permissions

### DIFF
--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -23,7 +23,11 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         libicu72 \
+        sudo \
         wget \
+    && useradd --create-home --shell /bin/sh agentdeck \
+    && echo "agentdeck ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agentdeck \
+    && chmod 0440 /etc/sudoers.d/agentdeck \
     && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000
@@ -32,7 +36,7 @@ ENV AGENTDECK_WORKSPACE=/workspace
 EXPOSE 5000
 VOLUME ["/workspace"]
 
-COPY --from=build /app/publish .
+COPY --from=build --chown=agentdeck:agentdeck /app/publish .
 
-USER root
+USER agentdeck
 ENTRYPOINT ["./AgentDeck.Runner"]

--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -124,7 +124,7 @@ public sealed class MachineSetupService : IMachineSetupService
         return RunLinuxCommandAsync(
             "dotnet",
             ".NET SDK",
-            "wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-10.0",
+            "wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-10.0",
             cancellationToken);
     }
 
@@ -176,7 +176,9 @@ public sealed class MachineSetupService : IMachineSetupService
         var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
         var nonInteractiveCommand = $"export DEBIAN_FRONTEND=noninteractive && {commandText}";
         var finalCommand =
-            $"if command -v sudo >/dev/null 2>&1; then sudo -n sh -lc {QuotePosix(nonInteractiveCommand)}; else sh -lc {QuotePosix(nonInteractiveCommand)}; fi";
+            $"if command -v sudo >/dev/null 2>&1; then sudo -n sh -lc {QuotePosix(nonInteractiveCommand)}; " +
+            $"elif [ \"$(id -u)\" -eq 0 ]; then sh -lc {QuotePosix(nonInteractiveCommand)}; " +
+            "else echo 'Linux setup actions require root or passwordless sudo.' >&2; exit 1; fi";
 
         return RunDirectCommandAsync(
             capabilityId,

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker run --rm \
 
 The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
 
-The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, and it includes the native ICU dependency that .NET needs at runtime.
+The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
 
 If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 


### PR DESCRIPTION
## Summary\n- run the Debian runner image as a non-root gentdeck user with passwordless sudo\n- make Linux setup actions require root or passwordless sudo instead of falling back to unprivileged package-manager commands\n- write the .NET SDK bootstrap package to /tmp instead of the app working directory\n- update the Docker docs to describe the container's privilege model\n\n## Validation\n- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-issue64\n\nCloses #64