### PR TITLE
Add terminal crash diagnostics

### DIFF
--- a/AgentDeck.Runner/Hubs/AgentHub.cs
+++ b/AgentDeck.Runner/Hubs/AgentHub.cs
@@ -59,7 +59,8 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
         var workingDir = ResolveWorkingDirectory(request.WorkingDirectory);
         var command = ResolveCommand(request.Command);
         var arguments = request.Arguments;
-        var (launchCommand, launchArguments) = ResolveLaunch(command, arguments, workingDir, !string.IsNullOrWhiteSpace(request.Command));
+        var commandWasSpecified = !string.IsNullOrWhiteSpace(request.Command);
+        var (launchCommand, launchArguments) = ResolveLaunch(command, arguments, workingDir, commandWasSpecified);
 
         var session = new TerminalSession
         {
@@ -75,11 +76,32 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
 
         try
         {
+            _logger.LogInformation(
+                "Creating session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}, commandWasSpecified={CommandWasSpecified}",
+                sessionId,
+                request.Name,
+                request.Command ?? "<default>",
+                command,
+                FormatArguments(arguments),
+                workingDir,
+                launchCommand,
+                FormatArguments(launchArguments),
+                commandWasSpecified);
             await _ptyManager.StartAsync(sessionId, launchCommand, launchArguments, workingDir, request.Cols, request.Rows);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to start PTY for session {SessionId}", sessionId);
+            _logger.LogError(
+                ex,
+                "Failed to start PTY for session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}",
+                sessionId,
+                request.Name,
+                request.Command ?? "<default>",
+                command,
+                FormatArguments(arguments),
+                workingDir,
+                launchCommand,
+                FormatArguments(launchArguments));
             session.Status = TerminalStatus.Error;
             _sessionStore.Update(session);
             await Clients.All.SessionCreatedAsync(session);
@@ -186,4 +208,7 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
     {
         return $"'{value.Replace("'", "'\"'\"'")}'";
     }
+
+    private static string FormatArguments(IReadOnlyList<string> arguments) =>
+        arguments.Count == 0 ? "<none>" : string.Join(" ", arguments);
 }

--- a/AgentDeck.Runner/Services/HubOutputForwarder.cs
+++ b/AgentDeck.Runner/Services/HubOutputForwarder.cs
@@ -3,16 +3,19 @@ using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Hubs;
 using AgentDeck.Shared.Models;
 using Microsoft.AspNetCore.SignalR;
