### PR TITLE
Respect mobile safe areas and phone layouts

### DIFF
--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -13,6 +13,10 @@
     --color-green: #a6e3a1;
     --color-red: #f38ba8;
     --color-yellow: #f9e2af;
+    --safe-area-top: env(safe-area-inset-top, 0px);
+    --safe-area-right: env(safe-area-inset-right, 0px);
+    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-area-left: env(safe-area-inset-left, 0px);
 }
 
 html, body {
@@ -43,7 +47,8 @@ main {
 .app-shell {
     display: grid;
     grid-template-columns: 220px 1fr;
-    height: 100vh;
+    height: 100dvh;
+    min-height: 100dvh;
     overflow: hidden;
 }
 
@@ -280,7 +285,7 @@ main {
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: 0.9rem 1rem;
+    padding: calc(0.9rem + var(--safe-area-top)) calc(1rem + var(--safe-area-right)) 0.9rem calc(1rem + var(--safe-area-left));
     background: var(--color-surface);
     border-bottom: 1px solid rgba(255,255,255,0.06);
 }
@@ -294,7 +299,7 @@ main {
     align-items: center;
     justify-content: space-around;
     gap: 0.5rem;
-    padding: 0.65rem 1rem 0.8rem;
+    padding: 0.65rem calc(1rem + var(--safe-area-right)) calc(0.8rem + var(--safe-area-bottom)) calc(1rem + var(--safe-area-left));
     background: rgba(24, 24, 37, 0.96);
     border-top: 1px solid rgba(255,255,255,0.08);
 }
@@ -471,7 +476,97 @@ main {
     }
 
     .main-content {
+        padding-inline: calc(0.75rem + var(--safe-area-left)) calc(0.75rem + var(--safe-area-right));
         padding-bottom: 0;
+    }
+
+    .page-header,
+    .command-bar {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .page-header,
+    .settings-card__header,
+    .form-actions,
+    .mobile-terminals-page__header,
+    .capability-card__header,
+    .modal__footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .settings-card {
+        margin: 0.75rem 0;
+        padding: 1rem;
+    }
+
+    .machine-layout,
+    .capability-version-picker__inputs {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .command-bar {
+        flex-wrap: wrap;
+        align-items: stretch;
+    }
+
+    .command-bar__input {
+        min-width: 0;
+        width: 100%;
+    }
+
+    .mobile-terminals-page {
+        padding: 1rem 0;
+    }
+
+    .empty-state {
+        padding: 2rem 1rem;
+    }
+
+    .modal,
+    .app-error-modal,
+    .shortcuts-card {
+        width: min(100%, 42rem);
+    }
+
+    .shortcuts-card {
+        min-width: 0;
+    }
+}
+
+@media (max-width: 900px) and (orientation: landscape) {
+    .mobile-topbar {
+        padding-top: calc(0.6rem + var(--safe-area-top));
+        padding-bottom: 0.6rem;
+    }
+
+    .mobile-session-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .command-bar__pill {
+        flex: 0 0 auto;
+    }
+}
+
+@media (max-width: 640px) {
+    .mobile-nav__item {
+        width: 2.75rem;
+        height: 2.75rem;
+    }
+
+    .mobile-session-card,
+    .settings-card,
+    .modal,
+    .app-error-modal,
+    .shortcuts-card {
+        border-radius: 10px;
+    }
+
+    .shortcuts-table td:first-child {
+        padding-right: 0.75rem;
     }
 }
 
@@ -1210,6 +1305,7 @@ main {
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: calc(1rem + var(--safe-area-top)) calc(1rem + var(--safe-area-right)) calc(1rem + var(--safe-area-bottom)) calc(1rem + var(--safe-area-left));
     z-index: 100;
 }
 
@@ -1244,7 +1340,7 @@ main {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.5rem;
+    padding: calc(1.5rem + var(--safe-area-top)) calc(1.5rem + var(--safe-area-right)) calc(1.5rem + var(--safe-area-bottom)) calc(1.5rem + var(--safe-area-left));
     background: rgba(0, 0, 0, 0.7);
 }
 
@@ -1503,6 +1599,7 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: calc(1rem + var(--safe-area-top)) calc(1rem + var(--safe-area-right)) calc(1rem + var(--safe-area-bottom)) calc(1rem + var(--safe-area-left));
     z-index: 1500;
 }
 

--- a/AgentDeck/Platforms/Android/MainActivity.cs
+++ b/AgentDeck/Platforms/Android/MainActivity.cs
@@ -1,9 +1,21 @@
 using Android.App;
 using Android.Content.PM;
+using Android.OS;
+using Android.Views;
+using AndroidX.Core.View;
 
 namespace AgentDeck.Platforms.Android;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    WindowSoftInputMode = SoftInput.AdjustResize,
+    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        WindowCompat.SetDecorFitsSystemWindows(Window!, true);
+    }
 }


### PR DESCRIPTION
## Summary
- configure the Android host activity to fit system windows and resize for the soft keyboard
- add safe-area-aware spacing for the mobile shell, overlays, and dialogs
- tighten phone-specific responsive layouts for settings, command bars, and landscape terminal browsing

## Issue
Closes #86

## Validation
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-android -c Release -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-android-issue86
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-windows-issue86