### PR TITLE
Improve mobile settings page layout

### DIFF
--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -5,263 +5,289 @@
 @inject ILogger<Settings> Logger
 @implements IDisposable
 
-<div class="page-header">
-    <h1>Settings</h1>
-</div>
-
-<div class="settings-card">
-    <div class="settings-card__header">
-        <h2>Runner Machines</h2>
-        <div class="form-actions">
-            <button class="btn btn-accent" @onclick="AddMachine">Add Machine</button>
-            <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
-                @(_saving ? "Saving..." : "Save")
-            </button>
+<div class="settings-page">
+    <div class="page-header settings-page__header">
+        <div>
+            <h1>Settings</h1>
+            <p>Manage runner machines, connectivity, and machine setup from one place.</p>
         </div>
     </div>
 
-    @if (_errorMessage is not null)
-    {
-        <p class="error-message">@_errorMessage</p>
-    }
-
-    <div class="machine-layout">
-        <div class="machine-list">
-            @foreach (var machine in _settings.Machines)
-            {
-                <button class="machine-card @(IsSelectedMachine(machine) ? "machine-card--selected" : "")"
-                        @onclick="() => SelectMachine(machine.Id)">
-                    <span class="machine-card__title">@machine.Name</span>
-                    <span class="machine-card__url">@machine.RunnerUrl</span>
-                    <span class="machine-card__meta">
-                        @if (string.Equals(_settings.PreferredMachineId, machine.Id, StringComparison.OrdinalIgnoreCase))
-                        {
-                            <span class="machine-badge">Default terminal</span>
-                        }
-                        <span class="machine-state machine-state--@GetStatusClass(machine)">
-                            @GetStatusLabel(machine)
-                        </span>
-                    </span>
-                </button>
-            }
-        </div>
-
-        @if (SelectedMachine is not null)
-        {
-            <div class="machine-editor">
-                <div class="form-field">
-                    <label for="machine-name">Machine Name</label>
-                    <input id="machine-name" type="text" class="input" @bind="SelectedMachine.Name" />
-                </div>
-
-                <div class="form-field">
-                    <label for="runner-url">Runner URL</label>
-                    <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
-                           placeholder="http://localhost:5000" />
-                </div>
-
-                <div class="form-field">
-                    <label class="checkbox-label">
-                        <input type="checkbox" @bind="SelectedMachine.AutoConnect" />
-                        Auto-connect on startup
-                    </label>
-                </div>
-
-                <div class="form-actions">
-                    <button class="btn btn-accent" @onclick="() => SetPreferredMachine(SelectedMachine.Id)">
-                        Make Default For New Terminals
-                    </button>
-
-                    @if (Connections.GetConnectionState(SelectedMachine.Id) == HubConnectionState.Connected)
-                    {
-                        <button class="btn btn-danger" @onclick="() => DisconnectAsync(SelectedMachine.Id)">Disconnect</button>
-                    }
-                    else
-                    {
-                        <button class="btn btn-primary" @onclick="() => ConnectAsync(SelectedMachine)">
-                            Connect
-                        </button>
-                    }
-
-                    <button class="btn btn-danger"
-                            @onclick="() => DeleteMachineAsync(SelectedMachine.Id)"
-                            disabled="@(_settings.Machines.Count == 1)">
-                        Delete Machine
-                    </button>
-                </div>
+    <div class="settings-card settings-page__card">
+        <div class="settings-card__header settings-page__section-header">
+            <div>
+                <h2>Runner Machines</h2>
+                <p class="settings-card__description">Choose a machine, update its connection details, and control how new terminals are created.</p>
             </div>
-        }
-    </div>
-</div>
-
-@if (SelectedMachine is not null)
-{
-    <div class="settings-card">
-        <h2>Connection Status: @SelectedMachine.Name</h2>
-        <p>State: <strong class="status-text-@GetStatusClass(SelectedMachine)">@GetStatusLabel(SelectedMachine)</strong></p>
-        <p>Hub URL: <code>@GetHubUrl(SelectedMachine)</code></p>
-    </div>
-
-    <div class="settings-card">
-        <div class="settings-card__header">
-            <h2>Machine Setup: @SelectedMachine.Name</h2>
-            <div class="form-actions">
-                <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
-                    Refresh Capabilities
+            <div class="form-actions form-actions--toolbar">
+                <button class="btn btn-accent" @onclick="AddMachine">Add Machine</button>
+                <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
+                    @(_saving ? "Saving..." : "Save")
                 </button>
             </div>
         </div>
 
-        <p class="settings-card__description">
-            AgentDeck now treats each runner target as a machine to inspect and prepare in place. Detect which supported tools are already installed and install missing ones directly on this machine.
-        </p>
+        @if (_errorMessage is not null)
+        {
+            <p class="error-message">@_errorMessage</p>
+        }
 
-        @if (_capabilitiesErrorMessage is not null)
-        {
-            <p class="error-message">@_capabilitiesErrorMessage</p>
-        }
-        else if (_capabilitiesBusy)
-        {
-            <p>Detecting supported tools on this machine...</p>
-        }
-        else if (_machineCapabilities is null)
-        {
-            <p>Refresh capabilities to inspect which supported CLIs and SDKs are installed on this machine.</p>
-        }
-        else
-        {
-            <div class="setup-summary">
-                <div class="setup-summary__item">
-                    <span class="setup-summary__label">Installed</span>
-                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Installed)</strong>
-                </div>
-                <div class="setup-summary__item">
-                    <span class="setup-summary__label">Missing</span>
-                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Missing)</strong>
-                </div>
-                <div class="setup-summary__item">
-                    <span class="setup-summary__label">Errors</span>
-                    <strong>@GetCapabilityCount(MachineCapabilityStatus.Error)</strong>
-                </div>
-            </div>
-
-            <div class="capability-grid">
-                @foreach (var capability in _machineCapabilities.Capabilities.OrderBy(capability => capability.Category).ThenBy(capability => capability.Name))
+        <div class="machine-layout">
+            <div class="machine-list machine-list--settings">
+                @foreach (var machine in _settings.Machines)
                 {
-                    <article class="capability-card">
-                        <div class="capability-card__header">
-                            <div>
-                                <h3>@capability.Name</h3>
-                                <p>@capability.Category.ToUpperInvariant()</p>
-                            </div>
-                            <span class="capability-status capability-status--@GetCapabilityStatusClass(capability)">
-                                @capability.Status
+                    <button class="machine-card @(IsSelectedMachine(machine) ? "machine-card--selected" : "")"
+                            @onclick="() => SelectMachine(machine.Id)">
+                        <span class="machine-card__title">@machine.Name</span>
+                        <span class="machine-card__url">@machine.RunnerUrl</span>
+                        <span class="machine-card__meta">
+                            @if (string.Equals(_settings.PreferredMachineId, machine.Id, StringComparison.OrdinalIgnoreCase))
+                            {
+                                <span class="machine-badge">Default terminal</span>
+                            }
+                            <span class="machine-state machine-state--@GetStatusClass(machine)">
+                                @GetStatusLabel(machine)
                             </span>
-                        </div>
-
-                        @if (!string.IsNullOrWhiteSpace(capability.Version))
-                        {
-                            <p><strong>Version:</strong> <code>@capability.Version</code></p>
-                        }
-
-                        @if (capability.InstalledVersions.Count > 1)
-                        {
-                            <p><strong>Installed versions:</strong> @string.Join(", ", capability.InstalledVersions)</p>
-                        }
-
-                        @if (!string.IsNullOrWhiteSpace(capability.Message))
-                        {
-                            <p class="capability-card__message">@capability.Message</p>
-                        }
-
-                        @if (SupportsVersionSelection(capability))
-                        {
-                            <div class="capability-version-picker">
-                                <label>SDK version</label>
-                                <div class="capability-version-picker__inputs">
-                                    <select class="input"
-                                            value="@GetPresetSdkVersion(capability.Id)"
-                                            @onchange="args => SetPresetSdkVersion(capability.Id, args.Value?.ToString())">
-                                        <option value="">Default</option>
-                                        @foreach (var option in GetSdkVersionOptions(capability.Id))
-                                        {
-                                            <option value="@option">@option</option>
-                                        }
-                                    </select>
-                                    <input type="text"
-                                           class="input"
-                                           value="@GetCustomSdkVersion(capability.Id)"
-                                           @oninput="args => SetCustomSdkVersion(capability.Id, args.Value?.ToString())"
-                                           placeholder="Custom version" />
-                                </div>
-                                <p class="capability-card__message">Leave both fields blank to install the default version.</p>
-                            </div>
-                        }
-
-                        @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability) || SupportsUpdateAction(capability))
-                        {
-                            <div class="capability-card__actions">
-                                @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability))
-                                {
-                                    <button class="btn btn-primary"
-                                            @onclick="() => InstallCapabilityAsync(capability)"
-                                            disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
-                                        @(IsCapabilityActionRunning(capability, "install")
-                                            ? "Installing..."
-                                            : SupportsVersionSelection(capability) ? "Install Version" : "Install")
-                                    </button>
-                                }
-
-                                @if (SupportsUpdateAction(capability))
-                                {
-                                    <button class="btn btn-accent"
-                                            @onclick="() => UpdateCapabilityAsync(capability)"
-                                            disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
-                                        @(IsCapabilityActionRunning(capability, "update") ? "Updating..." : "Update")
-                                    </button>
-                                }
-                            </div>
-                        }
-                    </article>
+                        </span>
+                    </button>
                 }
             </div>