+using System.Collections.Concurrent;
 
 namespace AgentDeck.Runner.Services;
 
 /// <summary>Wires PTY process events (output, exit) to the SignalR hub.</summary>
 public sealed class HubOutputForwarder : IHostedService
 {
+    private const int OutputTailLimit = 4096;
     private readonly IPtyProcessManager _ptyManager;
     private readonly IAgentSessionStore _sessionStore;
     private readonly IHubContext<AgentHub, IAgentHubClient> _hubContext;
     private readonly ILogger<HubOutputForwarder> _logger;
+    private readonly ConcurrentDictionary<string, string> _recentOutputBySession = new();
 
     public HubOutputForwarder(
         IPtyProcessManager ptyManager,
@@ -43,15 +46,46 @@ public sealed class HubOutputForwarder : IHostedService
 
     private void OnOutputReceived(object? sender, (string SessionId, string Data) e)
     {
+        _recentOutputBySession.AddOrUpdate(
+            e.SessionId,
+            _ => TruncateTail(e.Data),
+            (_, existing) => TruncateTail(existing + e.Data));
+
         var output = new TerminalOutput { SessionId = e.SessionId, Data = e.Data };
         _ = _hubContext.Clients.Group(e.SessionId).ReceiveOutputAsync(output);
     }
 
     private void OnProcessExited(object? sender, (string SessionId, int ExitCode) e)
     {
-        _logger.LogInformation("Session {SessionId} process exited (code {ExitCode})", e.SessionId, e.ExitCode);
-
         var session = _sessionStore.Get(e.SessionId);
+        var recentOutput = _recentOutputBySession.TryRemove(e.SessionId, out var outputTail)
+            ? outputTail
+            : string.Empty;
+
+        if (e.ExitCode == 0)
+        {
+            _logger.LogInformation(
+                "Session {SessionId} process exited cleanly (code {ExitCode}): name={Name}, command={Command}, arguments={Arguments}, workingDirectory={WorkingDirectory}",
+                e.SessionId,
+                e.ExitCode,
+                session?.Name ?? "<unknown>",
+                session?.Command ?? "<unknown>",
+                FormatArguments(session?.Arguments),
+                session?.WorkingDirectory ?? "<unknown>");
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Session {SessionId} process exited with code {ExitCode}: name={Name}, command={Command}, arguments={Arguments}, workingDirectory={WorkingDirectory}, recentOutput={RecentOutput}",
+                e.SessionId,
+                e.ExitCode,
+                session?.Name ?? "<unknown>",
+                session?.Command ?? "<unknown>",
+                FormatArguments(session?.Arguments),
+                session?.WorkingDirectory ?? "<unknown>",
+                string.IsNullOrWhiteSpace(recentOutput) ? "<none>" : recentOutput);
+        }
+
         if (session is not null)
         {
             session.Status = e.ExitCode == 0 ? TerminalStatus.Stopped : TerminalStatus.Error;
@@ -60,4 +94,10 @@ public sealed class HubOutputForwarder : IHostedService
             _ = _hubContext.Clients.All.SessionUpdatedAsync(session);
         }
     }
+
+    private static string FormatArguments(IReadOnlyList<string>? arguments) =>
+        arguments is null || arguments.Count == 0 ? "<none>" : string.Join(" ", arguments);
+
+    private static string TruncateTail(string value) =>
+        value.Length <= OutputTailLimit ? value : value[^OutputTailLimit..];
 }

--- a/AgentDeck.Runner/Services/PtyProcessManager.cs
+++ b/AgentDeck.Runner/Services/PtyProcessManager.cs
@@ -36,12 +36,45 @@ public sealed class PtyProcessManager : IPtyProcessManager
             CommandLine = commandLine,
         };
 
-        var connection = await PtyProvider.SpawnAsync(options, cancellationToken);
+        _logger.LogInformation(
+            "Starting PTY process for session {SessionId}: app={App}, cwd={WorkingDirectory}, cols={Cols}, rows={Rows}, commandLine={CommandLine}",
+            sessionId,
+            command,
+            workingDirectory,
+            cols,
+            rows,
+            string.Join(" ", commandLine));
+
+        IPtyConnection connection;
+        try
+        {
+            connection = await PtyProvider.SpawnAsync(options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to spawn PTY process for session {SessionId}: app={App}, cwd={WorkingDirectory}, cols={Cols}, rows={Rows}, commandLine={CommandLine}",
+                sessionId,
+                command,
+                workingDirectory,
+                cols,
+                rows,
+                string.Join(" ", commandLine));
+            throw;
+        }
+
         var cts = new CancellationTokenSource();
 
         connection.ProcessExited += (_, e) =>
         {
-            _logger.LogDebug("PTY process exited for session {SessionId} with code {ExitCode}", sessionId, e.ExitCode);
+            _logger.LogInformation(
+                "PTY process exited for session {SessionId} with code {ExitCode}: app={App}, cwd={WorkingDirectory}, commandLine={CommandLine}",
+                sessionId,
+                e.ExitCode,
+                command,
+                workingDirectory,
+                string.Join(" ", commandLine));
             ProcessExited?.Invoke(this, (sessionId, e.ExitCode));
             cts.Cancel();
         };


### PR DESCRIPTION
## Summary
- log resolved session launch details before starting PTY processes
- log PTY spawn failures with full command context
- log non-zero terminal exits with session metadata and recent output tail

## Issue
Closes #77

## Validation
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-app-issue77