### PR TITLE
Add CLI update actions

### DIFF
--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -198,16 +198,28 @@
                             </div>
                         }
 
-                        @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability))
+                        @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability) || SupportsUpdateAction(capability))
                         {
                             <div class="capability-card__actions">
-                                <button class="btn btn-primary"
-                                        @onclick="() => InstallCapabilityAsync(capability)"
-                                        disabled="@(_capabilitiesBusy || _installingCapabilityId == capability.Id)">
-                                    @(_installingCapabilityId == capability.Id
-                                        ? "Installing..."
-                                        : SupportsVersionSelection(capability) ? "Install Version" : "Install")
-                                </button>
+                                @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability))
+                                {
+                                    <button class="btn btn-primary"
+                                            @onclick="() => InstallCapabilityAsync(capability)"
+                                            disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
+                                        @(IsCapabilityActionRunning(capability, "install")
+                                            ? "Installing..."
+                                            : SupportsVersionSelection(capability) ? "Install Version" : "Install")
+                                    </button>
+                                }
+
+                                @if (SupportsUpdateAction(capability))
+                                {
+                                    <button class="btn btn-accent"
+                                            @onclick="() => UpdateCapabilityAsync(capability)"
+                                            disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
+                                        @(IsCapabilityActionRunning(capability, "update") ? "Updating..." : "Update")
+                                    </button>
+                                }
                             </div>
                         }
                     </article>
@@ -221,7 +233,7 @@
                     <h3>Last Setup Action</h3>
                     <p>
                         <strong>@_lastCapabilityInstallResult.CapabilityName:</strong>
-                        @(_lastCapabilityInstallResult.Succeeded ? "installed" : "failed")
+                        @(GetCapabilityActionResultLabel(_lastCapabilityInstallResult))
                         @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.RequestedVersion))
                         {
                             <span> (@_lastCapabilityInstallResult.RequestedVersion)</span>
@@ -260,7 +272,8 @@
     private readonly HashSet<string> _capabilitiesBusyMachineIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string?> _selectedSdkVersions = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string?> _customSdkVersions = new(StringComparer.OrdinalIgnoreCase);
-    private string? _installingCapabilityId;
+    private string? _activeCapabilityId;
+    private string? _activeCapabilityAction;
     private MachineCapabilityInstallResult? _lastCapabilityInstallResult;
     private string? _selectedMachineId;
 
@@ -471,7 +484,8 @@
         }
 
         var machine = SelectedMachine;
-        _installingCapabilityId = capability.Id;
+        _activeCapabilityId = capability.Id;
+        _activeCapabilityAction = "install";
         _machineCapabilityErrors.Remove(machine.Id);
 
         try
@@ -504,7 +518,8 @@
         }
         finally
         {
-            _installingCapabilityId = null;
+            _activeCapabilityId = null;
+            _activeCapabilityAction = null;
         }
     }
 
@@ -518,6 +533,74 @@
     private static bool SupportsVersionSelection(MachineCapability capability) =>
         capability.Category.Equals("sdk", StringComparison.OrdinalIgnoreCase) &&
         capability.Id is "python" or "node" or "dotnet";
