### PR TITLE
Design emulator and simulator contracts

### DIFF
--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -1,6 +1,7 @@
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Runner.Hubs;
 using AgentDeck.Runner.Services;
+using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -37,6 +38,7 @@ builder.Services.AddSignalR(opts =>
 builder.Services.AddSingleton<IAgentSessionStore, AgentSessionStore>();
 builder.Services.AddSingleton<IOrchestrationJobService, OrchestrationJobService>();
 builder.Services.AddSingleton<IRemoteViewerSessionService, RemoteViewerSessionService>();
+builder.Services.AddSingleton<IVirtualDeviceCatalogService, VirtualDeviceCatalogService>();
 builder.Services.AddSingleton<IWorkspaceService, WorkspaceService>();
 builder.Services.AddSingleton<IMachineCapabilityService, MachineCapabilityService>();
 builder.Services.AddSingleton<IMachineSetupService, MachineSetupService>();
@@ -69,7 +71,17 @@ app.MapGet("/api/orchestration/jobs/{id}", (string id, IOrchestrationJobService 
     jobs.Get(id) is { } job ? Results.Ok(job) : Results.NotFound());
 
 app.MapPost("/api/orchestration/jobs", (CreateOrchestrationJobRequest request, IOrchestrationJobService jobs) =>
-    Results.Ok(jobs.Queue(request)));
+{
+    if (request.DeviceSelection is not null && !request.DeviceSelection.HasTarget)
+    {
+        return Results.BadRequest(new
+        {
+            message = "Device selection must include either a device ID or a profile ID."
+        });
+    }
+
+    return Results.Ok(jobs.Queue(request));
+});
 
 app.MapPost("/api/orchestration/jobs/{id}/status", (string id, UpdateOrchestrationJobStatusRequest request, IOrchestrationJobService jobs) =>
     jobs.UpdateStatus(id, request) is { } job ? Results.Ok(job) : Results.NotFound());
@@ -112,6 +124,22 @@ app.MapPost("/api/viewers/sessions/{id}/close", (string id, IRemoteViewerSession
         RemoteViewerSessionMutationOutcome.InvalidTransition when result.Session is not null => Results.Conflict(result.Session),
         _ => Results.NotFound()
     };
+});
+
+app.MapGet("/api/virtual-devices/catalogs", (IVirtualDeviceCatalogService devices) =>
+    Results.Ok(devices.GetCatalogs()));
+
+app.MapGet("/api/virtual-devices/catalogs/{catalogKind}", (string catalogKind, IVirtualDeviceCatalogService devices) =>
+{
+    if (!Enum.TryParse<VirtualDeviceCatalogKind>(catalogKind, true, out var parsedCatalogKind))
+    {
+        return Results.BadRequest(new
+        {
+            message = $"Unknown virtual device catalog '{catalogKind}'."
+        });
+    }
+
+    return devices.GetCatalog(parsedCatalogKind) is { } snapshot ? Results.Ok(snapshot) : Results.NotFound();
 });
 
 app.MapGet("/api/workspace", (IWorkspaceService workspace) =>

--- a/AgentDeck.Runner/Services/IVirtualDeviceCatalogService.cs
+++ b/AgentDeck.Runner/Services/IVirtualDeviceCatalogService.cs
@@ -1,0 +1,11 @@
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <summary>Exposes supported virtual device catalogs and current discovery snapshots for the local runner.</summary>
+public interface IVirtualDeviceCatalogService
+{
+    IReadOnlyList<VirtualDeviceCatalogSnapshot> GetCatalogs();
+    VirtualDeviceCatalogSnapshot? GetCatalog(VirtualDeviceCatalogKind catalogKind);
+}

--- a/AgentDeck.Runner/Services/OrchestrationJobService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationJobService.cs
@@ -31,6 +31,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             LaunchCommand = request.LaunchCommand,
             BootstrapCommand = request.BootstrapCommand,
             DebugConfigurationName = request.DebugConfigurationName,
+            DeviceSelection = CloneDeviceSelection(request.DeviceSelection),
             Status = OrchestrationJobStatus.Queued,
             StatusMessage = "Queued for orchestration.",
             CreatedAt = now,
@@ -156,7 +157,8 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             Message = request.Mode == ProjectLaunchMode.Debug
                 ? string.Join(" | ", new[] { request.BootstrapCommand, request.DebugConfigurationName }
                     .Where(value => !string.IsNullOrWhiteSpace(value)))
-                : request.LaunchCommand
+                : string.Join(" | ", new[] { request.LaunchCommand, request.DeviceSelection?.DisplayName }
+                    .Where(value => !string.IsNullOrWhiteSpace(value)))
         });
 
         return steps;
