### PR TITLE
Fix PTY command line argv handling

### DIFF
--- a/AgentDeck.Runner/Services/PtyProcessManager.cs
+++ b/AgentDeck.Runner/Services/PtyProcessManager.cs
@@ -24,8 +24,8 @@ public sealed class PtyProcessManager : IPtyProcessManager
     public async Task StartAsync(string sessionId, string command, IReadOnlyList<string> arguments, string workingDirectory, int cols, int rows, CancellationToken cancellationToken = default)
     {
         var commandLine = arguments.Count > 0
-            ? [command, .. arguments]
-            : (string[])[command];
+            ? arguments.ToArray()
+            : Array.Empty<string>();
 
         var options = new PtyOptions
         {
@@ -46,7 +46,7 @@ public sealed class PtyProcessManager : IPtyProcessManager
             workingDirectory,
             cols,
             rows,
-            string.Join(" ", commandLine));
+            commandLine.Length == 0 ? "<none>" : string.Join(" ", commandLine));
 
         IPtyConnection connection;
         try
@@ -63,7 +63,7 @@ public sealed class PtyProcessManager : IPtyProcessManager
                 workingDirectory,
                 cols,
                 rows,
-                string.Join(" ", commandLine));
+                commandLine.Length == 0 ? "<none>" : string.Join(" ", commandLine));
             throw;
         }
 
@@ -77,7 +77,7 @@ public sealed class PtyProcessManager : IPtyProcessManager
                 e.ExitCode,
                 command,
                 workingDirectory,
-                string.Join(" ", commandLine));
+                commandLine.Length == 0 ? "<none>" : string.Join(" ", commandLine));
             ProcessExited?.Invoke(this, (sessionId, e.ExitCode));
             cts.Cancel();
         };
@@ -178,7 +178,7 @@ public sealed class PtyProcessManager : IPtyProcessManager
             workingDirectoryMetadata,
             ptmxMetadata,
             ptsMetadata,
-            string.Join(" ", commandLine));
+            commandLine.Count == 0 ? "<none>" : string.Join(" ", commandLine));
     }
 
     private static string? ResolveCommandPath(string command)


### PR DESCRIPTION
## Summary
- stop duplicating the executable path in PTY spawn argv
- pass only actual arguments through PtyOptions.CommandLine
- keep PTY diagnostics aligned with the corrected argument shape

## Issue
Closes #81

## Validation
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-app-issue81