+
+    private static bool SupportsUpdateAction(MachineCapability capability) =>
+        capability.Status == MachineCapabilityStatus.Installed &&
+        capability.Category.Equals("cli", StringComparison.OrdinalIgnoreCase) &&
+        capability.Id is "gh" or "copilot";
+
+    private bool IsCapabilityActionRunning(MachineCapability capability, string action) =>
+        string.Equals(_activeCapabilityId, capability.Id, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(_activeCapabilityAction, action, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsCapabilityBusy(MachineCapability capability) =>
+        string.Equals(_activeCapabilityId, capability.Id, StringComparison.OrdinalIgnoreCase);
+
+    private async Task UpdateCapabilityAsync(MachineCapability capability)
+    {
+        if (SelectedMachine is null)
+        {
+            return;
+        }
+
+        var machine = SelectedMachine;
+        _activeCapabilityId = capability.Id;
+        _activeCapabilityAction = "update";
+        _machineCapabilityErrors.Remove(machine.Id);
+
+        try
+        {
+            var result = await Connections.UpdateMachineCapabilityAsync(machine, capability.Id);
+            _lastCapabilityInstallResult = result;
+
+            if (result is null)
+            {
+                _machineCapabilityErrors[machine.Id] = $"The runner did not return an update result for {capability.Name}.";
+                return;
+            }
+
+            if (result.Succeeded)
+            {
+                ToastService.Show($"Updated {capability.Name}", ToastKind.Success);
+            }
+            else
+            {
+                ToastService.Show($"Failed to update {capability.Name}", ToastKind.Error);
+            }
+
+            await RefreshMachineCapabilitiesAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to update capability {CapabilityId} on machine {MachineId}", capability.Id, machine.Id);
+            _machineCapabilityErrors[machine.Id] = $"Failed to update {capability.Name}: {ex.Message}";
+        }
+        finally
+        {
+            _activeCapabilityId = null;
+            _activeCapabilityAction = null;
+        }
+    }
+
+    private static string GetCapabilityActionResultLabel(MachineCapabilityInstallResult result)
+    {
+        if (!result.Succeeded)
+        {
+            return result.Action.Equals("update", StringComparison.OrdinalIgnoreCase) ? "update failed" : "install failed";
+        }
+
+        return result.Action.Equals("update", StringComparison.OrdinalIgnoreCase) ? "updated" : "installed";
+    }
 
     private static IReadOnlyList<string> GetSdkVersionOptions(string capabilityId) => capabilityId switch
     {

--- a/AgentDeck.Core/Services/AgentDeckClient.cs
+++ b/AgentDeck.Core/Services/AgentDeckClient.cs
@@ -184,6 +184,22 @@ public sealed class AgentDeckClient : IAgentDeckClient, IAsyncDisposable
         }
     }
 
+    public async Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(string capabilityId, CancellationToken ct = default)
+    {
+        if (_http.BaseAddress is null) return null;
+        try
+        {
+            using var response = await _http.PostAsync($"/api/capabilities/{Uri.EscapeDataString(capabilityId)}/update", null, ct);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MachineCapabilityInstallResult>(cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "UpdateMachineCapabilityAsync failed for {CapabilityId}", capabilityId);
+            return null;
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_connection is not null)

--- a/AgentDeck.Core/Services/IAgentDeckClient.cs
+++ b/AgentDeck.Core/Services/IAgentDeckClient.cs
@@ -67,4 +67,7 @@ public interface IAgentDeckClient
 
     /// <summary>Install a supported CLI or SDK on the runner machine via REST.</summary>
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string capabilityId, string? version = null, CancellationToken ct = default);
+
+    /// <summary>Update a supported CLI on the runner machine via REST.</summary>
+    Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(string capabilityId, CancellationToken ct = default);
 }

--- a/AgentDeck.Core/Services/IRunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/IRunnerConnectionManager.cs
@@ -27,4 +27,5 @@ public interface IRunnerConnectionManager
     Task<WorkspaceInfo?> GetWorkspaceAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
     Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(RunnerMachineSettings machine, string capabilityId, string? version = null, CancellationToken cancellationToken = default);
+    Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(RunnerMachineSettings machine, string capabilityId, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Core/Services/RunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/RunnerConnectionManager.cs
@@ -170,6 +170,17 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
         return await entry.Client.InstallMachineCapabilityAsync(capabilityId, version, cancellationToken);
     }
 
