### PR TITLE
Publish coordinator-hosted runner artifacts

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -8,6 +8,8 @@ public sealed class CoordinatorOptions
 
     public string? PublicBaseUrl { get; set; }
 
+    public string ArtifactRoot { get; set; } = "artifacts";
+
     public string DesiredRunnerVersion { get; set; } = "0.1.0-dev";
 
     public int MinimumSupportedProtocolVersion { get; set; } = 1;

--- a/AgentDeck.Coordinator/Configuration/CoordinatorUpdateManifestOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorUpdateManifestOptions.cs
@@ -8,6 +8,7 @@ public sealed class CoordinatorUpdateManifestOptions
     public string Version { get; set; } = "0.1.0-dev";
     public string Channel { get; set; } = "stable";
     public string ArtifactUrl { get; set; } = "https://example.invalid/agentdeck/runner-0.1.0-dev.zip";
+    public string? HostedArtifactPath { get; set; }
     public string? Sha256 { get; set; }
     public long? ArtifactSizeBytes { get; set; }
     public int MinimumProtocolVersion { get; set; } = 1;
@@ -21,5 +22,6 @@ public sealed class CoordinatorUpdateManifestOptions
     public string? ProvenanceUri { get; set; }
     public string? SignerId { get; set; }
     public string SignatureAlgorithm { get; set; } = RunnerUpdateManifestSigning.RsaSha256Algorithm;
+    public string? PrivateKeyPem { get; set; }
     public string? Signature { get; set; }
 }

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddOptions<CoordinatorOptions>()
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddHttpClient();
 builder.Services.AddSignalR();
+builder.Services.AddSingleton<ICoordinatorArtifactService, CoordinatorArtifactService>();
 builder.Services.AddSingleton<IRunnerDefinitionCatalogService, RunnerDefinitionCatalogService>();
 builder.Services.AddSingleton<IWorkerRegistryService, WorkerRegistryService>();
 builder.Services.AddSingleton<ICompanionRegistryService, CompanionRegistryService>();
@@ -36,6 +37,14 @@ app.Logger.LogInformation(
     coordinatorOptions.WorkerExpiry);
 
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTimeOffset.UtcNow }));
+
+app.MapGet("/artifacts/{**artifactPath}", (string artifactPath, ICoordinatorArtifactService artifacts) =>
+{
+    var physicalPath = artifacts.TryResolveArtifactPath(artifactPath);
+    return physicalPath is null
+        ? Results.NotFound()
+        : Results.File(physicalPath, "application/octet-stream", enableRangeProcessing: true);
+});
 
 app.MapPost("/api/companions/register", (RegisterCompanionRequest? request, ICompanionRegistryService companions) =>
     Results.Ok(companions.RegisterCompanion(request ?? new RegisterCompanionRequest())));

