### PR TITLE
Add coordinator and worker machine roles

### DIFF
--- a/AgentDeck.Core/Models/ConnectionSettings.cs
+++ b/AgentDeck.Core/Models/ConnectionSettings.cs
@@ -1,3 +1,5 @@
+using AgentDeck.Shared.Enums;
+
 namespace AgentDeck.Core.Models;
 
 /// <summary>User-configured runner machine profiles for the companion app.</summary>
@@ -78,6 +80,7 @@ public sealed class ConnectionSettings
         {
             Id = LocalMachineId,
             Name = "Local machine",
+            Role = RunnerMachineRole.Standalone,
             RunnerUrl = "http://localhost:5000",
             AutoConnect = true
         };

--- a/AgentDeck.Core/Models/RunnerMachineSettings.cs
+++ b/AgentDeck.Core/Models/RunnerMachineSettings.cs
@@ -1,3 +1,5 @@
+using AgentDeck.Shared.Enums;
+
 namespace AgentDeck.Core.Models;
 
 /// <summary>Named runner machine profile managed by the companion app.</summary>
@@ -8,6 +10,9 @@ public sealed class RunnerMachineSettings
 
     /// <summary>User-facing machine name.</summary>
     public string Name { get; set; } = "Local machine";
+
+    /// <summary>Intended orchestration role for this machine profile.</summary>
+    public RunnerMachineRole Role { get; set; } = RunnerMachineRole.Standalone;
 
     /// <summary>Base URL of the runner (e.g. http://192.168.1.5:5000).</summary>
     public string RunnerUrl { get; set; } = "http://localhost:5000";
@@ -21,6 +26,7 @@ public sealed class RunnerMachineSettings
         {
             Id = Id,
             Name = Name,
+            Role = Role,
             RunnerUrl = RunnerUrl,
             AutoConnect = AutoConnect
         };

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -41,6 +41,7 @@
                         <span class="machine-card__title">@machine.Name</span>
                         <span class="machine-card__url">@machine.RunnerUrl</span>
                         <span class="machine-card__meta">
+                            <span class="machine-badge">@GetMachineRoleLabel(machine.Role)</span>
                             @if (string.Equals(_settings.PreferredMachineId, machine.Id, StringComparison.OrdinalIgnoreCase))
                             {
                                 <span class="machine-badge">Default terminal</span>
@@ -65,6 +66,17 @@
                         <label for="runner-url">Runner URL</label>
                         <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
                                placeholder="http://localhost:5000" />
+                    </div>
+
+                    <div class="form-field">
+                        <label for="machine-role">Machine Role</label>
+                        <select id="machine-role" class="input" @bind="SelectedMachine.Role">
+                            @foreach (var role in _machineRoles)
+                            {
+                                <option value="@role">@GetMachineRoleLabel(role)</option>
+                            }
+                        </select>
+                        <p class="settings-card__description">@GetMachineRoleDescription(SelectedMachine.Role)</p>
                     </div>
 
                     <div class="form-field">
@@ -117,9 +129,41 @@
                         <strong class="status-text-@GetStatusClass(SelectedMachine)">@GetStatusLabel(SelectedMachine)</strong>
                     </div>
                     <div class="settings-status-row">
+                        <span class="settings-status-row__label">Role</span>
+                        <strong class="settings-status-row__value">@GetMachineRoleLabel(SelectedMachine.Role)</strong>
+                    </div>
+                    <div class="settings-status-row">
                         <span class="settings-status-row__label">Hub URL</span>
                         <code class="settings-status-row__value">@GetHubUrl(SelectedMachine)</code>
                     </div>
+                    @if (_machineCapabilities?.Platform is not null)
+                    {
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Detected platform</span>
+                            <strong class="settings-status-row__value">@GetHostPlatformLabel(_machineCapabilities.Platform.HostPlatform)</strong>
+                        </div>
+                        @if (!string.IsNullOrWhiteSpace(_machineCapabilities.Platform.Architecture))
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Architecture</span>
+                                <span class="settings-status-row__value">@_machineCapabilities.Platform.Architecture</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(_machineCapabilities.Platform.OperatingSystemDescription))
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">OS description</span>
+                                <span class="settings-status-row__value">@_machineCapabilities.Platform.OperatingSystemDescription</span>
+                            </div>
+                        }
+                        @if (_machineCapabilities.SupportedTargets.Count > 0)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Target readiness</span>
+                                <span class="settings-status-row__value">@string.Join(", ", _machineCapabilities.SupportedTargets.Select(FormatTargetSummary))</span>
+                            </div>
+                        }
+                    }
                 </div>
             </div>
 