+    public async Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(RunnerMachineSettings machine, string capabilityId, CancellationToken cancellationToken = default)
+    {
+        var entry = GetOrCreateEntry(machine);
+        if (entry.Client.ConnectionState != HubConnectionState.Connected)
+        {
+            await entry.Client.ConnectAsync(BuildHubUrl(machine.RunnerUrl), cancellationToken);
+        }
+
+        return await entry.Client.UpdateMachineCapabilityAsync(capabilityId, cancellationToken);
+    }
+
     public async ValueTask DisposeAsync()
     {
         IAgentDeckClient[] clients;

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -550,6 +550,9 @@ main {
 
 .capability-card__actions {
     margin-top: 0.85rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .capability-version-picker {

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -69,6 +69,9 @@ app.MapGet("/api/capabilities", async (IMachineCapabilityService capabilities, C
 app.MapPost("/api/capabilities/{capabilityId}/install", async (string capabilityId, MachineCapabilityInstallRequest? request, IMachineSetupService setup, CancellationToken cancellationToken) =>
     Results.Ok(await setup.InstallCapabilityAsync(capabilityId, request?.Version, cancellationToken)));
 
+app.MapPost("/api/capabilities/{capabilityId}/update", async (string capabilityId, IMachineSetupService setup, CancellationToken cancellationToken) =>
+    Results.Ok(await setup.UpdateCapabilityAsync(capabilityId, cancellationToken)));
+
 app.MapHub<AgentHub>("/hubs/agent");
 
 app.Lifetime.ApplicationStarted.Register(() =>

--- a/AgentDeck.Runner/Services/IMachineSetupService.cs
+++ b/AgentDeck.Runner/Services/IMachineSetupService.cs
@@ -6,4 +6,5 @@ namespace AgentDeck.Runner.Services;
 public interface IMachineSetupService
 {
     Task<MachineCapabilityInstallResult> InstallCapabilityAsync(string capabilityId, string? version = null, CancellationToken cancellationToken = default);
+    Task<MachineCapabilityInstallResult> UpdateCapabilityAsync(string capabilityId, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -25,7 +25,19 @@ public sealed class MachineSetupService : IMachineSetupService
             "node" => await InstallNodeAsync(requestedVersion, cancellationToken),
             "python" => await InstallPythonAsync(requestedVersion, cancellationToken),
             "dotnet" => await InstallDotNetAsync(requestedVersion, cancellationToken),
-            _ => CreateFailureResult(request, capabilityId, requestedVersion, $"Installing '{capabilityId}' is not supported.")
+            _ => CreateFailureResult(request, capabilityId, "install", requestedVersion, $"Installing '{capabilityId}' is not supported.")
+        };
+    }
+
+    public Task<MachineCapabilityInstallResult> UpdateCapabilityAsync(string capabilityId, CancellationToken cancellationToken = default)
+    {
+        var request = capabilityId.Trim().ToLowerInvariant();
+
+        return request switch
+        {
+            "gh" => UpdateGitHubCliAsync(cancellationToken),
+            "copilot" => UpdateCopilotCliAsync(cancellationToken),
+            _ => Task.FromResult(CreateFailureResult(request, capabilityId, "update", null, $"Updating '{capabilityId}' is not supported."))
         };
     }
 
@@ -37,14 +49,16 @@ public sealed class MachineSetupService : IMachineSetupService
                 "gh",
                 "GitHub CLI",
                 "winget install --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
-                cancellationToken);
+                cancellationToken,
+                action: "install");
         }
 
         return RunLinuxCommandAsync(
             "gh",
             "GitHub CLI",
             "apt-get update && apt-get install -y gh",
-            cancellationToken);
+            cancellationToken,
+            action: "install");
     }
 
     private Task<MachineCapabilityInstallResult> InstallCopilotCliAsync(CancellationToken cancellationToken)
@@ -56,6 +70,7 @@ public sealed class MachineSetupService : IMachineSetupService
                 return Task.FromResult(CreateFailureResult(
                     "copilot",
                     "GitHub Copilot CLI",
+                    "install",
                     null,
                     "npm is required to install GitHub Copilot CLI. Install Node.js first."));
             }
@@ -65,14 +80,16 @@ public sealed class MachineSetupService : IMachineSetupService
                 "GitHub Copilot CLI",
                 "npm",
                 ["install", "-g", "@github/copilot"],
-                cancellationToken);
+                cancellationToken,
+                action: "install");
         }
 
         return RunLinuxCommandAsync(
             "copilot",
             "GitHub Copilot CLI",
             "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
-            cancellationToken);
+            cancellationToken,
+            action: "install");
     }
 
     private Task<MachineCapabilityInstallResult> InstallNodeAsync(string? requestedVersion, CancellationToken cancellationToken)
