### PR TITLE
Use the native Linux installer for Copilot CLI

### DIFF
--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -54,23 +54,32 @@ public sealed class MachineSetupService : IMachineSetupService
 
     private Task<MachineCapabilityInstallResult> InstallCopilotCliAsync(CancellationToken cancellationToken)
     {
-        if (!CommandExists("npm"))
+        if (OperatingSystem.IsWindows())
         {
-            return Task.FromResult(new MachineCapabilityInstallResult
+            if (!CommandExists("npm"))
             {
-                CapabilityId = "copilot",
-                CapabilityName = "GitHub Copilot CLI",
-                Succeeded = false,
-                ExitCode = -1,
-                Message = "npm is required to install GitHub Copilot CLI. Install Node.js first."
-            });
+                return Task.FromResult(new MachineCapabilityInstallResult
+                {
+                    CapabilityId = "copilot",
+                    CapabilityName = "GitHub Copilot CLI",
+                    Succeeded = false,
+                    ExitCode = -1,
+                    Message = "npm is required to install GitHub Copilot CLI. Install Node.js first."
+                });
+            }
+
+            return RunDirectCommandAsync(
+                "copilot",
+                "GitHub Copilot CLI",
+                "npm",
+                ["install", "-g", "@github/copilot"],
+                cancellationToken);
         }
 
-        return RunDirectCommandAsync(
+        return RunLinuxCommandAsync(
             "copilot",
             "GitHub Copilot CLI",
-            "npm",
-            ["install", "-g", "@github/copilot"],
+            "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
             cancellationToken);
     }
 


### PR DESCRIPTION
## Summary\n- keep the existing Windows Copilot install path\n- switch the Linux Copilot install path to the native curl -fsSL https://gh.io/copilot-install | bash flow\n- bootstrap curl with apt on Linux if it is not already installed\n\n## Validation\n- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo\n- dotnet publish AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-runner-issue68\n\nCloses #68