### PR TITLE
Add project orchestration UI

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -347,6 +347,94 @@ app.MapGet("/api/machines/{machineId}/capabilities", async (string machineId, Ht
     }
 });
 
+app.MapGet("/api/machines/{machineId}/orchestration/jobs", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        return Results.Ok(await runners.GetOrchestrationJobsAsync(machineId, cancellationToken));
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.NotFound(new { message = ex.Message });
+    }
+});
+
+app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machineId, CreateOrchestrationJobRequest request, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        return Results.Ok(await runners.QueueOrchestrationJobAsync(machineId, request, GetActorId(httpContext), cancellationToken));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+});
+
+app.MapPost("/api/machines/{machineId}/orchestration/jobs/{jobId}/cancel", async (string machineId, string jobId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var job = await runners.CancelOrchestrationJobAsync(machineId, jobId, GetActorId(httpContext), cancellationToken);
+        return job is null ? Results.NotFound() : Results.Ok(job);
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+});
+
+app.MapGet("/api/machines/{machineId}/viewers/sessions", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        return Results.Ok(await runners.GetViewerSessionsAsync(machineId, cancellationToken));
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.NotFound(new { message = ex.Message });
+    }
+});
+
+app.MapGet("/api/machines/{machineId}/virtual-devices/catalogs", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        return Results.Ok(await runners.GetVirtualDeviceCatalogsAsync(machineId, cancellationToken));
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.NotFound(new { message = ex.Message });
+    }
+});
+
+app.MapPost("/api/machines/{machineId}/virtual-devices/resolve", async (string machineId, VirtualDeviceLaunchSelection selection, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var resolution = await runners.ResolveVirtualDeviceAsync(machineId, selection, cancellationToken);
+        return resolution is null ? Results.NotFound() : Results.Ok(resolution);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+});
+
 app.MapPost("/api/machines/{machineId}/capabilities/{capabilityId}/install", async (string machineId, string capabilityId, MachineCapabilityInstallRequest? request, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try

--- a/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
@@ -16,4 +16,10 @@ public interface IRunnerBrokerService
     Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string machineId, string capabilityId, MachineCapabilityInstallRequest request, string actorId, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(string machineId, string capabilityId, string actorId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<OrchestrationJob>> GetOrchestrationJobsAsync(string machineId, CancellationToken cancellationToken = default);
+    Task<OrchestrationJob?> QueueOrchestrationJobAsync(string machineId, CreateOrchestrationJobRequest request, string actorId, CancellationToken cancellationToken = default);
+    Task<OrchestrationJob?> CancelOrchestrationJobAsync(string machineId, string jobId, string actorId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<RemoteViewerSession>> GetViewerSessionsAsync(string machineId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetVirtualDeviceCatalogsAsync(string machineId, CancellationToken cancellationToken = default);
+    Task<VirtualDeviceLaunchResolution?> ResolveVirtualDeviceAsync(string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -183,6 +183,80 @@ public sealed class RunnerBrokerService : IRunnerBrokerService, IAsyncDisposable
         return await response.Content.ReadFromJsonAsync<MachineCapabilityInstallResult>(cancellationToken: cancellationToken);
     }
 
+    public async Task<IReadOnlyList<OrchestrationJob>> GetOrchestrationJobsAsync(string machineId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation("Brokering orchestration job list request for machine {MachineName} ({MachineId})", entry.Machine?.MachineName ?? machineId, machineId);
+        return await entry.HttpClient!.GetFromJsonAsync<IReadOnlyList<OrchestrationJob>>("api/orchestration/jobs", cancellationToken) ?? [];
+    }
+
+    public async Task<OrchestrationJob?> QueueOrchestrationJobAsync(string machineId, CreateOrchestrationJobRequest request, string actorId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Brokering orchestration queue for project {ProjectId} profile {LaunchProfileId} on machine {MachineName} ({MachineId}) requested by {ActorId}",
+            request.ProjectId,
+            request.LaunchProfileId,
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            actorId);
+        using var response = await CreateRunnerRequest(entry, HttpMethod.Post, "api/orchestration/jobs", actorId)
+            .WithJsonContent(request)
+            .SendAsync(entry.HttpClient!, cancellationToken);
+        await EnsureBrokerSuccessAsync(response, "queue orchestration job", cancellationToken);
+        return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
+    }
+
+    public async Task<OrchestrationJob?> CancelOrchestrationJobAsync(string machineId, string jobId, string actorId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Brokering orchestration cancel for job {JobId} on machine {MachineName} ({MachineId}) requested by {ActorId}",
+            jobId,
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            actorId);
+        using var response = await CreateRunnerRequest(entry, HttpMethod.Post, $"api/orchestration/jobs/{Uri.EscapeDataString(jobId)}/cancel", actorId)
+            .SendAsync(entry.HttpClient!, cancellationToken);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureBrokerSuccessAsync(response, "cancel orchestration job", cancellationToken);
+        return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RemoteViewerSession>> GetViewerSessionsAsync(string machineId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation("Brokering viewer session list request for machine {MachineName} ({MachineId})", entry.Machine?.MachineName ?? machineId, machineId);
+        return await entry.HttpClient!.GetFromJsonAsync<IReadOnlyList<RemoteViewerSession>>("api/viewers/sessions", cancellationToken) ?? [];
+    }
+
+    public async Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetVirtualDeviceCatalogsAsync(string machineId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation("Brokering virtual device catalog request for machine {MachineName} ({MachineId})", entry.Machine?.MachineName ?? machineId, machineId);
+        return await entry.HttpClient!.GetFromJsonAsync<IReadOnlyList<VirtualDeviceCatalogSnapshot>>("api/virtual-devices/catalogs", cancellationToken) ?? [];
+    }
+
+    public async Task<VirtualDeviceLaunchResolution?> ResolveVirtualDeviceAsync(string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation("Brokering virtual device resolution for machine {MachineName} ({MachineId})", entry.Machine?.MachineName ?? machineId, machineId);
+        using var response = await new HttpRequestMessage(HttpMethod.Post, "api/virtual-devices/resolve")
+            .WithJsonContent(selection)
+            .SendAsync(entry.HttpClient!, cancellationToken);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureBrokerSuccessAsync(response, "resolve virtual device", cancellationToken);
+        return await response.Content.ReadFromJsonAsync<VirtualDeviceLaunchResolution>(cancellationToken: cancellationToken);
+    }
+
     public async ValueTask DisposeAsync()
     {
         foreach (var entry in _entries.Values)
@@ -348,6 +422,20 @@ public sealed class RunnerBrokerService : IRunnerBrokerService, IAsyncDisposable
         request.Headers.TryAddWithoutValidation(AgentDeckHeaderNames.Actor, string.IsNullOrWhiteSpace(actorId) ? "coordinator" : actorId.Trim());
         request.Headers.TryAddWithoutValidation("User-Agent", "AgentDeck.Coordinator");
         return request;
+    }
+
+    private static async Task EnsureBrokerSuccessAsync(HttpResponseMessage response, string operation, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var responseText = await response.Content.ReadAsStringAsync(cancellationToken);
+        var message = string.IsNullOrWhiteSpace(responseText)
+            ? $"Runner {operation} request failed with HTTP {(int)response.StatusCode}."
+            : responseText;
+        throw new InvalidOperationException(message);
     }
 }
 

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -36,6 +36,7 @@
             </div>
             <div class="project-page__actions">
                 <a class="btn btn-accent" href="/">Dashboard</a>
+                <button class="btn btn-accent" @onclick="RefreshRuntimeAsync">Refresh runtime state</button>
             </div>
         </div>
 
@@ -73,13 +74,193 @@
                             <div class="project-machine-card__actions">
                                 <button class="btn btn-primary"
                                         disabled="@(!machine.IsOnline || _openingMachineId == machine.MachineId)"
-                                        @onclick="() => OpenProjectAsync(machine.MachineId)">
+                                        @onclick="() => OpenProjectAsync(machine.MachineId, navigateToSession: true)">
                                     @(_openingMachineId == machine.MachineId ? "Opening..." : "Open project")
                                 </button>
                             </div>
                         </article>
                     }
                 </div>
+            </section>
+
+            <section class="dashboard-section-card">
+                <div class="dashboard-section-card__header">
+                    <div>
+                        <h2>Launch profiles</h2>
+                        <p>Queue real run and debug jobs through the coordinator, with host selection, device selection, and live viewer/job state tied to the selected machine.</p>
+                    </div>
+                </div>
+
+                <div class="project-template-grid">
+                    @foreach (var profile in _project.Definition.LaunchProfiles.OrderBy(profile => profile.Platform).ThenBy(profile => profile.Mode).ThenBy(profile => profile.DisplayName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        var availableMachines = GetAvailableMachines(profile);
+                        var selectedMachineId = GetSelectedMachineId(profile, availableMachines);
+                        var selectedMachine = availableMachines.FirstOrDefault(machine => string.Equals(machine.MachineId, selectedMachineId, StringComparison.OrdinalIgnoreCase));
+                        var deviceChoices = GetDeviceChoices(profile, selectedMachineId);
+                        var selectedDeviceChoice = GetSelectedDeviceChoice(profile, deviceChoices);
+
+                        <article class="project-template-card">
+                            <div class="project-template-card__header">
+                                <div>
+                                    <h3>@profile.DisplayName</h3>
+                                    <p>@GetLaunchProfileSummary(profile)</p>
+                                </div>
+                                <span class="machine-badge">@profile.Platform</span>
+                            </div>
+
+                            <div class="orchestration-form">
+                                <label class="form-field">
+                                    <span class="orchestration-form__label">Machine</span>
+                                    <select class="input"
+                                            value="@selectedMachineId"
+                                            @onchange="args => OnMachineChanged(profile.Id, args.Value?.ToString())">
+                                        <option value="">Select machine</option>
+                                        @foreach (var machine in availableMachines)
+                                        {
+                                            <option value="@machine.MachineId">@machine.MachineName (@GetPlatformLabel(machine.HostPlatform))</option>
+                                        }
+                                    </select>
+                                </label>
+
+                                @if (ProfileNeedsDeviceSelection(profile))
+                                {
+                                    <label class="form-field">
+                                        <span class="orchestration-form__label">@GetDeviceLabel(profile)</span>
+                                        <select class="input"
+                                                value="@selectedDeviceChoice"
+                                                disabled="@string.IsNullOrWhiteSpace(selectedMachineId)"
+                                                @onchange="args => OnDeviceChanged(profile.Id, args.Value?.ToString())">
+                                            <option value="">Select device</option>
+                                            @foreach (var choice in deviceChoices)
+                                            {
+                                                <option value="@choice.Value">@choice.Label</option>
+                                            }
+                                        </select>
+                                    </label>
+                                    <p class="project-template-target__note">@GetDeviceStatusMessage(profile, selectedMachineId, deviceChoices.Count)</p>
+                                }
+                                else
+                                {
+                                    <p class="project-template-target__note">@GetMachineStatusMessage(profile, availableMachines.Count)</p>
+                                }
+
+                                @if (!string.IsNullOrWhiteSpace(profile.Notes))
+                                {
+                                    <p class="project-template-target__note">@profile.Notes</p>
+                                }
+
+                                <div class="project-machine-card__actions">
+                                    <button class="btn btn-primary"
+                                            disabled="@(!CanQueueProfile(profile, selectedMachineId, deviceChoices.Count))"
+                                            @onclick="() => QueueLaunchAsync(profile)">
+                                        @GetQueueButtonLabel(profile)
+                                    </button>
+                                </div>
+                            </div>
+                        </article>
+                    }
+                </div>
+            </section>
+
+            <section class="dashboard-section-card">
+                <div class="dashboard-section-card__header">
+                    <div>
+                        <h2>Live orchestration jobs</h2>
+                        <p>Real runner-backed run and debug jobs, including session IDs, viewer links, and current lifecycle state.</p>
+                    </div>
+                </div>
+
+                @if (_projectJobs.Count == 0)
+                {
+                    <p>No orchestration jobs are currently tracked for this project.</p>
+                }
+                else
+                {
+                    <div class="project-list">
+                        @foreach (var job in _projectJobs.OrderByDescending(job => job.UpdatedAt))
+                        {
+                            <article class="project-list-card">
+                                <div class="project-runtime-card__body">
+                                    <div class="project-session-card__header">
+                                        <div>
+                                            <h3>@job.LaunchProfileName</h3>
+                                            <p>@GetJobSummary(job)</p>
+                                        </div>
+                                        <span class="machine-badge">@job.Status</span>
+                                    </div>
+                                    <p class="project-template-target__note">Machine @(job.TargetMachineName ?? job.TargetMachineId ?? "unknown") • updated @job.UpdatedAt.ToLocalTime().ToString("g")</p>
+                                    @if (job.Logs.Count > 0)
+                                    {
+                                        <p class="project-template-target__note">@job.Logs.Last().Message</p>
+                                    }
+                                    <div class="project-machine-card__targets">
+                                        @if (!string.IsNullOrWhiteSpace(job.SessionId))
+                                        {
+                                            <span class="project-template-profile">Session @job.SessionId[..Math.Min(job.SessionId.Length, 8)]</span>
+                                        }
+                                        @if (!string.IsNullOrWhiteSpace(job.ViewerSessionId))
+                                        {
+                                            <span class="project-template-profile">Viewer @job.ViewerSessionId[..Math.Min(job.ViewerSessionId.Length, 8)]</span>
+                                        }
+                                        @if (job.DeviceSelection?.HasTarget == true)
+                                        {
+                                            <span class="project-template-profile">@GetDeviceSelectionLabel(job.DeviceSelection)</span>
+                                        }
+                                    </div>
+                                </div>
+                                <div class="project-runtime-card__actions">
+                                    @if (CanCancelJob(job))
+                                    {
+                                        <button class="btn btn-danger" @onclick="() => CancelJobAsync(job)">Cancel</button>
+                                    }
+                                </div>
+                            </article>
+                        }
+                    </div>
+                }
+            </section>
+
+            <section class="dashboard-section-card">
+                <div class="dashboard-section-card__header">
+                    <div>
+                        <h2>Viewer session entry points</h2>
+                        <p>Viewer sessions created by runner execution, surfaced here through the coordinator rather than direct machine access.</p>
+                    </div>
+                </div>
+
+                @if (_projectViewerSessions.Count == 0)
+                {
+                    <p>No viewer sessions are currently registered for this project.</p>
+                }
+                else
+                {
+                    <div class="project-list">
+                        @foreach (var viewer in _projectViewerSessions.OrderByDescending(viewer => viewer.UpdatedAt))
+                        {
+                            <article class="project-list-card">
+                                <div class="project-runtime-card__body">
+                                    <div class="project-session-card__header">
+                                        <div>
+                                            <h3>@viewer.Target.DisplayName</h3>
+                                            <p>@GetViewerSummary(viewer)</p>
+                                        </div>
+                                        <span class="machine-badge">@viewer.Status</span>
+                                    </div>
+                                    <p class="project-template-target__note">Machine @(viewer.MachineName ?? viewer.MachineId ?? "unknown") • updated @viewer.UpdatedAt.ToLocalTime().ToString("g")</p>
+                                    @if (!string.IsNullOrWhiteSpace(viewer.ConnectionUri))
+                                    {
+                                        <p class="project-template-target__note"><code>@viewer.ConnectionUri</code></p>
+                                    }
+                                    else if (!string.IsNullOrWhiteSpace(viewer.StatusMessage))
+                                    {
+                                        <p class="project-template-target__note">@viewer.StatusMessage</p>
+                                    }
+                                </div>
+                            </article>
+                        }
+                    </div>
+                }
             </section>
 
             <section class="dashboard-section-card">
@@ -134,12 +315,12 @@
                             <a class="project-session-card project-session-card--link" href="/project-sessions/@Uri.EscapeDataString(session.Id)">
                                 <div class="project-session-card__header">
                                     <div>
-                                        <h3>@session.MachineName</h3>
+                                        <h3>@(session.MachineName ?? "Coordinator session")</h3>
                                         <p>@GetControllerSummary(session)</p>
                                     </div>
                                     <span class="machine-badge">@session.Surfaces.Count tabs</span>
                                 </div>
-                                <p class="project-session-card__meta">Updated @session.UpdatedAt.ToLocalTime().ToString("g")</p>
+                                <p class="project-session-card__meta">@GetProjectSessionMeta(session)</p>
                             </a>
                         }
                     </div>
@@ -152,11 +333,19 @@
 @code {
     [Parameter] public string ProjectId { get; set; } = string.Empty;
 
+    private readonly Dictionary<string, string?> _selectedMachineByProfileId = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string?> _selectedDeviceByProfileId = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, IReadOnlyList<VirtualDeviceCatalogSnapshot>> _deviceCatalogsByMachineId = new(StringComparer.OrdinalIgnoreCase);
     private CompanionDashboardState _dashboard = new();
     private CompanionProjectSummary? _project;
     private IReadOnlyList<ProjectSessionRecord> _projectSessions = [];
+    private IReadOnlyList<OrchestrationJob> _projectJobs = [];
+    private IReadOnlyList<RemoteViewerSession> _projectViewerSessions = [];
     private bool _loading = true;
     private string? _openingMachineId;
+    private string? _queueingProfileId;
+    private string? _cancellingJobId;
+    private string? _coordinatorUrl;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -168,12 +357,21 @@
         _loading = true;
         try
         {
+            var settings = await SettingsService.LoadAsync();
+            _coordinatorUrl = settings.CoordinatorUrl;
             _dashboard = await DashboardState.BuildAsync();
             _project = _dashboard.Projects.FirstOrDefault(project =>
                 string.Equals(project.Definition.Id, ProjectId, StringComparison.OrdinalIgnoreCase));
             _projectSessions = _dashboard.ProjectSessions
                 .Where(session => string.Equals(session.ProjectId, ProjectId, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
+
+            if (_project is not null)
+            {
+                InitializeProfileSelections();
+                await EnsureDeviceCatalogsAsync();
+                await LoadRuntimeStateAsync();
+            }
         }
         finally
         {
@@ -181,24 +379,141 @@
         }
     }
 
-    private async Task OpenProjectAsync(string machineId)
+    private async Task RefreshRuntimeAsync()
     {
         if (_project is null)
         {
             return;
         }
 
-        var settings = await SettingsService.LoadAsync();
-        if (string.IsNullOrWhiteSpace(settings.CoordinatorUrl))
+        try
         {
-            Toasts.Show("Configure a coordinator URL before opening projects.", ToastKind.Warning);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+    }
+
+    private void InitializeProfileSelections()
+    {
+        if (_project is null)
+        {
+            return;
+        }
+
+        foreach (var profile in _project.Definition.LaunchProfiles)
+        {
+            if (_selectedMachineByProfileId.ContainsKey(profile.Id))
+            {
+                continue;
+            }
+
+            var availableMachines = GetAvailableMachines(profile);
+            _selectedMachineByProfileId[profile.Id] = availableMachines.FirstOrDefault()?.MachineId;
+        }
+    }
+
+    private IReadOnlyList<CompanionMachineSummary> GetAvailableMachines(ProjectLaunchProfile profile)
+    {
+        return _dashboard.Machines
+            .Where(machine => machine.IsOnline && machine.SupportedTargets.Any(target =>
+                target.Platform == profile.Platform &&
+                target.Status == MachineTargetSupportStatus.Supported))
+            .OrderByDescending(machine => string.Equals(machine.MachineId, profile.PreferredMachineId, StringComparison.OrdinalIgnoreCase))
+            .ThenBy(machine => machine.MachineName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private string? GetSelectedMachineId(ProjectLaunchProfile profile, IReadOnlyList<CompanionMachineSummary> availableMachines)
+    {
+        if (_selectedMachineByProfileId.TryGetValue(profile.Id, out var machineId) &&
+            availableMachines.Any(machine => string.Equals(machine.MachineId, machineId, StringComparison.OrdinalIgnoreCase)))
+        {
+            return machineId;
+        }
+
+        var defaultMachineId = availableMachines.FirstOrDefault()?.MachineId;
+        _selectedMachineByProfileId[profile.Id] = defaultMachineId;
+        return defaultMachineId;
+    }
+
+    private async Task EnsureDeviceCatalogsAsync()
+    {
+        if (_project is null || string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            return;
+        }
+
+        foreach (var profile in _project.Definition.LaunchProfiles.Where(ProfileNeedsDeviceSelection))
+        {
+            if (!_selectedMachineByProfileId.TryGetValue(profile.Id, out var machineId) || string.IsNullOrWhiteSpace(machineId))
+            {
+                continue;
+            }
+
+            if (_deviceCatalogsByMachineId.ContainsKey(machineId))
+            {
+                continue;
+            }
+
+            _deviceCatalogsByMachineId[machineId] = await CoordinatorClient.GetMachineVirtualDeviceCatalogsAsync(_coordinatorUrl, machineId);
+        }
+    }
+
+    private async Task LoadRuntimeStateAsync()
+    {
+        if (_project is null || string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            _projectJobs = [];
+            _projectViewerSessions = [];
+            return;
+        }
+
+        var machinesToQuery = _dashboard.Machines
+            .Where(machine => machine.IsOnline && (
+                _project.Definition.Workspaces.Any(workspace => string.Equals(workspace.MachineId, machine.MachineId, StringComparison.OrdinalIgnoreCase)) ||
+                _project.Definition.LaunchProfiles.Any(profile => GetAvailableMachines(profile).Any(candidate => string.Equals(candidate.MachineId, machine.MachineId, StringComparison.OrdinalIgnoreCase)))))
+            .Select(machine => machine.MachineId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var jobs = new List<OrchestrationJob>();
+        var viewers = new List<RemoteViewerSession>();
+
+        foreach (var machineId in machinesToQuery)
+        {
+            jobs.AddRange((await CoordinatorClient.GetMachineOrchestrationJobsAsync(_coordinatorUrl, machineId))
+                .Where(job => string.Equals(job.ProjectId, ProjectId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        var jobIds = jobs.Select(job => job.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var machineId in machinesToQuery)
+        {
+            viewers.AddRange((await CoordinatorClient.GetMachineViewerSessionsAsync(_coordinatorUrl, machineId))
+                .Where(viewer => !string.IsNullOrWhiteSpace(viewer.JobId) && jobIds.Contains(viewer.JobId)));
+        }
+
+        _projectJobs = jobs
+            .OrderByDescending(job => job.UpdatedAt)
+            .ToArray();
+        _projectViewerSessions = viewers
+            .OrderByDescending(viewer => viewer.UpdatedAt)
+            .ToArray();
+    }
+
+    private async Task OpenProjectAsync(string machineId, bool navigateToSession)
+    {
+        if (_project is null || string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
             return;
         }
 
         _openingMachineId = machineId;
         try
         {
-            var result = await CoordinatorClient.OpenProjectOnMachineAsync(settings.CoordinatorUrl, _project.Definition.Id, machineId);
+            var result = await CoordinatorClient.OpenProjectOnMachineAsync(_coordinatorUrl, _project.Definition.Id, machineId);
             if (result is null)
             {
                 Toasts.Show("The coordinator could not open that project on the selected machine.", ToastKind.Error);
@@ -208,7 +523,11 @@
             SessionState.AddOrUpdate(result.Session);
             ActiveSession.SetActiveSession(result.Session.Id);
             Toasts.Show($"Opened {result.Project.Name} on {result.Workspace.MachineName ?? result.Workspace.MachineId}.", ToastKind.Success);
-            Nav.NavigateTo($"/project-sessions/{Uri.EscapeDataString(result.ProjectSession.Id)}");
+            await LoadAsync();
+            if (navigateToSession)
+            {
+                Nav.NavigateTo($"/project-sessions/{Uri.EscapeDataString(result.ProjectSession.Id)}");
+            }
         }
         catch (Exception ex)
         {
@@ -220,10 +539,257 @@
         }
     }
 
+    private async Task QueueLaunchAsync(ProjectLaunchProfile profile)
+    {
+        if (_project is null || string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            return;
+        }
+
+        var availableMachines = GetAvailableMachines(profile);
+        var machineId = GetSelectedMachineId(profile, availableMachines);
+        if (string.IsNullOrWhiteSpace(machineId))
+        {
+            Toasts.Show("Select a machine before launching this profile.", ToastKind.Warning);
+            return;
+        }
+
+        _queueingProfileId = profile.Id;
+        try
+        {
+            var workspace = _project.Definition.Workspaces.FirstOrDefault(candidate =>
+                string.Equals(candidate.MachineId, machineId, StringComparison.OrdinalIgnoreCase));
+            if (workspace is null)
+            {
+                await OpenProjectAsync(machineId, navigateToSession: false);
+                workspace = _project?.Definition.Workspaces.FirstOrDefault(candidate =>
+                    string.Equals(candidate.MachineId, machineId, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (workspace is null)
+            {
+                throw new InvalidOperationException("The project workspace is not available on the selected machine.");
+            }
+
+            VirtualDeviceLaunchSelection? deviceSelection = null;
+            if (ProfileNeedsDeviceSelection(profile))
+            {
+                deviceSelection = await BuildDeviceSelectionAsync(profile, machineId);
+            }
+
+            var machine = availableMachines.FirstOrDefault(candidate => string.Equals(candidate.MachineId, machineId, StringComparison.OrdinalIgnoreCase));
+            var request = new CreateOrchestrationJobRequest
+            {
+                ProjectId = _project.Definition.Id,
+                ProjectName = _project.Definition.Name,
+                LaunchProfileId = profile.Id,
+                LaunchProfileName = profile.DisplayName,
+                WorkingDirectory = workspace.ProjectPath,
+                Platform = profile.Platform,
+                Mode = profile.Mode,
+                LaunchDriver = profile.LaunchDriver,
+                TargetMachineRole = machine?.Role ?? RunnerMachineRole.Worker,
+                TargetMachineId = machineId,
+                TargetMachineName = machine?.MachineName,
+                BuildCommand = profile.BuildCommand,
+                LaunchCommand = profile.LaunchCommand,
+                BootstrapCommand = profile.BootstrapCommand,
+                DebugConfigurationName = profile.DebugConfigurationName,
+                DeviceSelection = deviceSelection
+            };
+
+            var job = await CoordinatorClient.QueueMachineOrchestrationJobAsync(_coordinatorUrl, machineId, request);
+            if (job is null)
+            {
+                Toasts.Show("The coordinator could not queue that launch.", ToastKind.Error);
+                return;
+            }
+
+            Toasts.Show($"Queued {profile.DisplayName} on {machine?.MachineName ?? machineId}.", ToastKind.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _queueingProfileId = null;
+        }
+    }
+
+    private async Task<VirtualDeviceLaunchSelection?> BuildDeviceSelectionAsync(ProjectLaunchProfile profile, string machineId)
+    {
+        var selectedValue = GetSelectedDeviceChoice(profile, GetDeviceChoices(profile, machineId));
+        if (string.IsNullOrWhiteSpace(selectedValue) || profile.DeviceCatalog is null)
+        {
+            throw new InvalidOperationException("Select a device or profile before launching this target.");
+        }
+
+        var selection = selectedValue.StartsWith("device:", StringComparison.OrdinalIgnoreCase)
+            ? new VirtualDeviceLaunchSelection
+            {
+                CatalogKind = profile.DeviceCatalog.Value,
+                TargetPlatform = profile.Platform,
+                DeviceId = selectedValue["device:".Length..]
+            }
+            : new VirtualDeviceLaunchSelection
+            {
+                CatalogKind = profile.DeviceCatalog.Value,
+                TargetPlatform = profile.Platform,
+                ProfileId = selectedValue["profile:".Length..]
+            };
+
+        var resolution = await CoordinatorClient.ResolveMachineVirtualDeviceAsync(_coordinatorUrl!, machineId, selection);
+        if (resolution is null || !resolution.CanLaunch)
+        {
+            throw new InvalidOperationException(resolution?.Message ?? "The selected device could not be resolved for launch.");
+        }
+
+        return resolution.Selection;
+    }
+
+    private async Task CancelJobAsync(OrchestrationJob job)
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl) || string.IsNullOrWhiteSpace(job.TargetMachineId))
+        {
+            return;
+        }
+
+        _cancellingJobId = job.Id;
+        try
+        {
+            await CoordinatorClient.CancelMachineOrchestrationJobAsync(_coordinatorUrl, job.TargetMachineId, job.Id);
+            Toasts.Show($"Cancellation requested for {job.LaunchProfileName}.", ToastKind.Info);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _cancellingJobId = null;
+        }
+    }
+
+    private IReadOnlyList<DeviceChoice> GetDeviceChoices(ProjectLaunchProfile profile, string? machineId)
+    {
+        if (string.IsNullOrWhiteSpace(machineId) ||
+            !_deviceCatalogsByMachineId.TryGetValue(machineId, out var snapshots) ||
+            profile.DeviceCatalog is null)
+        {
+            return [];
+        }
+
+        var snapshot = snapshots.FirstOrDefault(candidate => candidate.CatalogKind == profile.DeviceCatalog.Value);
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        return snapshot.Devices
+            .Select(device => new DeviceChoice($"device:{device.Id}", $"{device.DisplayName} ({device.State})"))
+            .Concat(snapshot.Profiles.Select(profileChoice => new DeviceChoice($"profile:{profileChoice.Id}", $"{profileChoice.DisplayName} profile")))
+            .ToArray();
+    }
+
+    private string? GetSelectedDeviceChoice(ProjectLaunchProfile profile, IReadOnlyList<DeviceChoice> choices)
+    {
+        if (_selectedDeviceByProfileId.TryGetValue(profile.Id, out var selectedValue) &&
+            choices.Any(choice => string.Equals(choice.Value, selectedValue, StringComparison.OrdinalIgnoreCase)))
+        {
+            return selectedValue;
+        }
+
+        var defaultValue = choices.FirstOrDefault(choice =>
+            string.Equals(choice.Value, $"profile:{profile.DefaultDeviceProfileId}", StringComparison.OrdinalIgnoreCase))?.Value
+            ?? choices.FirstOrDefault()?.Value;
+        _selectedDeviceByProfileId[profile.Id] = defaultValue;
+        return defaultValue;
+    }
+
+    private async Task OnMachineChanged(string profileId, string? machineId)
+    {
+        _selectedMachineByProfileId[profileId] = string.IsNullOrWhiteSpace(machineId) ? null : machineId;
+        _selectedDeviceByProfileId.Remove(profileId);
+        if (!string.IsNullOrWhiteSpace(machineId) &&
+            !_deviceCatalogsByMachineId.ContainsKey(machineId) &&
+            !string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            _deviceCatalogsByMachineId[machineId] = await CoordinatorClient.GetMachineVirtualDeviceCatalogsAsync(_coordinatorUrl, machineId);
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task OnDeviceChanged(string profileId, string? deviceValue)
+    {
+        _selectedDeviceByProfileId[profileId] = string.IsNullOrWhiteSpace(deviceValue) ? null : deviceValue;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    private bool ProfileNeedsDeviceSelection(ProjectLaunchProfile profile) =>
+        profile.RequiresEmulator || profile.RequiresSimulator;
+
+    private bool CanQueueProfile(ProjectLaunchProfile profile, string? selectedMachineId, int deviceChoiceCount)
+    {
+        if (_queueingProfileId == profile.Id || string.IsNullOrWhiteSpace(selectedMachineId))
+        {
+            return false;
+        }
+
+        return !ProfileNeedsDeviceSelection(profile) || deviceChoiceCount > 0;
+    }
+
+    private string GetQueueButtonLabel(ProjectLaunchProfile profile)
+    {
+        if (_queueingProfileId == profile.Id)
+        {
+            return "Queueing...";
+        }
+
+        return profile.Mode == ProjectLaunchMode.Debug ? "Debug" : "Run";
+    }
+
+    private static string GetLaunchProfileSummary(ProjectLaunchProfile profile)
+    {
+        var machineSummary = profile.RequiresVsCode ? "VS Code-backed" : "direct command";
+        return $"{profile.Mode} • {machineSummary}";
+    }
+
+    private string GetMachineStatusMessage(ProjectLaunchProfile profile, int machineCount) =>
+        machineCount == 0
+            ? $"No ready machine currently advertises {profile.Platform}."
+            : $"{machineCount} ready machine(s) can host this profile.";
+
+    private string GetDeviceStatusMessage(ProjectLaunchProfile profile, string? machineId, int deviceChoiceCount)
+    {
+        if (string.IsNullOrWhiteSpace(machineId))
+        {
+            return "Choose a machine before selecting a device.";
+        }
+
+        return deviceChoiceCount == 0
+            ? $"No {GetDeviceLabel(profile).ToLowerInvariant()} options are currently available on that machine."
+            : $"{deviceChoiceCount} {GetDeviceLabel(profile).ToLowerInvariant()} option(s) discovered on that machine.";
+    }
+
+    private static string GetDeviceLabel(ProjectLaunchProfile profile) =>
+        profile.RequiresSimulator ? "Simulator" : "Emulator";
+
     private string GetControllerSummary(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.CompanionId)
             ? "No controller companion recorded"
             : $"Controller {session.CompanionId}";
+
+    private string GetProjectSessionMeta(ProjectSessionRecord session)
+    {
+        var viewerSummary = session.ViewerCompanionIds.Count == 1
+            ? "1 viewer"
+            : $"{session.ViewerCompanionIds.Count} viewers";
+        return $"{viewerSummary} • updated {session.UpdatedAt.ToLocalTime():g}";
+    }
 
     private string GetMachineTargetSummary(CompanionMachineSummary machine)
     {
@@ -235,6 +801,33 @@
             ? "No supported targets advertised yet."
             : $"Ready targets: {string.Join(", ", readyTargets)}";
     }
+
+    private string GetJobSummary(OrchestrationJob job)
+    {
+        var mode = job.Mode == ProjectLaunchMode.Debug ? "Debug" : "Run";
+        return $"{mode} • {job.Platform}";
+    }
+
+    private string GetViewerSummary(RemoteViewerSession viewer)
+    {
+        var label = viewer.Target.Kind switch
+        {
+            RemoteViewerTargetKind.Desktop => "Desktop",
+            RemoteViewerTargetKind.Window => "Window",
+            RemoteViewerTargetKind.VsCode => "VS Code",
+            RemoteViewerTargetKind.Emulator => "Emulator",
+            RemoteViewerTargetKind.Simulator => "Simulator",
+            _ => "Viewer"
+        };
+        return $"{label} • {viewer.Provider}";
+    }
+
+    private static string GetDeviceSelectionLabel(VirtualDeviceLaunchSelection selection) =>
+        selection.DisplayName ?? selection.DeviceId ?? selection.ProfileId ?? "Device selection";
+
+    private bool CanCancelJob(OrchestrationJob job) =>
+        _cancellingJobId != job.Id &&
+        job.Status is OrchestrationJobStatus.Queued or OrchestrationJobStatus.Preparing or OrchestrationJobStatus.Dispatching or OrchestrationJobStatus.Running;
 
     private static string GetPlatformLabel(RunnerHostPlatform platform) => platform switch
     {
@@ -262,4 +855,6 @@
             ? "not configured"
             : definition.Repository.Url!;
     }
+
+    private sealed record DeviceChoice(string Value, string Label);
 }

--- a/AgentDeck.Core/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/CoordinatorApiClient.cs
@@ -189,6 +189,134 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         }
     }
 
+    public async Task<IReadOnlyList<OrchestrationJob>> GetMachineOrchestrationJobsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            return await httpClient.GetFromJsonAsync<IReadOnlyList<OrchestrationJob>>(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/orchestration/jobs",
+                cancellationToken) ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator orchestration lookup failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<OrchestrationJob?> QueueMachineOrchestrationJobAsync(string coordinatorUrl, string machineId, CreateOrchestrationJobRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsJsonAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/orchestration/jobs",
+                request,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator orchestration queue failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<OrchestrationJob?> CancelMachineOrchestrationJobAsync(string coordinatorUrl, string machineId, string jobId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/orchestration/jobs/{Uri.EscapeDataString(jobId)}/cancel",
+                content: null,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator orchestration cancel failed for machine {MachineId} job {JobId}", machineId, jobId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<RemoteViewerSession>> GetMachineViewerSessionsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            return await httpClient.GetFromJsonAsync<IReadOnlyList<RemoteViewerSession>>(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/sessions",
+                cancellationToken) ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator viewer session lookup failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetMachineVirtualDeviceCatalogsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            return await httpClient.GetFromJsonAsync<IReadOnlyList<VirtualDeviceCatalogSnapshot>>(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/virtual-devices/catalogs",
+                cancellationToken) ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator device catalog lookup failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<VirtualDeviceLaunchResolution?> ResolveMachineVirtualDeviceAsync(string coordinatorUrl, string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsJsonAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/virtual-devices/resolve",
+                selection,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<VirtualDeviceLaunchResolution>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator device resolution failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
     private HttpClient CreateClient(string coordinatorUrl)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(coordinatorUrl);

--- a/AgentDeck.Core/Services/ICoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/ICoordinatorApiClient.cs
@@ -20,4 +20,16 @@ public interface ICoordinatorApiClient
     Task<ProjectSessionRecord?> DetachProjectSessionAsync(string coordinatorUrl, string projectSessionId, CancellationToken cancellationToken = default);
 
     Task<ProjectSessionRecord?> UpdateProjectSessionControlAsync(string coordinatorUrl, string projectSessionId, UpdateProjectSessionControlRequest request, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OrchestrationJob>> GetMachineOrchestrationJobsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
+
+    Task<OrchestrationJob?> QueueMachineOrchestrationJobAsync(string coordinatorUrl, string machineId, CreateOrchestrationJobRequest request, CancellationToken cancellationToken = default);
+
+    Task<OrchestrationJob?> CancelMachineOrchestrationJobAsync(string coordinatorUrl, string machineId, string jobId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RemoteViewerSession>> GetMachineViewerSessionsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetMachineVirtualDeviceCatalogsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
+
+    Task<VirtualDeviceLaunchResolution?> ResolveMachineVirtualDeviceAsync(string coordinatorUrl, string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -629,6 +629,35 @@ main {
     overflow-wrap: anywhere;
 }
 
+.project-runtime-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.project-runtime-card__actions {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+}
+
+.orchestration-form {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 0.9rem;
+}
+
+.orchestration-form__label {
+    display: block;
+    margin-bottom: 0.3rem;
+    color: var(--color-subtext);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
 .surface-tabs {
     display: flex;
     flex-wrap: wrap;

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ The coordinator now also exposes a first-pass project-open flow at `/api/project
 
 The coordinator now also keeps a first-pass project-session surface registry at `/api/project-sessions` and `/api/project-sessions/{projectSessionId}/surfaces`. Project sessions are generic containers for the live tabs a project can expose over time, and the current open-project flow now creates a project session plus an initial terminal surface so later VS Code, simulator, emulator, and viewer surfaces can attach to the same shared session model.
 
+Project sessions now also model single-controller plus multi-viewer collaboration. The coordinator tracks attached companions, the active controller, and control-handoff state so only one companion can send terminal control input for a project-backed terminal at a time while other companions stay view-only until they request, force, or yield control through `/api/project-sessions/{projectSessionId}/attachments`, `/detach`, and `/control`.
+
 The runner also now exposes a first-pass orchestration job API, separate from terminal sessions, so coordinator-managed run/debug work can be queued, tracked by lifecycle status, associated with a target machine, and enriched with step/log data before full cross-machine dispatch is implemented.
 
 That orchestration layer now has real local execution paths for both direct-command run jobs and the first VS Code-backed debug jobs. Direct-command jobs build and launch on the runner, stream PTY output into job logs, and let cancellation stop the underlying process.
@@ -281,6 +283,8 @@ The runner now also exposes a remote viewer API with provider capabilities and v
 Window-, emulator-, simulator-, and VS Code-targeted viewer sessions still remain additive modeling layers above the transport. They keep their distinct target metadata, but this slice still only boots a transport for full-desktop sessions; focused capture for those narrower surfaces remains follow-up work on top of the managed helper seam.
 
 The shared model now also includes first-pass virtual device catalogs for Android emulators and Apple simulators, plus launch-selection contracts that can be attached to orchestration jobs. The runner exposes `/api/virtual-devices/catalogs` and `/api/virtual-devices/resolve`, and the catalog endpoint now performs real runner-side discovery where Android emulator or Apple simulator tooling is available. Runner capability snapshots also use those catalogs to advertise Android and iOS as distinct coordinator-visible target-readiness entries, including which device catalog backs later selection flows.
+
+The coordinator now also brokers those orchestration, viewer-session, and virtual-device APIs back out under `/api/machines/{machineId}/...`, and the companion project page now uses that control-plane path to open a project on a runner, choose a ready host for each launch profile, choose emulator/simulator targets when required, queue real run/debug jobs, inspect live job state, and list viewer-session entry points without talking to runner URLs directly.
 
 ### Machine Capabilities
 


### PR DESCRIPTION
## Summary
- broker orchestration jobs, viewer sessions, and virtual-device catalogs through the coordinator machine endpoints
- add real project launch controls to the companion with machine selection, device selection, job state, cancellation, and viewer-session entry points
- document the new coordinator-brokered orchestration and project collaboration paths

## Testing
- dotnet build AgentDeck.slnx -c Release
- dotnet test AgentDeck.slnx -c Release --no-build

Closes #116