@@ -342,6 +344,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             LaunchCommand = job.LaunchCommand,
             BootstrapCommand = job.BootstrapCommand,
             DebugConfigurationName = job.DebugConfigurationName,
+            DeviceSelection = CloneDeviceSelection(job.DeviceSelection),
             Status = job.Status,
             SessionId = job.SessionId,
             ExitCode = job.ExitCode,
@@ -370,5 +373,21 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
                 })
             ]
         };
+    }
+
+    private static VirtualDeviceLaunchSelection? CloneDeviceSelection(VirtualDeviceLaunchSelection? selection)
+    {
+        return selection is null
+            ? null
+            : new VirtualDeviceLaunchSelection
+            {
+                CatalogKind = selection.CatalogKind,
+                TargetPlatform = selection.TargetPlatform,
+                DeviceId = selection.DeviceId,
+                ProfileId = selection.ProfileId,
+                DisplayName = selection.DisplayName,
+                StartBeforeLaunch = selection.StartBeforeLaunch,
+                ReuseRunningDevice = selection.ReuseRunningDevice
+            };
     }
 }

--- a/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
@@ -236,7 +236,8 @@ public sealed class RemoteViewerSessionService : IRemoteViewerSessionService
             JobId = target.JobId,
             SessionId = target.SessionId,
             WindowTitle = target.WindowTitle,
-            DeviceProfile = target.DeviceProfile
+            VirtualDeviceId = target.VirtualDeviceId,
+            VirtualDeviceProfileId = target.VirtualDeviceProfileId
         };
     }
 

--- a/AgentDeck.Runner/Services/VirtualDeviceCatalogService.cs
+++ b/AgentDeck.Runner/Services/VirtualDeviceCatalogService.cs
@@ -1,0 +1,87 @@
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+/// <inheritdoc />
+public sealed class VirtualDeviceCatalogService : IVirtualDeviceCatalogService
+{
+    private readonly RunnerHostPlatform _hostPlatform = DetectHostPlatform();
+
+    public IReadOnlyList<VirtualDeviceCatalogSnapshot> GetCatalogs()
+    {
+        return VirtualDeviceCatalog.GetCatalogs(_hostPlatform)
+            .Select(CloneSnapshot)
+            .ToArray();
+    }
+
+    public VirtualDeviceCatalogSnapshot? GetCatalog(VirtualDeviceCatalogKind catalogKind)
+    {
+        var catalog = VirtualDeviceCatalog.GetCatalogs(_hostPlatform)
+            .FirstOrDefault(snapshot => snapshot.CatalogKind == catalogKind);
+
+        return catalog is null ? null : CloneSnapshot(catalog);
+    }
+
+    private static RunnerHostPlatform DetectHostPlatform()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return RunnerHostPlatform.Windows;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return RunnerHostPlatform.MacOS;
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return RunnerHostPlatform.Linux;
+        }
+
+        return RunnerHostPlatform.Unknown;
+    }
+
+    private static VirtualDeviceCatalogSnapshot CloneSnapshot(VirtualDeviceCatalogSnapshot snapshot)
+    {
+        return new VirtualDeviceCatalogSnapshot
+        {
+            CatalogKind = snapshot.CatalogKind,
+            HostPlatform = snapshot.HostPlatform,
+            CapturedAt = DateTimeOffset.UtcNow,
+            Profiles =
+            [
+                .. snapshot.Profiles.Select(profile => new VirtualDeviceProfile
+                {
+                    Id = profile.Id,
+                    CatalogKind = profile.CatalogKind,
+                    TargetPlatform = profile.TargetPlatform,
+                    DisplayName = profile.DisplayName,
+                    FormFactor = profile.FormFactor,
+                    PlatformVersion = profile.PlatformVersion,
+                    Width = profile.Width,
+                    Height = profile.Height,
+                    IsDefault = profile.IsDefault,
+                    Notes = profile.Notes
+                })
+            ],
+            Devices =
+            [
+                .. snapshot.Devices.Select(device => new VirtualDeviceInstance
+                {
+                    Id = device.Id,
+                    ProfileId = device.ProfileId,
+                    CatalogKind = device.CatalogKind,
+                    TargetPlatform = device.TargetPlatform,
+                    DisplayName = device.DisplayName,
+                    State = device.State,
+                    IsAvailableForLaunch = device.IsAvailableForLaunch,
+                    MachineId = device.MachineId,
+                    MachineName = device.MachineName,
+                    Notes = device.Notes
+                })
+            ]
+        };
+    }
+}

