### PR TITLE
Create mobile terminals page

### DIFF
--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -1,9 +1,86 @@
 @page "/terminals"
+@inject ISessionStateService SessionState
+@inject IActiveSessionService ActiveSession
+@inject IRunnerConnectionManager Connections
+@inject NavigationManager Nav
 
-<div class="mobile-page-placeholder">
-    <div class="empty-state">
-        <div class="empty-icon">▣</div>
-        <h2>Terminals</h2>
-        <p>The dedicated mobile terminals experience is being wired in next.</p>
+<div class="mobile-terminals-page">
+    <div class="mobile-terminals-page__header">
+        <div>
+            <h1>Terminals</h1>
+            <p>@GetHeaderSubtitle()</p>
+        </div>
+        <button class="btn btn-primary" @onclick="OpenNewTerminal">New</button>
     </div>
+
+    @if (SessionState.Sessions.Count == 0)
+    {
+        <div class="mobile-page-placeholder">
+            <div class="empty-state">
+                <div class="empty-icon">▣</div>
+                <h2>No active terminals</h2>
+                <p>
+                    @if (Connections.ConnectedMachineCount == 0)
+                    {
+                        <span>Connect to a runner in <a href="/settings">Settings</a> to create a terminal.</span>
+                    }
+                    else
+                    {
+                        <span>Tap <strong>New</strong> to create your first terminal.</span>
+                    }
+                </p>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="mobile-session-list">
+            @foreach (var session in SessionState.Sessions)
+            {
+                <button class="mobile-session-card @(IsActive(session.Id) ? "mobile-session-card--active" : "")"
+                        @onclick="() => SelectSession(session.Id)">
+                    <div class="mobile-session-card__header">
+                        <div class="mobile-session-card__title">
+                            <span>@session.Name</span>
+                            @if (!string.IsNullOrWhiteSpace(session.MachineName))
+                            {
+                                <span class="mobile-session-card__machine">@session.MachineName</span>
+                            }
+                        </div>
+                        <StatusBadge Status="session.Status" />
+                    </div>
+                    <div class="mobile-session-card__meta">
+                        <span>ID <code>@session.Id[..Math.Min(session.Id.Length, 8)]</code></span>
+                        @if (session.ExitCode is not null)
+                        {
+                            <span>Exit @session.ExitCode</span>
+                        }
+                    </div>
+                </button>
+            }
+        </div>
+    }
 </div>
+
+@code {
+    private void OpenNewTerminal() => ActiveSession.OpenDialog();
+
+    private void SelectSession(string sessionId)
+    {
+        ActiveSession.SetActiveSession(sessionId);
+        Nav.NavigateTo("/");
+    }
+
+    private bool IsActive(string sessionId) => string.Equals(ActiveSession.ActiveSessionId, sessionId, StringComparison.Ordinal);
+
+    private string GetHeaderSubtitle()
+    {
+        var count = SessionState.Sessions.Count;
+        if (count == 0)
+        {
+            return "Create and switch between active sessions.";
+        }
+
+        return count == 1 ? "1 active session" : $"{count} active sessions";
+    }
+}

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -370,6 +370,92 @@ main {
     display: flex;
 }
 
+.mobile-terminals-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+    min-height: 100%;
+}
+
+.mobile-terminals-page__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.mobile-terminals-page__header h1 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.mobile-terminals-page__header p {
+    margin: 0.25rem 0 0;
+    color: var(--color-subtext);
+    font-size: 0.82rem;
+}
+
+.mobile-session-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.mobile-session-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    width: 100%;
+    padding: 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--color-surface);
+    color: var(--color-text);
+    text-align: left;
+}
+
+.mobile-session-card--active {
+    border-color: var(--color-accent);
+    background: rgba(137,180,250,0.12);
+}
+
+.mobile-session-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.mobile-session-card__title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+    font-weight: 600;
+}
+
+.mobile-session-card__machine {
+    color: var(--color-subtext);
+    font-size: 0.78rem;
+    font-weight: 400;
+    word-break: break-word;
+}
+
+.mobile-session-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    color: var(--color-subtext);
+    font-size: 0.76rem;
+}
+
+.mobile-session-card__meta code {
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    background: rgba(0,0,0,0.2);
+}
+
 @media (max-width: 900px) {
     .app-shell {
         grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- replace the placeholder terminals route with a mobile-friendly sessions page
- let phone users browse active sessions and activate one from the list
- allow creating a new terminal directly from the terminals page

## Issue
Closes #85

## Validation
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-app-issue85