### PR TITLE
Design remote viewing foundations

### DIFF
--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddSignalR(opts =>
 
 builder.Services.AddSingleton<IAgentSessionStore, AgentSessionStore>();
 builder.Services.AddSingleton<IOrchestrationJobService, OrchestrationJobService>();
+builder.Services.AddSingleton<IRemoteViewerSessionService, RemoteViewerSessionService>();
 builder.Services.AddSingleton<IWorkspaceService, WorkspaceService>();
 builder.Services.AddSingleton<IMachineCapabilityService, MachineCapabilityService>();
 builder.Services.AddSingleton<IMachineSetupService, MachineSetupService>();
@@ -78,6 +79,40 @@ app.MapPost("/api/orchestration/jobs/{id}/logs", (string id, AppendOrchestration
 
 app.MapPost("/api/orchestration/jobs/{id}/cancel", (string id, IOrchestrationJobService jobs) =>
     jobs.RequestCancellation(id) is { } job ? Results.Ok(job) : Results.NotFound());
+
+app.MapGet("/api/viewers/providers", (IRemoteViewerSessionService viewers) =>
+    Results.Ok(viewers.GetAvailableProviders()));
+
+app.MapGet("/api/viewers/sessions", (IRemoteViewerSessionService viewers) =>
+    Results.Ok(viewers.GetAll()));
+
+app.MapGet("/api/viewers/sessions/{id}", (string id, IRemoteViewerSessionService viewers) =>
+    viewers.Get(id) is { } session ? Results.Ok(session) : Results.NotFound());
+
+app.MapPost("/api/viewers/sessions", (CreateRemoteViewerSessionRequest request, IRemoteViewerSessionService viewers) =>
+    Results.Ok(viewers.Create(request)));
+
+app.MapPost("/api/viewers/sessions/{id}/status", (string id, UpdateRemoteViewerSessionRequest request, IRemoteViewerSessionService viewers) =>
+{
+    var result = viewers.Update(id, request);
+    return result.Outcome switch
+    {
+        RemoteViewerSessionMutationOutcome.Updated when result.Session is not null => Results.Ok(result.Session),
+        RemoteViewerSessionMutationOutcome.InvalidTransition when result.Session is not null => Results.Conflict(result.Session),
+        _ => Results.NotFound()
+    };
+});
+
+app.MapPost("/api/viewers/sessions/{id}/close", (string id, IRemoteViewerSessionService viewers) =>
+{
+    var result = viewers.Close(id);
+    return result.Outcome switch
+    {
+        RemoteViewerSessionMutationOutcome.Updated when result.Session is not null => Results.Ok(result.Session),
+        RemoteViewerSessionMutationOutcome.InvalidTransition when result.Session is not null => Results.Conflict(result.Session),
+        _ => Results.NotFound()
+    };
+});
 
 app.MapGet("/api/workspace", (IWorkspaceService workspace) =>
     Results.Ok(workspace.GetWorkspaceInfo()));

--- a/AgentDeck.Runner/Services/IRemoteViewerSessionService.cs
+++ b/AgentDeck.Runner/Services/IRemoteViewerSessionService.cs
@@ -1,0 +1,14 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <summary>Tracks remote viewer sessions and provider capabilities for the local runner machine.</summary>
+public interface IRemoteViewerSessionService
+{
+    IReadOnlyList<RemoteViewerProviderCapability> GetAvailableProviders();
+    RemoteViewerSession Create(CreateRemoteViewerSessionRequest request);
+    RemoteViewerSession? Get(string sessionId);
+    IReadOnlyList<RemoteViewerSession> GetAll();
+    RemoteViewerSessionMutationResult Update(string sessionId, UpdateRemoteViewerSessionRequest request);
+    RemoteViewerSessionMutationResult Close(string sessionId, string? message = null);
+}

--- a/AgentDeck.Runner/Services/RemoteViewerSessionMutationOutcome.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionMutationOutcome.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Runner.Services;
+
+public enum RemoteViewerSessionMutationOutcome
+{
+    Updated,
+    NotFound,
+    InvalidTransition
+}

--- a/AgentDeck.Runner/Services/RemoteViewerSessionMutationResult.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionMutationResult.cs
@@ -1,0 +1,9 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class RemoteViewerSessionMutationResult
+{
+    public required RemoteViewerSessionMutationOutcome Outcome { get; init; }
+    public RemoteViewerSession? Session { get; init; }
+}

--- a/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
@@ -1,0 +1,269 @@
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <inheritdoc />
+public sealed class RemoteViewerSessionService : IRemoteViewerSessionService
+{
+    private const int MaxRetainedTerminalHistory = 100;
+    private readonly Lock _gate = new();
+    private readonly Dictionary<string, RemoteViewerSession> _sessions = [];
+
+    public IReadOnlyList<RemoteViewerProviderCapability> GetAvailableProviders()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return
+            [
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.Rdp,
+                    DisplayName = "RDP-compatible desktop viewer",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Best fit for full Windows desktop access."
+                },
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.Vnc,
+                    DisplayName = "VNC-compatible viewer",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop, RemoteViewerTargetKind.Window, RemoteViewerTargetKind.Emulator, RemoteViewerTargetKind.VsCode],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Window targeting still requires platform-specific capture support."
+                }
+            ];
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return
+            [
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.ScreenSharing,
+                    DisplayName = "Screen Sharing",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop, RemoteViewerTargetKind.Window, RemoteViewerTargetKind.Simulator, RemoteViewerTargetKind.VsCode],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "macOS screen sharing can back desktop and simulator viewing."
+                },
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.Vnc,
+                    DisplayName = "VNC-compatible viewer",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop, RemoteViewerTargetKind.Window],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Window-level targeting is still an orchestration concern above the transport."
+                }
+            ];
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return
+            [
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.Vnc,
+                    DisplayName = "VNC-compatible viewer",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop, RemoteViewerTargetKind.Window, RemoteViewerTargetKind.Emulator, RemoteViewerTargetKind.VsCode],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Good general-purpose transport for Linux desktop and app surfaces."
+                },
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.X11,
+                    DisplayName = "X11 window stream",
+                    SupportedTargets = [RemoteViewerTargetKind.Window],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Best fit when window-level capture is available on X11."
+                },
+                new RemoteViewerProviderCapability
+                {
+                    Provider = RemoteViewerProviderKind.Wayland,
+                    DisplayName = "Wayland capture session",
+                    SupportedTargets = [RemoteViewerTargetKind.Desktop, RemoteViewerTargetKind.Window],
+                    RequiresInteractiveDesktop = true,
+                    Notes = "Wayland support depends on compositor-specific capture hooks."
+                }
+            ];
+        }
+
+        return [];
+    }
+
+    public RemoteViewerSession Create(CreateRemoteViewerSessionRequest request)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var session = new RemoteViewerSession
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            MachineId = request.MachineId,
+            MachineName = request.MachineName,
+            JobId = request.JobId ?? request.Target.JobId,
+            Target = CloneTarget(request.Target),
+            Provider = request.Provider,
+            Status = RemoteViewerSessionStatus.Requested,
+            StatusMessage = "Viewer session requested.",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        lock (_gate)
+        {
+            _sessions[session.Id] = session;
+            PruneTerminalSessions(session.Id);
+        }
+
+        return CloneSession(session);
+    }
+
+    public RemoteViewerSession? Get(string sessionId)
+    {
+        lock (_gate)
+        {
+            return _sessions.TryGetValue(sessionId, out var session) ? CloneSession(session) : null;
+        }
+    }
+
+    public IReadOnlyList<RemoteViewerSession> GetAll()
+    {
+        lock (_gate)
+        {
+            return [.. _sessions.Values.OrderByDescending(session => session.CreatedAt).Select(CloneSession)];
+        }
+    }
+
+    public RemoteViewerSessionMutationResult Update(string sessionId, UpdateRemoteViewerSessionRequest request)
+    {
+        lock (_gate)
+        {
+            if (!_sessions.TryGetValue(sessionId, out var session))
+            {
+                return new RemoteViewerSessionMutationResult
+                {
+                    Outcome = RemoteViewerSessionMutationOutcome.NotFound
+                };
+            }
+
+            if (!IsValidTransition(session.Status, request.Status))
+            {
+                return new RemoteViewerSessionMutationResult
+                {
+                    Outcome = RemoteViewerSessionMutationOutcome.InvalidTransition,
+                    Session = CloneSession(session)
+                };
+            }
+
+            if (session.Status == RemoteViewerSessionStatus.Closed && request.Status == RemoteViewerSessionStatus.Closed)
+            {
+                var updatedClosedSession = new RemoteViewerSession(session)
+                {
+                    StatusMessage = request.Message ?? session.StatusMessage,
+                    UpdatedAt = DateTimeOffset.UtcNow
+                };
+
+                _sessions[sessionId] = updatedClosedSession;
+                PruneTerminalSessions(sessionId);
+
+                return new RemoteViewerSessionMutationResult
+                {
+                    Outcome = RemoteViewerSessionMutationOutcome.Updated,
+                    Session = CloneSession(updatedClosedSession)
+                };
+            }
+
+            var updated = new RemoteViewerSession(session)
+            {
+                Status = request.Status,
+                ConnectionUri = request.ConnectionUri ?? session.ConnectionUri,
+                AccessToken = request.AccessToken ?? session.AccessToken,
+                StatusMessage = request.Message ?? session.StatusMessage,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            _sessions[sessionId] = updated;
+            PruneTerminalSessions(sessionId);
+            return new RemoteViewerSessionMutationResult
+            {
+                Outcome = RemoteViewerSessionMutationOutcome.Updated,
+                Session = CloneSession(updated)
+            };
+        }
+    }
+
+    public RemoteViewerSessionMutationResult Close(string sessionId, string? message = null)
+    {
+        return Update(sessionId, new UpdateRemoteViewerSessionRequest
+        {
+            Status = RemoteViewerSessionStatus.Closed,
+            Message = message ?? "Viewer session closed."
+        });
+    }
+
+    private static bool IsValidTransition(RemoteViewerSessionStatus from, RemoteViewerSessionStatus to)
+    {
+        if (from == to)
+        {
+            return true;
+        }
+
+        return (from, to) switch
+        {
+            (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Preparing) => true,
+            (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Failed) => true,
+            (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Ready) => true,
+            (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Failed) => true,
+            (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Ready, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Ready, RemoteViewerSessionStatus.Failed) => true,
+            (RemoteViewerSessionStatus.Failed, RemoteViewerSessionStatus.Closed) => true,
+            _ => false
+        };
+    }
+
+    private static RemoteViewerSession CloneSession(RemoteViewerSession session)
+    {
+        return new RemoteViewerSession(session);
+    }
+
+    private static RemoteViewerTarget CloneTarget(RemoteViewerTarget target)
+    {
+        return new RemoteViewerTarget
+        {
+            Kind = target.Kind,
+            DisplayName = target.DisplayName,
+            JobId = target.JobId,
+            SessionId = target.SessionId,
+            WindowTitle = target.WindowTitle,
+            DeviceProfile = target.DeviceProfile
+        };
+    }
+
+    private void PruneTerminalSessions(string protectedSessionId)
+    {
+        var orderedTerminalSessions = _sessions.Values
+            .Where(session => session.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+            .OrderByDescending(session => session.UpdatedAt)
+            .ThenByDescending(session => session.CreatedAt)
+            .ThenBy(session => session.Id, StringComparer.Ordinal)
+            .ToList();
+
+        var retainedIds = orderedTerminalSessions
+            .Take(MaxRetainedTerminalHistory)
+            .Select(session => session.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        retainedIds.Add(protectedSessionId);
+
+        var removableIds = orderedTerminalSessions
+            .Where(session => !retainedIds.Contains(session.Id))
+            .Select(session => session.Id)
+            .ToList();
+
+        foreach (var sessionId in removableIds)
+        {
+            _sessions.Remove(sessionId);
+        }
+    }
+}

--- a/AgentDeck.Shared/Enums/RemoteViewerProviderKind.cs
+++ b/AgentDeck.Shared/Enums/RemoteViewerProviderKind.cs
@@ -1,0 +1,12 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Provider/transport family used to expose a remote viewer session.</summary>
+public enum RemoteViewerProviderKind
+{
+    Auto,
+    Vnc,
+    Rdp,
+    ScreenSharing,
+    X11,
+    Wayland
+}

--- a/AgentDeck.Shared/Enums/RemoteViewerSessionStatus.cs
+++ b/AgentDeck.Shared/Enums/RemoteViewerSessionStatus.cs
@@ -1,0 +1,11 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Lifecycle state for a remote viewer session.</summary>
+public enum RemoteViewerSessionStatus
+{
+    Requested,
+    Preparing,
+    Ready,
+    Failed,
+    Closed
+}

--- a/AgentDeck.Shared/Enums/RemoteViewerTargetKind.cs
+++ b/AgentDeck.Shared/Enums/RemoteViewerTargetKind.cs
@@ -1,0 +1,11 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Logical surface that a remote viewer session can attach to.</summary>
+public enum RemoteViewerTargetKind
+{
+    Desktop,
+    Window,
+    Emulator,
+    Simulator,
+    VsCode
+}

--- a/AgentDeck.Shared/Models/CreateRemoteViewerSessionRequest.cs
+++ b/AgentDeck.Shared/Models/CreateRemoteViewerSessionRequest.cs
@@ -1,0 +1,13 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Request payload for creating a remote viewer session.</summary>
+public sealed class CreateRemoteViewerSessionRequest
+{
+    public string? MachineId { get; init; }
+    public string? MachineName { get; init; }
+    public string? JobId { get; init; }
+    public RemoteViewerTarget Target { get; init; } = new();
+    public RemoteViewerProviderKind Provider { get; init; } = RemoteViewerProviderKind.Auto;
+}

--- a/AgentDeck.Shared/Models/RemoteViewerProviderCapability.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerProviderCapability.cs
@@ -1,0 +1,13 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Represents a viewing provider that a runner can potentially use.</summary>
+public sealed class RemoteViewerProviderCapability
+{
+    public RemoteViewerProviderKind Provider { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public IReadOnlyList<RemoteViewerTargetKind> SupportedTargets { get; init; } = [];
+    public bool RequiresInteractiveDesktop { get; init; }
+    public string? Notes { get; init; }
+}

--- a/AgentDeck.Shared/Models/RemoteViewerSession.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerSession.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Represents a remote viewer session that is distinct from orchestration jobs and terminals.</summary>
+public sealed class RemoteViewerSession
+{
+    [SetsRequiredMembers]
+    public RemoteViewerSession()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public RemoteViewerSession(RemoteViewerSession other)
+    {
+        Id = other.Id;
+        MachineId = other.MachineId;
+        MachineName = other.MachineName;
+        JobId = other.JobId;
+        Target = new RemoteViewerTarget
+        {
+            Kind = other.Target.Kind,
+            DisplayName = other.Target.DisplayName,
+            JobId = other.Target.JobId,
+            SessionId = other.Target.SessionId,
+            WindowTitle = other.Target.WindowTitle,
+            DeviceProfile = other.Target.DeviceProfile
+        };
+        Provider = other.Provider;
+        Status = other.Status;
+        ConnectionUri = other.ConnectionUri;
+        AccessToken = other.AccessToken;
+        StatusMessage = other.StatusMessage;
+        CreatedAt = other.CreatedAt;
+        UpdatedAt = other.UpdatedAt;
+    }
+
+    public required string Id { get; init; } = string.Empty;
+    public string? MachineId { get; init; }
+    public string? MachineName { get; init; }
+    public string? JobId { get; init; }
+    public RemoteViewerTarget Target { get; init; } = new();
+    public RemoteViewerProviderKind Provider { get; init; } = RemoteViewerProviderKind.Auto;
+    public RemoteViewerSessionStatus Status { get; init; } = RemoteViewerSessionStatus.Requested;
+    public string? ConnectionUri { get; init; }
+    public string? AccessToken { get; init; }
+    public string? StatusMessage { get; init; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/AgentDeck.Shared/Models/RemoteViewerTarget.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerTarget.cs
@@ -1,0 +1,14 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Describes what a remote viewer session should display.</summary>
+public sealed class RemoteViewerTarget
+{
+    public RemoteViewerTargetKind Kind { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public string? JobId { get; init; }
+    public string? SessionId { get; init; }
+    public string? WindowTitle { get; init; }
+    public string? DeviceProfile { get; init; }
+}

--- a/AgentDeck.Shared/Models/UpdateRemoteViewerSessionRequest.cs
+++ b/AgentDeck.Shared/Models/UpdateRemoteViewerSessionRequest.cs
@@ -1,0 +1,12 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Request payload for progressing or closing a remote viewer session.</summary>
+public sealed class UpdateRemoteViewerSessionRequest
+{
+    public RemoteViewerSessionStatus Status { get; init; }
+    public string? ConnectionUri { get; init; }
+    public string? AccessToken { get; init; }
+    public string? Message { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Shared orchestration contracts now also include repository/project metadata, per
 
 The runner also now exposes a first-pass orchestration job API, separate from terminal sessions, so coordinator-managed run/debug work can be queued, tracked by lifecycle status, associated with a target machine, and enriched with step/log data before full cross-machine dispatch is implemented.
 
+The runner now also exposes a first-pass remote viewer API with provider capabilities and viewer-session records distinct from both jobs and terminal sessions. This creates a dedicated place to model full-desktop, window, emulator/simulator, and VS Code viewing before actual VNC/RDP/platform-capture implementations are wired in.
+
 ### Machine Capabilities
 
 The **Machine Setup** section can detect whether the selected machine has these supported tools available:


### PR DESCRIPTION
## Summary
- add shared remote-viewing contracts for viewer targets, providers, sessions, and session lifecycle updates
- add a runner-side in-memory remote viewer session service plus provider discovery and viewer session REST endpoints
- keep remote viewing distinct from terminal sessions and orchestration jobs so later VNC/RDP/window/emulator/VS Code work has a dedicated API surface

## Validation
- dotnet build AgentDeck.Shared\\AgentDeck.Shared.csproj -nologo
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -f net10.0-windows10.0.19041.0 -nologo

Closes #101