--- a/AgentDeck.Shared/Enums/VirtualDeviceCatalogKind.cs
+++ b/AgentDeck.Shared/Enums/VirtualDeviceCatalogKind.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Catalog family used to organize virtual development devices.</summary>
+public enum VirtualDeviceCatalogKind
+{
+    AndroidEmulator,
+    AppleSimulator
+}

--- a/AgentDeck.Shared/Enums/VirtualDeviceFormFactor.cs
+++ b/AgentDeck.Shared/Enums/VirtualDeviceFormFactor.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Basic device form factor for emulator and simulator profiles.</summary>
+public enum VirtualDeviceFormFactor
+{
+    Phone,
+    Tablet,
+    Desktop
+}

--- a/AgentDeck.Shared/Enums/VirtualDeviceState.cs
+++ b/AgentDeck.Shared/Enums/VirtualDeviceState.cs
@@ -1,0 +1,12 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Observed lifecycle state for a discovered emulator or simulator instance.</summary>
+public enum VirtualDeviceState
+{
+    Unknown,
+    Available,
+    Booting,
+    Running,
+    Busy,
+    Unavailable
+}

--- a/AgentDeck.Shared/Models/CreateOrchestrationJobRequest.cs
+++ b/AgentDeck.Shared/Models/CreateOrchestrationJobRequest.cs
@@ -20,4 +20,5 @@ public sealed class CreateOrchestrationJobRequest
     public string? LaunchCommand { get; init; }
     public string? BootstrapCommand { get; init; }
     public string? DebugConfigurationName { get; init; }
+    public VirtualDeviceLaunchSelection? DeviceSelection { get; init; }
 }

--- a/AgentDeck.Shared/Models/OrchestrationJob.cs
+++ b/AgentDeck.Shared/Models/OrchestrationJob.cs
@@ -21,6 +21,7 @@ public sealed class OrchestrationJob
     public string? LaunchCommand { get; init; }
     public string? BootstrapCommand { get; init; }
     public string? DebugConfigurationName { get; init; }
+    public VirtualDeviceLaunchSelection? DeviceSelection { get; init; }
     public OrchestrationJobStatus Status { get; set; } = OrchestrationJobStatus.Queued;
     public string? SessionId { get; set; }
     public int? ExitCode { get; set; }

--- a/AgentDeck.Shared/Models/ProjectLaunchProfile.cs
+++ b/AgentDeck.Shared/Models/ProjectLaunchProfile.cs
@@ -19,6 +19,7 @@ public sealed class ProjectLaunchProfile
     public bool RequiresVsCode { get; init; }
     public bool RequiresEmulator { get; init; }
     public bool RequiresSimulator { get; init; }
