### PR TITLE
Handle arbitrary Linux UIDs in setup elevation

### DIFF
--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -176,8 +176,13 @@ public sealed class MachineSetupService : IMachineSetupService
         var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
         var nonInteractiveCommand = $"export DEBIAN_FRONTEND=noninteractive && {commandText}";
         var finalCommand =
-            $"if command -v sudo >/dev/null 2>&1; then sudo -n sh -lc {QuotePosix(nonInteractiveCommand)}; " +
-            $"elif [ \"$(id -u)\" -eq 0 ]; then sh -lc {QuotePosix(nonInteractiveCommand)}; " +
+            $"if [ \"$(id -u)\" -eq 0 ]; then sh -lc {QuotePosix(nonInteractiveCommand)}; " +
+            "elif command -v sudo >/dev/null 2>&1; then " +
+            "if id -un >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then " +
+            $"sudo -n sh -lc {QuotePosix(nonInteractiveCommand)}; " +
+            "elif ! id -un >/dev/null 2>&1; then " +
+            "echo 'Linux setup actions cannot use sudo because the current UID is not present in /etc/passwd.' >&2; exit 1; " +
+            "else echo 'Linux setup actions require passwordless sudo for the current user.' >&2; exit 1; fi; " +
             "else echo 'Linux setup actions require root or passwordless sudo.' >&2; exit 1; fi";
 
         return RunDirectCommandAsync(

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The checked-in runner image now uses a Debian-based self-contained final stage i
 
 If you run the runner inside a container, AgentDeck treats that container as just another machine. Connect the companion app to the runner URL, then use **Settings -> Machine Setup** to inspect which supported tools are installed and install missing ones inside that machine.
 
+If you override the container user, Linux setup actions still need either `root` or a passwd-backed user with passwordless `sudo`. Arbitrary numeric UIDs that are not present in `/etc/passwd` can run the runner, but they cannot perform privileged package installs through the setup flow.
+
 ### Running the Companion App (Windows)
 
 ```bash


### PR DESCRIPTION
## Summary\n- run Linux setup commands directly when already root\n- only attempt passwordless sudo when the current identity is passwd-backed and sudo -n true succeeds\n- return a clear error for arbitrary numeric UIDs that are not present in /etc/passwd\n- document the container-user limitation for privileged setup actions\n\n## Validation\n- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-issue66\n\nCloses #66