### PR TITLE
Auto-fit active terminal on resize

### DIFF
--- a/AgentDeck.Core/Components/TerminalPanel.razor
+++ b/AgentDeck.Core/Components/TerminalPanel.razor
@@ -14,6 +14,7 @@
     private string _containerId = string.Empty;
     private DotNetObjectReference<TerminalPanel>? _dotnetRef;
     private bool _initialised;
+    private bool _wasActive;
 
     protected override void OnParametersSet()
     {
@@ -38,20 +39,36 @@
         if (size.HasValue)
             await Connections.ResizeTerminalAsync(Session.Id, size.Value.Cols, size.Value.Rows);
 
+        if (IsActive)
+        {
+            await TerminalJs.RegisterAutoFitAsync(Session.Id);
+        }
+
         await TerminalJs.FocusAsync(Session.Id);
+        _wasActive = IsActive;
     }
 
     protected override async Task OnParametersSetAsync()
     {
-        if (_initialised && IsActive)
+        if (!_initialised)
+            return;
+
+        if (IsActive && !_wasActive)
         {
             // Re-fit when this tab becomes visible (window may have been resized
             // while this panel was hidden) and push the new size to the runner.
+            await TerminalJs.RegisterAutoFitAsync(Session.Id);
             var size = await TerminalJs.FitAndGetSizeAsync(Session.Id);
             if (size.HasValue)
                 await Connections.ResizeTerminalAsync(Session.Id, size.Value.Cols, size.Value.Rows);
             await TerminalJs.FocusAsync(Session.Id);
         }
+        else if (!IsActive && _wasActive)
+        {
+            await TerminalJs.UnregisterAutoFitAsync(Session.Id);
+        }
+
+        _wasActive = IsActive;
     }
 
     private void OnOutputReceived(object? sender, TerminalOutput output)
@@ -84,6 +101,7 @@
 
         if (_initialised)
         {
+            await TerminalJs.UnregisterAutoFitAsync(Session.Id);
             await Connections.LeaveSessionAsync(Session.Id);
             await TerminalJs.DisposeTerminalAsync(Session.Id);
         }

--- a/AgentDeck.Core/Services/TerminalInterop.cs
+++ b/AgentDeck.Core/Services/TerminalInterop.cs
@@ -57,6 +57,18 @@ public sealed class TerminalInterop : IAsyncDisposable
         await module.InvokeVoidAsync("focusTerminal", sessionId);
     }
 
+    public async Task RegisterAutoFitAsync(string sessionId)
+    {
+        var module = await _moduleTask.Value;
+        await module.InvokeVoidAsync("registerAutoFit", sessionId);
+    }
+
+    public async Task UnregisterAutoFitAsync(string sessionId)
+    {
+        var module = await _moduleTask.Value;
+        await module.InvokeVoidAsync("unregisterAutoFit", sessionId);
+    }
+
     public async Task DisposeTerminalAsync(string sessionId)
     {
         var module = await _moduleTask.Value;

--- a/AgentDeck.Core/wwwroot/js/agentdeck.js
+++ b/AgentDeck.Core/wwwroot/js/agentdeck.js
@@ -3,6 +3,29 @@
 
 const terminals = new Map();
 
+function canMeasureContainer(container) {
+    return !!container
+        && document.body.contains(container)
+        && container.clientWidth > 0
+        && container.clientHeight > 0;
+}
+
+function scheduleFit(entry) {
+    if (!entry || entry.fitFrame !== null) {
+        return;
+    }
+
+    entry.fitFrame = requestAnimationFrame(() => {
+        entry.fitFrame = null;
+
+        if (!canMeasureContainer(entry.container)) {
+            return;
+        }
+
+        try { entry.fitAddon.fit(); } catch (_) {}
+    });
+}
+
 /**
  * Create and mount an xterm.js terminal in the given DOM element.
  * @param {string} elementId - The id of the container div
@@ -71,7 +94,16 @@ export function createTerminal(elementId, sessionId, dotnetRef, theme) {
             .catch(err => console.warn('[AgentDeck] OnTerminalResize failed:', err));
     });
 
-    terminals.set(sessionId, { term, fitAddon, dotnetRef });
+    terminals.set(sessionId, {
+        term,
+        fitAddon,
+        dotnetRef,
+        container,
+        fitFrame: null,
+        resizeObserver: null,
+        resizeHandler: null,
+        viewportResizeHandler: null
+    });
 }
 
 /**
@@ -90,9 +122,7 @@ export function writeToTerminal(sessionId, data) {
 export function fitTerminal(sessionId) {
     const entry = terminals.get(sessionId);
     if (entry) {
-        requestAnimationFrame(() => {
-            try { entry.fitAddon.fit(); } catch (_) {}
-        });
+        scheduleFit(entry);
     }
 }
 
@@ -107,10 +137,62 @@ export function fitAndGetSize(sessionId) {
         requestAnimationFrame(() => {
             const entry = terminals.get(sessionId);
             if (!entry) { resolve(null); return; }
+            if (!canMeasureContainer(entry.container)) { resolve(null); return; }
             try { entry.fitAddon.fit(); } catch (_) {}
             resolve({ cols: entry.term.cols, rows: entry.term.rows });
         });
     });
+}
+
+export function registerAutoFit(sessionId) {
+    const entry = terminals.get(sessionId);
+    if (!entry) {
+        return;
+    }
+
+    unregisterAutoFit(sessionId);
+
+    const onResize = () => scheduleFit(entry);
+    entry.resizeHandler = onResize;
+
+    if (typeof ResizeObserver !== 'undefined') {
+        entry.resizeObserver = new ResizeObserver(onResize);
+        entry.resizeObserver.observe(entry.container);
+    }
+
+    window.addEventListener('resize', onResize);
+
+    if (window.visualViewport) {
+        entry.viewportResizeHandler = onResize;
+        window.visualViewport.addEventListener('resize', onResize);
+    }
+}
+
+export function unregisterAutoFit(sessionId) {
+    const entry = terminals.get(sessionId);
+    if (!entry) {
+        return;
+    }
+
+    if (entry.resizeObserver) {
+        entry.resizeObserver.disconnect();
+        entry.resizeObserver = null;
+    }
+
+    if (entry.resizeHandler) {
+        window.removeEventListener('resize', entry.resizeHandler);
+        entry.resizeHandler = null;
+    }
+
+    if (entry.viewportResizeHandler && window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', entry.viewportResizeHandler);
+        entry.viewportResizeHandler = null;
+    }
+
+    if (entry.fitFrame !== null) {
+        cancelAnimationFrame(entry.fitFrame);
+        entry.fitFrame = null;
+    }
 }
 
 /**
@@ -127,6 +209,7 @@ export function focusTerminal(sessionId) {
 export function disposeTerminal(sessionId) {
     const entry = terminals.get(sessionId);
     if (entry) {
+        unregisterAutoFit(sessionId);
         try { entry.term.dispose(); } catch (_) {}
         // Release the .NET reference immediately rather than waiting for JS GC,
         // since the term.onData/onResize closures captured it.


### PR DESCRIPTION
## Summary
- register live auto-fit observers for the active terminal
- unregister resize listeners for inactive or disposed terminals
- keep hidden terminals idle until they become active again

## Issue
Closes #94

## Validation
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-windows10.0.19041.0 -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-terminal-resize-fix
- dotnet build AgentDeck\\AgentDeck.csproj -nologo -f net10.0-android -c Release -o C:\\Users\\Alpha\\AppData\\Local\\Temp\\agentdeck-terminal-resize-android