-            <p class="machine-capabilities__timestamp">Last checked @(_machineCapabilities.CapturedAt.ToLocalTime().ToString("g"))</p>
 
-            @if (_lastCapabilityInstallResult is not null)
+            @if (SelectedMachine is not null)
             {
-                <div class="capability-install-result">
-                    <h3>Last Setup Action</h3>
-                    <p>
-                        <strong>@_lastCapabilityInstallResult.CapabilityName:</strong>
-                        @(GetCapabilityActionResultLabel(_lastCapabilityInstallResult))
-                        @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.RequestedVersion))
+                <div class="machine-editor machine-editor--settings">
+                    <div class="form-field">
+                        <label for="machine-name">Machine Name</label>
+                        <input id="machine-name" type="text" class="input" @bind="SelectedMachine.Name" />
+                    </div>
+
+                    <div class="form-field">
+                        <label for="runner-url">Runner URL</label>
+                        <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
+                               placeholder="http://localhost:5000" />
+                    </div>
+
+                    <div class="form-field">
+                        <label class="checkbox-label">
+                            <input type="checkbox" @bind="SelectedMachine.AutoConnect" />
+                            Auto-connect on startup
+                        </label>
+                    </div>
+
+                    <div class="form-actions form-actions--settings">
+                        <button class="btn btn-accent" @onclick="() => SetPreferredMachine(SelectedMachine.Id)">
+                            Make Default For New Terminals
+                        </button>
+
+                        @if (Connections.GetConnectionState(SelectedMachine.Id) == HubConnectionState.Connected)
                         {
-                            <span> (@_lastCapabilityInstallResult.RequestedVersion)</span>
+                            <button class="btn btn-danger" @onclick="() => DisconnectAsync(SelectedMachine.Id)">Disconnect</button>
                         }