-    public string? DeviceProfile { get; init; }
+    public VirtualDeviceCatalogKind? DeviceCatalog { get; init; }
+    public string? DefaultDeviceProfileId { get; init; }
     public string? Notes { get; init; }
 }

--- a/AgentDeck.Shared/Models/ProjectTemplateCatalog.cs
+++ b/AgentDeck.Shared/Models/ProjectTemplateCatalog.cs
@@ -51,6 +51,18 @@ public static class ProjectTemplateCatalog
         var requiresEmulator = target.Platform == ApplicationTargetPlatform.Android;
         var requiresSimulator = target.Platform == ApplicationTargetPlatform.iOS;
         var launchDriver = requiresVsCode ? ProjectLaunchDriver.VsCode : ProjectLaunchDriver.DirectCommand;
+        VirtualDeviceCatalogKind? deviceCatalog = target.Platform switch
+        {
+            ApplicationTargetPlatform.Android => VirtualDeviceCatalogKind.AndroidEmulator,
+            ApplicationTargetPlatform.iOS => VirtualDeviceCatalogKind.AppleSimulator,
+            _ => null
+        };
+        var defaultDeviceProfileId = target.Platform switch
+        {
+            ApplicationTargetPlatform.Android => "android-phone-default",
+            ApplicationTargetPlatform.iOS => "apple-iphone-default",
+            _ => null
+        };
 
         return new ProjectLaunchProfile
         {
@@ -67,6 +79,8 @@ public static class ProjectTemplateCatalog
             RequiresVsCode = requiresVsCode,
             RequiresEmulator = requiresEmulator,
             RequiresSimulator = requiresSimulator,
+            DeviceCatalog = deviceCatalog,
+            DefaultDeviceProfileId = defaultDeviceProfileId,
             Notes = BuildLaunchNotes(target, mode, requiresEmulator, requiresSimulator)
         };
     }

--- a/AgentDeck.Shared/Models/RemoteViewerSession.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerSession.cs
@@ -25,7 +25,8 @@ public sealed class RemoteViewerSession
             JobId = other.Target.JobId,
             SessionId = other.Target.SessionId,
             WindowTitle = other.Target.WindowTitle,
-            DeviceProfile = other.Target.DeviceProfile
+            VirtualDeviceId = other.Target.VirtualDeviceId,
+            VirtualDeviceProfileId = other.Target.VirtualDeviceProfileId
         };
         Provider = other.Provider;
         Status = other.Status;

--- a/AgentDeck.Shared/Models/RemoteViewerTarget.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerTarget.cs
@@ -10,5 +10,6 @@ public sealed class RemoteViewerTarget
     public string? JobId { get; init; }
     public string? SessionId { get; init; }
     public string? WindowTitle { get; init; }
-    public string? DeviceProfile { get; init; }
+    public string? VirtualDeviceId { get; init; }
+    public string? VirtualDeviceProfileId { get; init; }
 }