@@ -84,6 +101,7 @@ public sealed class MachineSetupService : IMachineSetupService
                 "Node.js",
                 BuildWindowsNodeInstallCommand(requestedVersion),
                 cancellationToken,
+                action: "install",
                 requestedVersion);
         }
 
@@ -92,6 +110,7 @@ public sealed class MachineSetupService : IMachineSetupService
             "Node.js",
             BuildLinuxNodeInstallCommand(requestedVersion),
             cancellationToken,
+            action: "install",
             requestedVersion);
     }
 
@@ -105,6 +124,7 @@ public sealed class MachineSetupService : IMachineSetupService
                 "Python",
                 $"winget install --id Python.Python.{version} -e --accept-package-agreements --accept-source-agreements",
                 cancellationToken,
+                action: "install",
                 version);
         }
 
@@ -117,6 +137,7 @@ public sealed class MachineSetupService : IMachineSetupService
             "Python",
             commandText,
             cancellationToken,
+            action: "install",
             requestedVersion);
     }
 
@@ -137,6 +158,7 @@ public sealed class MachineSetupService : IMachineSetupService
                 ".NET SDK",
                 commandText,
                 cancellationToken,
+                action: "install",
                 version);
         }
 
@@ -145,7 +167,59 @@ public sealed class MachineSetupService : IMachineSetupService
             ".NET SDK",
             $"wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-{version}",
             cancellationToken,
+            action: "install",
             version);
+    }
+
+    private Task<MachineCapabilityInstallResult> UpdateGitHubCliAsync(CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return RunWindowsCommandAsync(
+                "gh",
+                "GitHub CLI",
+                "winget upgrade --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
+                cancellationToken,
+                action: "update");
+        }
+
+        return RunLinuxCommandAsync(
+            "gh",
+            "GitHub CLI",
+            "apt-get update && apt-get install -y --only-upgrade gh",
+            cancellationToken,
+            action: "update");
+    }
+
+    private Task<MachineCapabilityInstallResult> UpdateCopilotCliAsync(CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            if (!CommandExists("npm"))
+            {
+                return Task.FromResult(CreateFailureResult(
+                    "copilot",
+                    "GitHub Copilot CLI",
+                    "update",
+                    null,
+                    "npm is required to update GitHub Copilot CLI. Install Node.js first."));
+            }
+
+            return RunDirectCommandAsync(
+                "copilot",
+                "GitHub Copilot CLI",
+                "npm",
+                ["update", "-g", "@github/copilot"],
+                cancellationToken,
+                action: "update");
+        }
+
+        return RunLinuxCommandAsync(
+            "copilot",
+            "GitHub Copilot CLI",
+            "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
+            cancellationToken,
+            action: "update");
     }
 
     private Task<MachineCapabilityInstallResult> RunWindowsCommandAsync(
@@ -153,6 +227,7 @@ public sealed class MachineSetupService : IMachineSetupService
         string capabilityName,
         string commandText,
         CancellationToken cancellationToken,
+        string action,
         string? requestedVersion = null)
     {
         if (!CommandExists("winget"))
@@ -160,6 +235,7 @@ public sealed class MachineSetupService : IMachineSetupService
             return Task.FromResult(CreateFailureResult(
                 capabilityId,
                 capabilityName,
+                action,
                 requestedVersion,
                 "winget is required for this installation flow but is not available on the machine."));
         }