-                    </p>
-                    @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.Message))
-                    {
-                        <p>@_lastCapabilityInstallResult.Message</p>
-                    }
-                    @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.CommandText))
-                    {
-                        <pre class="command-preview">@_lastCapabilityInstallResult.CommandText</pre>
-                    }
-                    @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardOutput))
-                    {
-                        <h3>Standard Output</h3>
-                        <pre class="command-preview">@_lastCapabilityInstallResult.StandardOutput</pre>
-                    }
-                    @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardError))
-                    {
-                        <h3>Standard Error</h3>
-                        <pre class="command-preview">@_lastCapabilityInstallResult.StandardError</pre>
-                    }
+                        else
+                        {
+                            <button class="btn btn-primary" @onclick="() => ConnectAsync(SelectedMachine)">
+                                Connect
+                            </button>
+                        }
+
+                        <button class="btn btn-danger"
+                                @onclick="() => DeleteMachineAsync(SelectedMachine.Id)"
+                                disabled="@(_settings.Machines.Count == 1)">
+                            Delete Machine
+                        </button>
+                    </div>
                 </div>
             }
-        }
+        </div>
     </div>
-}
+
+    @if (SelectedMachine is not null)
+    {
+        <div class="settings-page__details">
+            <div class="settings-card settings-page__card settings-card--status">
+                <div class="settings-card__header settings-page__section-header">
+                    <div>
+                        <h2>Connection Status</h2>
+                        <p class="settings-card__description">@SelectedMachine.Name</p>
+                    </div>
+                </div>
+                <div class="settings-status-list">
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">State</span>
+                        <strong class="status-text-@GetStatusClass(SelectedMachine)">@GetStatusLabel(SelectedMachine)</strong>
+                    </div>
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">Hub URL</span>
+                        <code class="settings-status-row__value">@GetHubUrl(SelectedMachine)</code>
+                    </div>
+                </div>
+            </div>
+
+            <div class="settings-card settings-page__card">
+                <div class="settings-card__header settings-page__section-header">
+                    <div>
+                        <h2>Machine Setup</h2>
+                        <p class="settings-card__description">@SelectedMachine.Name</p>
+                    </div>
+                    <div class="form-actions form-actions--toolbar">
+                        <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
+                            Refresh Capabilities
+                        </button>
+                    </div>
+                </div>
+
+                <p class="settings-card__description">
+                    AgentDeck now treats each runner target as a machine to inspect and prepare in place. Detect which supported tools are already installed and install missing ones directly on this machine.
+                </p>
+
+                @if (_capabilitiesErrorMessage is not null)
+                {
+                    <p class="error-message">@_capabilitiesErrorMessage</p>
+                }
+                else if (_capabilitiesBusy)
+                {
+                    <p>Detecting supported tools on this machine...</p>
+                }
+                else if (_machineCapabilities is null)
+                {
+                    <p>Refresh capabilities to inspect which supported CLIs and SDKs are installed on this machine.</p>
+                }
+                else
+                {
+                    <div class="setup-summary setup-summary--settings">
+                        <div class="setup-summary__item">
+                            <span class="setup-summary__label">Installed</span>
+                            <strong>@GetCapabilityCount(MachineCapabilityStatus.Installed)</strong>
+                        </div>
+                        <div class="setup-summary__item">
+                            <span class="setup-summary__label">Missing</span>
+                            <strong>@GetCapabilityCount(MachineCapabilityStatus.Missing)</strong>
+                        </div>
+                        <div class="setup-summary__item">
+                            <span class="setup-summary__label">Errors</span>
+                            <strong>@GetCapabilityCount(MachineCapabilityStatus.Error)</strong>
+                        </div>
+                    </div>
+
+                    <div class="capability-grid capability-grid--settings">
+                        @foreach (var capability in _machineCapabilities.Capabilities.OrderBy(capability => capability.Category).ThenBy(capability => capability.Name))
+                        {
+                            <article class="capability-card">
+                                <div class="capability-card__header">
+                                    <div>
+                                        <h3>@capability.Name</h3>
+                                        <p>@capability.Category.ToUpperInvariant()</p>
+                                    </div>
+                                    <span class="capability-status capability-status--@GetCapabilityStatusClass(capability)">
+                                        @capability.Status
+                                    </span>
+                                </div>
+
+                                @if (!string.IsNullOrWhiteSpace(capability.Version))
+                                {
+                                    <p><strong>Version:</strong> <code>@capability.Version</code></p>
+                                }
+
+                                @if (capability.InstalledVersions.Count > 1)
+                                {
+                                    <p><strong>Installed versions:</strong> @string.Join(", ", capability.InstalledVersions)</p>
+                                }
+
+                                @if (!string.IsNullOrWhiteSpace(capability.Message))
+                                {
+                                    <p class="capability-card__message">@capability.Message</p>
+                                }
+
+                                @if (SupportsVersionSelection(capability))
+                                {
+                                    <div class="capability-version-picker">
+                                        <label>SDK version</label>
+                                        <div class="capability-version-picker__inputs">
+                                            <select class="input"
+                                                    value="@GetPresetSdkVersion(capability.Id)"
+                                                    @onchange="args => SetPresetSdkVersion(capability.Id, args.Value?.ToString())">
+                                                <option value="">Default</option>
+                                                @foreach (var option in GetSdkVersionOptions(capability.Id))
+                                                {
+                                                    <option value="@option">@option</option>
+                                                }
+                                            </select>
+                                            <input type="text"
+                                                   class="input"
+                                                   value="@GetCustomSdkVersion(capability.Id)"
+                                                   @oninput="args => SetCustomSdkVersion(capability.Id, args.Value?.ToString())"
+                                                   placeholder="Custom version" />
+                                        </div>
+                                        <p class="capability-card__message">Leave both fields blank to install the default version.</p>
+                                    </div>
+                                }
+
+                                @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability) || SupportsUpdateAction(capability))
+                                {
+                                    <div class="capability-card__actions">
+                                        @if (capability.Status == MachineCapabilityStatus.Missing || SupportsVersionSelection(capability))
+                                        {
+                                            <button class="btn btn-primary"
+                                                    @onclick="() => InstallCapabilityAsync(capability)"
+                                                    disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
+                                                @(IsCapabilityActionRunning(capability, "install")
+                                                    ? "Installing..."
+                                                    : SupportsVersionSelection(capability) ? "Install Version" : "Install")
+                                            </button>
+                                        }
+
+                                        @if (SupportsUpdateAction(capability))
+                                        {
+                                            <button class="btn btn-accent"
+                                                    @onclick="() => UpdateCapabilityAsync(capability)"
+                                                    disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
+                                                @(IsCapabilityActionRunning(capability, "update") ? "Updating..." : "Update")
+                                            </button>
+                                        }
+                                    </div>
+                                }
+                            </article>
+                        }
+                    </div>
+                    <p class="machine-capabilities__timestamp">Last checked @(_machineCapabilities.CapturedAt.ToLocalTime().ToString("g"))</p>
+
+                    @if (_lastCapabilityInstallResult is not null)
+                    {
+                        <div class="capability-install-result">
+                            <h3>Last Setup Action</h3>
+                            <p>
+                                <strong>@_lastCapabilityInstallResult.CapabilityName:</strong>
+                                @(GetCapabilityActionResultLabel(_lastCapabilityInstallResult))
+                                @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.RequestedVersion))
+                                {
+                                    <span> (@_lastCapabilityInstallResult.RequestedVersion)</span>
+                                }
+                            </p>
+                            @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.Message))
+                            {
+                                <p>@_lastCapabilityInstallResult.Message</p>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.CommandText))
+                            {
+                                <pre class="command-preview">@_lastCapabilityInstallResult.CommandText</pre>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardOutput))
+                            {
+                                <h3>Standard Output</h3>
+                                <pre class="command-preview">@_lastCapabilityInstallResult.StandardOutput</pre>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardError))
+                            {
+                                <h3>Standard Error</h3>
+                                <pre class="command-preview">@_lastCapabilityInstallResult.StandardError</pre>
+                            }
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    }
+</div>
 
 @code {
     private ConnectionSettings _settings = ConnectionSettings.CreateDefault();

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -501,6 +501,15 @@ main {
         padding: 1rem;
     }
 
+    .settings-page {
+        gap: 0.85rem;
+        padding-bottom: 0.75rem;
+    }
+
+    .settings-page__card {
+        margin: 0;
+    }
+
     .machine-layout,
     .capability-version-picker__inputs {
         grid-template-columns: minmax(0, 1fr);
@@ -533,6 +542,43 @@ main {
     .shortcuts-card {
         min-width: 0;
     }
+
+    .machine-list--settings {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(15rem, 82vw);
+        overflow-x: auto;
+        padding-bottom: 0.25rem;
+        scroll-snap-type: x proximity;
+    }
+
+    .machine-list--settings .machine-card {
+        min-height: 100%;
+        scroll-snap-align: start;
+    }
+
+    .setup-summary--settings {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .setup-summary--settings .setup-summary__item {
+        min-width: 0;
+    }
+
+    .capability-grid--settings {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .form-actions--toolbar .btn,
+    .form-actions--settings .btn,
+    .capability-card__actions .btn {
+        width: 100%;
+    }
+
+    .capability-card {
+        padding: 1rem;
+    }
 }
 
 @media (max-width: 900px) and (orientation: landscape) {
@@ -548,6 +594,14 @@ main {
 
     .command-bar__pill {
         flex: 0 0 auto;
+    }
+
+    .machine-list--settings {
+        grid-auto-columns: minmax(18rem, 28rem);
+    }
+
+    .capability-grid--settings {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 }
 
@@ -567,6 +621,22 @@ main {
 
     .shortcuts-table td:first-child {
         padding-right: 0.75rem;
+    }
+
+    .settings-page__header p {
+        font-size: 0.82rem;
+    }
+
+    .setup-summary--settings {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-card__description {
+        font-size: 0.8rem;
+    }
+
+    .machine-list--settings {
+        grid-auto-columns: minmax(14rem, 85vw);
     }
 }
 
@@ -633,6 +703,37 @@ main {
     margin: 1rem 1.5rem;
 }
 
+.settings-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0 0 1rem;
+}
+
+.settings-page__header {
+    padding-bottom: 0;
+}
+
+.settings-page__header p {
+    margin: 0.35rem 0 0;
+    color: var(--color-subtext);
+    font-size: 0.9rem;
+    max-width: 42rem;
+}
+
+.settings-page__card {
+    margin: 0 1.5rem;
+}
+
+.settings-page__details {
+    display: grid;
+    gap: 1rem;
+}
+
+.settings-page__section-header > div:first-child {
+    min-width: 0;
+}
+
 .settings-card__header {
     display: flex;
     justify-content: space-between;
@@ -663,6 +764,17 @@ main {
 .checkbox-label { display: flex; align-items: center; gap: 0.5rem; cursor: pointer; color: var(--color-text); font-size: 0.875rem; }
 
 .form-actions { display: flex; gap: 0.75rem; margin-top: 1.25rem; }
+
+.form-actions--toolbar {
+    margin-top: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.form-actions--settings {
+    align-items: stretch;
+    flex-wrap: wrap;
+}
 
 .input--multiline {
     min-height: 5.5rem;
@@ -744,6 +856,10 @@ main {
 
 .machine-editor {
     min-width: 0;
+}
+
+.machine-editor--settings {
+    padding: 0.25rem 0;
 }
 
 .machine-badge,
@@ -895,6 +1011,27 @@ main {
 
 .capability-install-result h3 {
     margin: 0 0 0.75rem;
+}
+
+.settings-status-list {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.settings-status-row {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.settings-status-row__label {
+    color: var(--color-subtext);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.settings-status-row__value {
+    overflow-wrap: anywhere;
 }
 
 .legacy-settings {


### PR DESCRIPTION
## Summary
- give the settings page a dedicated mobile layout instead of relying on generic responsive rules
- make machine selection and settings actions easier to use on phones
- improve the readability of connection status and machine setup sections on small screens

## Issue
Closes #92

## Validation
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-mobile-settings-fix