--- a/AgentDeck.Shared/Models/VirtualDeviceCatalog.cs
+++ b/AgentDeck.Shared/Models/VirtualDeviceCatalog.cs
@@ -1,0 +1,101 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Shared default catalog definitions for Android emulators and Apple simulators.</summary>
+public static class VirtualDeviceCatalog
+{
+    private static readonly IReadOnlyList<VirtualDeviceProfile> AndroidProfiles =
+    [
+        new()
+        {
+            Id = "android-phone-default",
+            CatalogKind = VirtualDeviceCatalogKind.AndroidEmulator,
+            TargetPlatform = ApplicationTargetPlatform.Android,
+            DisplayName = "Pixel Phone",
+            FormFactor = VirtualDeviceFormFactor.Phone,
+            PlatformVersion = "Android 15",
+            Width = 1080,
+            Height = 2400,
+            IsDefault = true,
+            Notes = "General-purpose Android phone emulator profile."
+        },
+        new()
+        {
+            Id = "android-tablet-default",
+            CatalogKind = VirtualDeviceCatalogKind.AndroidEmulator,
+            TargetPlatform = ApplicationTargetPlatform.Android,
+            DisplayName = "Pixel Tablet",
+            FormFactor = VirtualDeviceFormFactor.Tablet,
+            PlatformVersion = "Android 15",
+            Width = 1600,
+            Height = 2560,
+            Notes = "Tablet-oriented Android emulator profile."
+        }
+    ];
+
+    private static readonly IReadOnlyList<VirtualDeviceProfile> AppleSimulatorProfiles =
+    [
+        new()
+        {
+            Id = "apple-iphone-default",
+            CatalogKind = VirtualDeviceCatalogKind.AppleSimulator,
+            TargetPlatform = ApplicationTargetPlatform.iOS,
+            DisplayName = "iPhone Pro",
+            FormFactor = VirtualDeviceFormFactor.Phone,
+            PlatformVersion = "iOS 18",
+            Width = 1320,
+            Height = 2868,
+            IsDefault = true,
+            Notes = "Default iPhone simulator profile for debug and run flows."
+        },
+        new()
+        {
+            Id = "apple-ipad-default",
+            CatalogKind = VirtualDeviceCatalogKind.AppleSimulator,
+            TargetPlatform = ApplicationTargetPlatform.iOS,
+            DisplayName = "iPad Pro",
+            FormFactor = VirtualDeviceFormFactor.Tablet,
+            PlatformVersion = "iPadOS 18",
+            Width = 2064,
+            Height = 2752,
+            Notes = "Default iPad simulator profile for tablet validation."
+        }
+    ];
+
+    /// <summary>Gets all profiles for a specific virtual device catalog.</summary>
+    public static IReadOnlyList<VirtualDeviceProfile> GetProfiles(VirtualDeviceCatalogKind catalogKind) => catalogKind switch
+    {
+        VirtualDeviceCatalogKind.AndroidEmulator => AndroidProfiles,
+        VirtualDeviceCatalogKind.AppleSimulator => AppleSimulatorProfiles,
+        _ => []
+    };
+
+    /// <summary>Gets a catalog snapshot template for a specific runner host platform.</summary>
+    public static IReadOnlyList<VirtualDeviceCatalogSnapshot> GetCatalogs(RunnerHostPlatform hostPlatform)
+    {
+        var catalogs = new List<VirtualDeviceCatalogSnapshot>();
+
+        if (hostPlatform is RunnerHostPlatform.Windows or RunnerHostPlatform.Linux or RunnerHostPlatform.MacOS)
+        {
+            catalogs.Add(new VirtualDeviceCatalogSnapshot
+            {
+                CatalogKind = VirtualDeviceCatalogKind.AndroidEmulator,
+                HostPlatform = hostPlatform,
+                Profiles = AndroidProfiles
+            });
+        }
+
+        if (hostPlatform == RunnerHostPlatform.MacOS)
+        {
+            catalogs.Add(new VirtualDeviceCatalogSnapshot
+            {
+                CatalogKind = VirtualDeviceCatalogKind.AppleSimulator,
+                HostPlatform = hostPlatform,
+                Profiles = AppleSimulatorProfiles
+            });
+        }
+
+        return catalogs;
+    }
+}