@@ -170,6 +246,7 @@ public sealed class MachineSetupService : IMachineSetupService
             "powershell.exe",
             ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", commandText],
             cancellationToken,
+            action,
             commandText,
             requestedVersion);
     }
@@ -179,6 +256,7 @@ public sealed class MachineSetupService : IMachineSetupService
         string capabilityName,
         string commandText,
         CancellationToken cancellationToken,
+        string action,
         string? requestedVersion = null)
     {
         if (!CommandExists("apt-get"))
@@ -186,6 +264,7 @@ public sealed class MachineSetupService : IMachineSetupService
             return Task.FromResult(CreateFailureResult(
                 capabilityId,
                 capabilityName,
+                action,
                 requestedVersion,
                 "apt-get is required for this installation flow but is not available on the machine."));
         }
@@ -208,6 +287,7 @@ public sealed class MachineSetupService : IMachineSetupService
             shellPath,
             ["-lc", finalCommand],
             cancellationToken,
+            action,
             finalCommand,
             requestedVersion);
     }
@@ -218,6 +298,7 @@ public sealed class MachineSetupService : IMachineSetupService
         string fileName,
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken,
+        string action,
         string? commandTextOverride = null,
         string? requestedVersion = null)
     {
@@ -247,6 +328,7 @@ public sealed class MachineSetupService : IMachineSetupService
             {
                 CapabilityId = capabilityId,
                 CapabilityName = capabilityName,
+                Action = action,
                 RequestedVersion = requestedVersion,
                 Succeeded = false,
                 ExitCode = -1,
@@ -276,6 +358,7 @@ public sealed class MachineSetupService : IMachineSetupService
         {
             CapabilityId = capabilityId,
             CapabilityName = capabilityName,
+            Action = action,
             RequestedVersion = requestedVersion,
             Succeeded = process.ExitCode == 0,
             ExitCode = process.ExitCode,
@@ -283,7 +366,7 @@ public sealed class MachineSetupService : IMachineSetupService
             StandardOutput = standardOutput,
             StandardError = standardError,
             Message = process.ExitCode == 0
-                ? $"Installed {capabilityName}{(requestedVersion is null ? string.Empty : $" {requestedVersion}")}."
+                ? $"{(action.Equals("update", StringComparison.OrdinalIgnoreCase) ? "Updated" : "Installed")} {capabilityName}{(requestedVersion is null ? string.Empty : $" {requestedVersion}")}."
                 : FirstMeaningfulLine(standardError, standardOutput)
         };
     }
@@ -325,6 +408,7 @@ public sealed class MachineSetupService : IMachineSetupService
     private static MachineCapabilityInstallResult CreateFailureResult(
         string capabilityId,
         string capabilityName,
+        string action,
         string? requestedVersion,
         string message)
     {
@@ -332,6 +416,7 @@ public sealed class MachineSetupService : IMachineSetupService
         {
             CapabilityId = capabilityId,
             CapabilityName = capabilityName,
+            Action = action,
             RequestedVersion = requestedVersion,
             Succeeded = false,
             ExitCode = -1,

--- a/AgentDeck.Shared/Models/MachineCapabilityInstallResult.cs
+++ b/AgentDeck.Shared/Models/MachineCapabilityInstallResult.cs
@@ -5,6 +5,7 @@ public sealed class MachineCapabilityInstallResult
 {
     public required string CapabilityId { get; init; }
     public required string CapabilityName { get; init; }
+    public string Action { get; init; } = "install";
     public string? RequestedVersion { get; init; }
     public bool Succeeded { get; init; }
     public int ExitCode { get; init; }


### PR DESCRIPTION
## Summary
- add explicit update actions for GitHub CLI and Copilot CLI in machine setup
- wire update requests through the runner API and companion connection services
- show update-specific buttons and result messaging in Settings

## Issue
Closes #72

## Validation
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-app-issue72