@@ -291,6 +335,8 @@
 
 @code {
     private ConnectionSettings _settings = ConnectionSettings.CreateDefault();
+    private static readonly RunnerMachineRole[] _machineRoles =
+        [RunnerMachineRole.Standalone, RunnerMachineRole.Coordinator, RunnerMachineRole.Worker];
     private bool _saving;
     private string? _errorMessage;
     private readonly Dictionary<string, MachineCapabilitiesSnapshot?> _machineCapabilitiesByMachine = new(StringComparer.OrdinalIgnoreCase);
@@ -358,6 +404,7 @@
         var machine = new RunnerMachineSettings
         {
             Name = name,
+            Role = RunnerMachineRole.Standalone,
             RunnerUrl = "http://localhost:5000",
             AutoConnect = false
         };
@@ -447,6 +494,31 @@
         HubConnectionState.Reconnecting => "Reconnecting...",
         _ => "Disconnected"
     };
+
+    private static string GetMachineRoleLabel(RunnerMachineRole role) => role switch
+    {
+        RunnerMachineRole.Coordinator => "Coordinator",
+        RunnerMachineRole.Worker => "Worker",
+        _ => "Standalone"
+    };
+
+    private static string GetMachineRoleDescription(RunnerMachineRole role) => role switch
+    {
+        RunnerMachineRole.Coordinator => "Use this machine as the main orchestration runner that will coordinate worker machines later.",
+        RunnerMachineRole.Worker => "Use this machine as a remote worker that receives run/debug work from a coordinator.",
+        _ => "Use this machine independently without assigning it to coordinator/worker orchestration yet."
+    };
+
+    private static string GetHostPlatformLabel(RunnerHostPlatform platform) => platform switch
+    {
+        RunnerHostPlatform.Linux => "Linux",
+        RunnerHostPlatform.Windows => "Windows",
+        RunnerHostPlatform.MacOS => "macOS",
+        _ => "Unknown"
+    };
+
+    private static string FormatTargetSummary(MachineTargetSupport target) =>
+        $"{target.DisplayName} ({target.Status})";
 
     private static string GetHubUrl(RunnerMachineSettings machine) => $"{machine.RunnerUrl.TrimEnd('/')}/hubs/agent";
 

--- a/AgentDeck.Shared/Enums/RunnerMachineRole.cs
+++ b/AgentDeck.Shared/Enums/RunnerMachineRole.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Declares how a configured runner machine participates in multi-machine orchestration.</summary>
+public enum RunnerMachineRole
+{
+    Standalone,
+    Coordinator,
+    Worker
+}

--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ The companion app supports multiple named runner machines.
 
 In **Settings** you can:
 - add and name machines
+- assign each machine a role (`Standalone`, `Coordinator`, or `Worker`)
 - set a default machine for new terminals
 - connect and disconnect each machine independently
 - inspect the connection status and hub URL for the selected machine
 
 When you create a new terminal, you choose which machine it should run on.
+
+The current orchestration foundation is additive: roles do not change terminal behavior yet, but they let you declare which machine is intended to act as the main coordinator and which machines are intended to act as workers as the distributed run/debug workflow grows.
 
 ### Machine Capabilities
 


### PR DESCRIPTION
## Summary
- add a shared machine-role enum for standalone, coordinator, and worker runners
- persist machine role selection in companion app settings
- surface machine role and detected platform/target readiness details in Settings

## Issue
Closes #98