--- a/AgentDeck.Shared/Models/VirtualDeviceCatalogSnapshot.cs
+++ b/AgentDeck.Shared/Models/VirtualDeviceCatalogSnapshot.cs
@@ -1,0 +1,13 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Catalog of supported device profiles and discovered instances for one provider family.</summary>
+public sealed class VirtualDeviceCatalogSnapshot
+{
+    public VirtualDeviceCatalogKind CatalogKind { get; init; }
+    public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Unknown;
+    public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
+    public IReadOnlyList<VirtualDeviceProfile> Profiles { get; init; } = [];
+    public IReadOnlyList<VirtualDeviceInstance> Devices { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/VirtualDeviceInstance.cs
+++ b/AgentDeck.Shared/Models/VirtualDeviceInstance.cs
@@ -1,0 +1,18 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Observed emulator or simulator instance discovered on a runner machine.</summary>
+public sealed class VirtualDeviceInstance
+{
+    public string Id { get; init; } = string.Empty;
+    public string ProfileId { get; init; } = string.Empty;
+    public VirtualDeviceCatalogKind CatalogKind { get; init; }
+    public ApplicationTargetPlatform TargetPlatform { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public VirtualDeviceState State { get; init; } = VirtualDeviceState.Unknown;
+    public bool IsAvailableForLaunch { get; init; }
+    public string? MachineId { get; init; }
+    public string? MachineName { get; init; }
+    public string? Notes { get; init; }
+}

--- a/AgentDeck.Shared/Models/VirtualDeviceLaunchSelection.cs
+++ b/AgentDeck.Shared/Models/VirtualDeviceLaunchSelection.cs
@@ -1,0 +1,18 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Launch-time device selection for emulator-backed and simulator-backed targets.</summary>
+public sealed class VirtualDeviceLaunchSelection
+{
+    public VirtualDeviceCatalogKind CatalogKind { get; init; }
+    public ApplicationTargetPlatform TargetPlatform { get; init; }
+    public string? DeviceId { get; init; }
+    public string? ProfileId { get; init; }
+    public string? DisplayName { get; init; }
+    public bool StartBeforeLaunch { get; init; } = true;
+    public bool ReuseRunningDevice { get; init; } = true;
+
+    /// <summary>True when the selection names a concrete device instance or a device profile to launch.</summary>
+    public bool HasTarget => !string.IsNullOrWhiteSpace(DeviceId) || !string.IsNullOrWhiteSpace(ProfileId);
+}

--- a/AgentDeck.Shared/Models/VirtualDeviceProfile.cs
+++ b/AgentDeck.Shared/Models/VirtualDeviceProfile.cs
@@ -1,0 +1,18 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Selectable emulator or simulator profile definition.</summary>
+public sealed class VirtualDeviceProfile
+{
+    public string Id { get; init; } = string.Empty;
+    public VirtualDeviceCatalogKind CatalogKind { get; init; }
+    public ApplicationTargetPlatform TargetPlatform { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public VirtualDeviceFormFactor FormFactor { get; init; }
+    public string PlatformVersion { get; init; } = string.Empty;
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public bool IsDefault { get; init; }
+    public string? Notes { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The runner also now exposes a first-pass orchestration job API, separate from te
 
 The runner now also exposes a first-pass remote viewer API with provider capabilities and viewer-session records distinct from both jobs and terminal sessions. This creates a dedicated place to model full-desktop, window, emulator/simulator, and VS Code viewing before actual VNC/RDP/platform-capture implementations are wired in.
 
+The shared model now also includes first-pass virtual device catalogs for Android emulators and Apple simulators, plus launch-selection contracts that can be attached to orchestration jobs. The runner exposes `/api/virtual-devices/catalogs` so later worker-specific emulator discovery and startup logic can plug into a stable API surface.
+
 ### Machine Capabilities
 
 The **Machine Setup** section can detect whether the selected machine has these supported tools available:


### PR DESCRIPTION
## Summary
- add shared virtual-device contracts for Android emulator and Apple simulator profiles, discovery snapshots, and launch selections
- wire launch profiles and orchestration jobs to carry explicit device-selection metadata
- add a runner-side read-only /api/virtual-devices/catalogs API for platform-filtered catalog snapshots

## Validation
- dotnet build AgentDeck.Shared\\AgentDeck.Shared.csproj -nologo
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -nologo
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -nologo
- dotnet build AgentDeck\\AgentDeck.csproj -f net10.0-windows10.0.19041.0 -nologo

Closes #102