--- a/AgentDeck.Coordinator/Services/CoordinatorArtifactService.cs
+++ b/AgentDeck.Coordinator/Services/CoordinatorArtifactService.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using AgentDeck.Coordinator.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Coordinator.Services;
+
+public sealed class CoordinatorArtifactService : ICoordinatorArtifactService
+{
+    private readonly string _artifactRoot;
+
+    public CoordinatorArtifactService(IOptions<CoordinatorOptions> coordinatorOptions, IHostEnvironment hostEnvironment)
+    {
+        ArgumentNullException.ThrowIfNull(coordinatorOptions);
+        ArgumentNullException.ThrowIfNull(hostEnvironment);
+
+        var configuredRoot = coordinatorOptions.Value.ArtifactRoot;
+        if (string.IsNullOrWhiteSpace(configuredRoot))
+        {
+            throw new InvalidOperationException(
+                $"Coordinator setting '{CoordinatorOptions.SectionName}:ArtifactRoot' is required.");
+        }
+
+        _artifactRoot = Path.GetFullPath(
+            Path.IsPathRooted(configuredRoot)
+                ? configuredRoot
+                : Path.Combine(hostEnvironment.ContentRootPath, configuredRoot.Trim()));
+    }
+
+    public CoordinatorHostedArtifact ResolveHostedArtifact(string relativePath, string? publicBaseUrl)
+    {
+        var normalizedRelativePath = NormalizeRelativePath(relativePath);
+        var physicalPath = GetValidatedArtifactPath(normalizedRelativePath);
+        var fileInfo = new FileInfo(physicalPath);
+        if (!fileInfo.Exists)
+        {
+            throw new InvalidOperationException(
+                $"Coordinator hosted artifact '{normalizedRelativePath}' was not found under '{_artifactRoot}'.");
+        }
+
+        if (!Uri.TryCreate(NormalizeRequired(publicBaseUrl, $"{CoordinatorOptions.SectionName}:PublicBaseUrl"), UriKind.Absolute, out var publicBaseUri))
+        {
+            throw new InvalidOperationException(
+                $"Coordinator setting '{CoordinatorOptions.SectionName}:PublicBaseUrl' must be an absolute URI when hosted artifacts are enabled.");
+        }
+
+        return new CoordinatorHostedArtifact(
+            normalizedRelativePath,
+            physicalPath,
+            BuildDownloadUrl(publicBaseUri, normalizedRelativePath),
+            ComputeSha256(physicalPath),
+            fileInfo.Length);
+    }
+
+    public string? TryResolveArtifactPath(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var normalizedRelativePath = NormalizeRelativePath(relativePath);
+            var physicalPath = GetValidatedArtifactPath(normalizedRelativePath);
+            return File.Exists(physicalPath) ? physicalPath : null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private string GetValidatedArtifactPath(string relativePath)
+    {
+        Directory.CreateDirectory(_artifactRoot);
+
+        var candidatePath = Path.GetFullPath(
+            Path.Combine(_artifactRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var rootPrefix = _artifactRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!candidatePath.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(candidatePath, _artifactRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Coordinator hosted artifact paths must stay inside the configured artifact root.");
+        }
+
+        return candidatePath;
+    }
+
+    private static string NormalizeRelativePath(string relativePath)
+    {
+        var segments = relativePath
+            .Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0)
+        {
+            throw new InvalidOperationException("Coordinator hosted artifact paths must not be empty.");
+        }
+
+        if (segments.Any(segment => segment is "." or ".."))
+        {
+            throw new InvalidOperationException("Coordinator hosted artifact paths must not contain '.' or '..' segments.");
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private static string BuildDownloadUrl(Uri publicBaseUri, string relativePath)
+    {
+        var baseUri = publicBaseUri.ToString().TrimEnd('/');
+        var encodedPath = string.Join(
+            "/",
+            relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .Select(Uri.EscapeDataString));
+        return $"{baseUri}/artifacts/{encodedPath}";
+    }
+
+    private static string ComputeSha256(string physicalPath)
+    {
+        using var stream = File.OpenRead(physicalPath);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string NormalizeRequired(string? value, string settingName) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException($"Coordinator setting '{settingName}' is required.")
+            : value.Trim();
+}

--- a/AgentDeck.Coordinator/Services/CoordinatorHostedArtifact.cs
+++ b/AgentDeck.Coordinator/Services/CoordinatorHostedArtifact.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Coordinator.Services;
+
+public sealed record CoordinatorHostedArtifact(
+    string RelativePath,
+    string PhysicalPath,
+    string DownloadUrl,
+    string Sha256,
+    long ArtifactSizeBytes);

--- a/AgentDeck.Coordinator/Services/ICoordinatorArtifactService.cs
+++ b/AgentDeck.Coordinator/Services/ICoordinatorArtifactService.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Coordinator.Services;
+
+public interface ICoordinatorArtifactService
+{
+    CoordinatorHostedArtifact ResolveHostedArtifact(string relativePath, string? publicBaseUrl);
+
+    string? TryResolveArtifactPath(string relativePath);
+}

--- a/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
@@ -9,21 +9,24 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     private readonly RunnerUpdateManifest _desiredUpdateManifest;
     private readonly RunnerWorkflowPack _desiredWorkflowPack;
 
-    public RunnerDefinitionCatalogService(IOptions<CoordinatorOptions> coordinatorOptions)
+    public RunnerDefinitionCatalogService(
+        IOptions<CoordinatorOptions> coordinatorOptions,
+        ICoordinatorArtifactService artifactService)
     {
         var options = coordinatorOptions.Value;
         var desiredUpdateManifest = options.DesiredUpdateManifest ?? new CoordinatorUpdateManifestOptions();
         var desiredWorkflowPack = options.DesiredWorkflowPack ?? new CoordinatorWorkflowPackOptions();
         var securityPolicy = options.SecurityPolicy ?? new CoordinatorSecurityPolicyOptions();
+        var hostedArtifact = ResolveHostedArtifact(options, desiredUpdateManifest, artifactService);
 
-        _desiredUpdateManifest = new RunnerUpdateManifest
+        var unsignedManifest = new RunnerUpdateManifest
         {
             ManifestId = NormalizeRequired(desiredUpdateManifest.ManifestId, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:ManifestId"),
             Version = NormalizeRequired(desiredUpdateManifest.Version, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:Version"),
             Channel = NormalizeRequired(desiredUpdateManifest.Channel, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:Channel"),
-            ArtifactUrl = NormalizeRequired(desiredUpdateManifest.ArtifactUrl, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:ArtifactUrl"),
-            Sha256 = NormalizeOptional(desiredUpdateManifest.Sha256),
-            ArtifactSizeBytes = desiredUpdateManifest.ArtifactSizeBytes,
+            ArtifactUrl = hostedArtifact?.DownloadUrl ?? NormalizeRequired(desiredUpdateManifest.ArtifactUrl, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:ArtifactUrl"),
+            Sha256 = hostedArtifact?.Sha256 ?? NormalizeOptional(desiredUpdateManifest.Sha256),
+            ArtifactSizeBytes = hostedArtifact?.ArtifactSizeBytes ?? desiredUpdateManifest.ArtifactSizeBytes,
             MinimumProtocolVersion = desiredUpdateManifest.MinimumProtocolVersion,
             MaximumProtocolVersion = desiredUpdateManifest.MaximumProtocolVersion,
             PublishedAt = desiredUpdateManifest.PublishedAt ?? DateTimeOffset.UtcNow,
@@ -38,14 +41,23 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                     ProvenanceUri = NormalizeOptional(desiredUpdateManifest.ProvenanceUri)
                 }
                 : null,
-            Signature = HasConfiguredSignature(desiredUpdateManifest)
-                ? new RunnerUpdateManifestSignature
-                {
-                    Algorithm = NormalizeRequired(desiredUpdateManifest.SignatureAlgorithm, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignatureAlgorithm"),
-                    SignerId = NormalizeRequired(desiredUpdateManifest.SignerId, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignerId"),
-                    Value = NormalizeRequired(desiredUpdateManifest.Signature, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:Signature")
-                }
-                : null
+            Signature = null
+        };
+
+        _desiredUpdateManifest = new RunnerUpdateManifest
+        {
+            ManifestId = unsignedManifest.ManifestId,
+            Version = unsignedManifest.Version,
+            Channel = unsignedManifest.Channel,
+            ArtifactUrl = unsignedManifest.ArtifactUrl,
+            Sha256 = unsignedManifest.Sha256,
+            ArtifactSizeBytes = unsignedManifest.ArtifactSizeBytes,
+            MinimumProtocolVersion = unsignedManifest.MinimumProtocolVersion,
+            MaximumProtocolVersion = unsignedManifest.MaximumProtocolVersion,
+            PublishedAt = unsignedManifest.PublishedAt,
+            Notes = unsignedManifest.Notes,
+            Provenance = unsignedManifest.Provenance,
+            Signature = BuildManifestSignature(unsignedManifest, desiredUpdateManifest)
         };
         ValidateUpdateManifest(_desiredUpdateManifest, options.PublicBaseUrl, securityPolicy);
 
@@ -94,6 +106,55 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
         string.IsNullOrWhiteSpace(value)
             ? throw new InvalidOperationException($"Coordinator setting '{settingName}' is required.")
             : value.Trim();
+
+    private static CoordinatorHostedArtifact? ResolveHostedArtifact(
+        CoordinatorOptions options,
+        CoordinatorUpdateManifestOptions manifest,
+        ICoordinatorArtifactService artifactService)
+    {
+        ArgumentNullException.ThrowIfNull(artifactService);
+
+        return string.IsNullOrWhiteSpace(manifest.HostedArtifactPath)
+            ? null
+            : artifactService.ResolveHostedArtifact(manifest.HostedArtifactPath, options.PublicBaseUrl);
+    }
+
+    private static RunnerUpdateManifestSignature? BuildManifestSignature(
+        RunnerUpdateManifest manifest,
+        CoordinatorUpdateManifestOptions options)
+    {
+        var algorithm = NormalizeRequired(options.SignatureAlgorithm, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignatureAlgorithm");
+        if (!string.IsNullOrWhiteSpace(options.PrivateKeyPem))
+        {
+            if (!string.Equals(algorithm, RunnerUpdateManifestSigning.RsaSha256Algorithm, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Coordinator update manifest auto-signing only supports '{RunnerUpdateManifestSigning.RsaSha256Algorithm}'.");
+            }
+
+            var signerId = NormalizeRequired(options.SignerId, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignerId");
+            if (!RunnerUpdateManifestSigning.TrySignManifest(manifest, options.PrivateKeyPem, out var signatureValue, out var error))
+            {
+                throw new InvalidOperationException(error);
+            }
+
+            return new RunnerUpdateManifestSignature
+            {
+                Algorithm = algorithm,
+                SignerId = signerId,
+                Value = signatureValue
+            };
+        }
+
+        return HasConfiguredSignature(options)
+            ? new RunnerUpdateManifestSignature
+            {
+                Algorithm = algorithm,
+                SignerId = NormalizeRequired(options.SignerId, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignerId"),
+                Value = NormalizeRequired(options.Signature, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:Signature")
+            }
+            : null;
+    }
 
     private static void ValidateUpdateManifest(
         RunnerUpdateManifest manifest,

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -2,6 +2,7 @@
   "Coordinator": {
     "Port": 5001,
     "PublicBaseUrl": "http://localhost:5001",
+    "ArtifactRoot": "artifacts",
     "DesiredRunnerVersion": "0.1.0-dev",
     "MinimumSupportedProtocolVersion": 1,
     "MaximumSupportedProtocolVersion": 1,

--- a/AgentDeck.Shared/Models/RunnerUpdateManifestSigning.cs
+++ b/AgentDeck.Shared/Models/RunnerUpdateManifestSigning.cs
@@ -87,6 +87,35 @@ public static class RunnerUpdateManifestSigning
         }
     }
 
+    public static bool TrySignManifest(RunnerUpdateManifest manifest, string privateKeyPem, out string signatureValue, out string error)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        if (string.IsNullOrWhiteSpace(privateKeyPem))
+        {
+            signatureValue = string.Empty;
+            error = "Manifest signing private key is required.";
+            return false;
+        }
+
+        try
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(privateKeyPem);
+            var payloadBytes = Encoding.UTF8.GetBytes(BuildSigningPayload(manifest));
+            var signatureBytes = rsa.SignData(payloadBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            signatureValue = Convert.ToBase64String(signatureBytes);
+            error = string.Empty;
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            signatureValue = string.Empty;
+            error = "Manifest signing private key is invalid.";
+            return false;
+        }
+    }
+
     public static string BuildSigningPayload(RunnerUpdateManifest manifest)
     {
         ArgumentNullException.ThrowIfNull(manifest);

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ The desired-state heartbeat can point to a specific update manifest and workflow
 
 Runner update staging is now a separate first-pass flow: workers can persist staged update metadata for an assigned manifest, and optionally download the referenced payload when `Coordinator:DownloadUpdatePayload` is enabled. When `Coordinator:ApplyStagedUpdate` is also enabled and policy allows apply, the runner launches a detached helper that waits for the current process to exit, extracts the trusted staged zip into a candidate install directory, preserves local `appsettings*.json`, and restarts from that candidate install. The runner reports structured update state back through its coordinator heartbeat so the control plane can distinguish between update-available, staged, applying, applied, and failed states.
 
+Coordinators can now also host runner artifacts directly from a local artifact root. When `Coordinator:DesiredUpdateManifest:HostedArtifactPath` is configured, the coordinator serves the file at `/artifacts/{path}`, derives the manifest `ArtifactUrl`, `Sha256`, and `ArtifactSizeBytes` from the hosted file, and can optionally generate the manifest signature from `Coordinator:DesiredUpdateManifest:PrivateKeyPem`. This makes same-origin runner update download testing possible without hard-coding placeholder checksum or size metadata.
+
 ### Control-plane security model
 
 - Runners only accept a non-HTTPS coordinator URL by default when it targets loopback and `Coordinator:AllowInsecureHttpCoordinatorForLoopback` is enabled for local development.
@@ -230,6 +232,7 @@ Runner update staging is now a separate first-pass flow: workers can persist sta
 - When `SecurityPolicy.RequireSignedUpdateManifest` is enabled, manifests must include an RSA-SHA256 detached signature whose signer ID appears in the policy and whose public key is trusted by the runner.
 - `Coordinator:ApplyStagedUpdate` stays off by default. The current apply flow only supports trusted `.zip` payloads and restarts into a candidate install directory rather than replacing the original install in place.
 - The checked-in coordinator manifest values and dev signer are placeholders for development shape only. Before enabling payload downloads in a real environment, replace the example coordinator-hosted artifact URL, checksum, provenance, and signer material with real published artifact metadata.
+- For local coordinator-hosted artifacts, place the runner ZIP under `Coordinator:ArtifactRoot`, set `Coordinator:DesiredUpdateManifest:HostedArtifactPath` to the relative path under that root, and keep `Coordinator:PublicBaseUrl` aligned with the URL runners use to reach the coordinator. If signed manifests remain enabled, set `Coordinator:DesiredUpdateManifest:PrivateKeyPem` so the coordinator can re-sign the manifest after deriving the real artifact metadata.
 
 ---
 


### PR DESCRIPTION
## Summary
- serve configured runner update artifacts directly from the coordinator
- derive manifest artifact URL/checksum/size from hosted files and support optional coordinator-side re-signing
- document the hosted artifact development flow

## Testing
- dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
- dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj
- start coordinator with a temp hosted ZIP and verify manifest + /artifacts download

Closes #166