### PR TITLE
Expose coordinator update rollout state

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -328,6 +328,14 @@ app.MapPut("/api/projects/{projectId}/workspaces/{machineId}", (string projectId
 app.MapGet("/api/machines", async (IWorkerRegistryService registry, CancellationToken cancellationToken) =>
     Results.Ok(await registry.GetMachinesAsync(cancellationToken)));
 
+app.MapGet("/api/updates/rollouts", async (IWorkerRegistryService registry, CancellationToken cancellationToken) =>
+    Results.Ok(await registry.GetUpdateRolloutsAsync(cancellationToken)));
+
+app.MapGet("/api/machines/{machineId}/updates/rollout", async (string machineId, IWorkerRegistryService registry, CancellationToken cancellationToken) =>
+    await registry.GetUpdateRolloutAsync(machineId, cancellationToken) is { } rollout
+        ? Results.Ok(rollout)
+        : Results.NotFound());
+
 app.MapGet("/api/machines/{machineId}/workspace", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try

--- a/AgentDeck.Coordinator/Services/IWorkerRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/IWorkerRegistryService.cs
@@ -8,5 +8,9 @@ public interface IWorkerRegistryService
 
     Task<RegisteredRunnerMachine?> GetMachineAsync(string machineId, CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<RunnerUpdateRolloutStatus>> GetUpdateRolloutsAsync(CancellationToken cancellationToken = default);
+
+    Task<RunnerUpdateRolloutStatus?> GetUpdateRolloutAsync(string machineId, CancellationToken cancellationToken = default);
+
     RegisterRunnerMachineResponse RegisterOrUpdateWorker(RegisterRunnerMachineRequest request);
 }

--- a/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
@@ -55,6 +55,35 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
         }
     }
 
+    public Task<IReadOnlyList<RunnerUpdateRolloutStatus>> GetUpdateRolloutsAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            IReadOnlyList<RunnerUpdateRolloutStatus> rollouts = RefreshWorkerStates()
+                .Select(machine => machine.UpdateRollout)
+                .Where(rollout => rollout is not null)
+                .Cast<RunnerUpdateRolloutStatus>()
+                .OrderBy(rollout => rollout.MachineName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return Task.FromResult(rollouts);
+        }
+    }
+
+    public Task<RunnerUpdateRolloutStatus?> GetUpdateRolloutAsync(string machineId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(machineId);
+
+        lock (_lock)
+        {
+            RefreshWorkerStates();
+            var normalizedMachineId = Normalize(machineId);
+            var rollout = _workers.TryGetValue(normalizedMachineId, out var worker)
+                ? worker.Machine.UpdateRollout
+                : null;
+            return Task.FromResult(rollout);
+        }
+    }
+
     public RegisterRunnerMachineResponse RegisterOrUpdateWorker(RegisterRunnerMachineRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -71,6 +100,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
             var normalizedMachineName = Normalize(request.MachineName);
             var normalizedAgentVersion = Normalize(request.AgentVersion);
             var normalizedRunnerUrl = string.IsNullOrWhiteSpace(request.RunnerUrl) ? null : request.RunnerUrl.Trim();
+            var updateRollout = BuildUpdateRollout(
+                machineId,
+                normalizedMachineName,
+                normalizedAgentVersion,
+                desiredState,
+                request.UpdateStatus,
+                isOnline: true);
             var machine = new RegisteredRunnerMachine
             {
                 MachineId = machineId,
@@ -83,6 +119,7 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
                 DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
                 UpdateStatus = request.UpdateStatus,
+                UpdateRollout = updateRollout,
                 RunnerUrl = normalizedRunnerUrl,
                 RegisteredAt = existing?.RegisteredAt ?? now,
                 LastSeenAt = now,
@@ -148,39 +185,47 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
             }
 
             var isOnline = machine.LastSeenAt >= onlineThreshold;
+            var desiredState = BuildDesiredState(machine.AgentVersion, machine.ProtocolVersion);
+            var refreshedMachine = new RegisteredRunnerMachine
+            {
+                MachineId = machine.MachineId,
+                MachineName = machine.MachineName,
+                Role = machine.Role,
+                AgentVersion = machine.AgentVersion,
+                ProtocolVersion = machine.ProtocolVersion,
+                WorkflowCatalogVersion = machine.WorkflowCatalogVersion,
+                SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
+                DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
+                DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
+                UpdateStatus = machine.UpdateStatus,
+                UpdateRollout = BuildUpdateRollout(
+                    machine.MachineId,
+                    machine.MachineName,
+                    machine.AgentVersion,
+                    desiredState,
+                    machine.UpdateStatus,
+                    isOnline),
+                RunnerUrl = machine.RunnerUrl,
+                RegisteredAt = machine.RegisteredAt,
+                LastSeenAt = machine.LastSeenAt,
+                IsOnline = isOnline,
+                IsCoordinator = machine.IsCoordinator,
+                UpdateAvailable = desiredState.UpdateAvailable,
+                ProtocolCompatible = desiredState.ProtocolCompatible,
+                Platform = machine.Platform,
+                SupportedTargets = machine.SupportedTargets
+            };
+            _workers[worker.Key] = new WorkerEntry(refreshedMachine);
             if (machine.IsOnline != isOnline)
             {
-                machine = new RegisteredRunnerMachine
-                {
-                    MachineId = machine.MachineId,
-                    MachineName = machine.MachineName,
-                    Role = machine.Role,
-                    AgentVersion = machine.AgentVersion,
-                    ProtocolVersion = machine.ProtocolVersion,
-                    WorkflowCatalogVersion = machine.WorkflowCatalogVersion,
-                    SecurityPolicyVersion = machine.SecurityPolicyVersion,
-                    DesiredUpdateManifestId = machine.DesiredUpdateManifestId,
-                    DesiredWorkflowPackId = machine.DesiredWorkflowPackId,
-                    UpdateStatus = machine.UpdateStatus,
-                    RunnerUrl = machine.RunnerUrl,
-                    RegisteredAt = machine.RegisteredAt,
-                    LastSeenAt = machine.LastSeenAt,
-                    IsOnline = isOnline,
-                    IsCoordinator = machine.IsCoordinator,
-                    UpdateAvailable = machine.UpdateAvailable,
-                    ProtocolCompatible = machine.ProtocolCompatible,
-                    Platform = machine.Platform,
-                    SupportedTargets = machine.SupportedTargets
-                };
-                _workers[worker.Key] = new WorkerEntry(machine);
                 _logger.LogInformation(
                     "Worker {MachineName} ({MachineId}) is now {State}",
-                    machine.MachineName,
-                    machine.MachineId,
+                    refreshedMachine.MachineName,
+                    refreshedMachine.MachineId,
                     isOnline ? "online" : "offline");
             }
 
-            machines.Add(machine);
+            machines.Add(refreshedMachine);
         }
 
         return machines;
@@ -243,6 +288,141 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
             StatusMessage = protocolCompatible
                 ? null
                 : $"Runner protocol {protocolVersion} is outside the coordinator supported range {_coordinatorOptions.MinimumSupportedProtocolVersion}-{_coordinatorOptions.MaximumSupportedProtocolVersion}."
+        };
+    }
+
+    private static RunnerUpdateRolloutStatus BuildUpdateRollout(
+        string machineId,
+        string machineName,
+        string currentVersion,
+        RunnerDesiredState desiredState,
+        RunnerUpdateStatus? updateStatus,
+        bool isOnline)
+    {
+        var statusMessage = string.Empty;
+        string? blockingReason = null;
+        string? failureMessage = updateStatus?.FailureMessage;
+        var state = RunnerUpdateRolloutState.UpToDate;
+        var applyPermitted = desiredState.SecurityPolicy.AllowUpdateApply;
+        var applyRequested = desiredState.ApplyUpdate;
+        var applyEligible = false;
+
+        if (!desiredState.ProtocolCompatible)
+        {
+            state = RunnerUpdateRolloutState.Blocked;
+            blockingReason = desiredState.StatusMessage ?? "Runner protocol is incompatible with the coordinator.";
+            statusMessage = blockingReason;
+        }
+        else if (!desiredState.UpdateAvailable)
+        {
+            state = RunnerUpdateRolloutState.UpToDate;
+            statusMessage = "Runner already matches the coordinator's desired version.";
+        }
+        else
+        {
+            switch (updateStatus?.State ?? RunnerUpdateStageState.None)
+            {
+                case RunnerUpdateStageState.Failed:
+                    state = RunnerUpdateRolloutState.Failed;
+                    statusMessage = failureMessage ?? "Runner update failed.";
+                    break;
+                case RunnerUpdateStageState.Applying:
+                    state = RunnerUpdateRolloutState.Applying;
+                    statusMessage = "Runner is currently applying the staged update.";
+                    break;
+                case RunnerUpdateStageState.Applied:
+                    state = RunnerUpdateRolloutState.Applied;
+                    statusMessage = "Runner reported the update as applied and is expected to restart on the new install.";
+                    break;
+                case RunnerUpdateStageState.PayloadStaged:
+                    if (applyRequested && !applyPermitted)
+                    {
+                        state = RunnerUpdateRolloutState.Blocked;
+                        blockingReason = $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit update apply.";
+                        statusMessage = blockingReason;
+                    }
+                    else if (applyRequested && isOnline)
+                    {
+                        state = RunnerUpdateRolloutState.ReadyToApply;
+                        applyEligible = true;
+                        statusMessage = "Payload is staged and the coordinator has requested apply.";
+                    }
+                    else if (applyRequested)
+                    {
+                        state = RunnerUpdateRolloutState.PayloadStaged;
+                        statusMessage = "Payload is staged and apply is requested, but the runner is currently offline.";
+                    }
+                    else
+                    {
+                        state = RunnerUpdateRolloutState.PayloadStaged;
+                        statusMessage = "Payload is staged and ready for a future apply request.";
+                    }
+
+                    break;
+                case RunnerUpdateStageState.ManifestStaged:
+                    if (applyRequested)
+                    {
+                        state = RunnerUpdateRolloutState.Blocked;
+                        blockingReason = "Coordinator requested apply, but the runner only staged the manifest. Payload download must be enabled before apply.";
+                        statusMessage = blockingReason;
+                    }
+                    else
+                    {
+                        state = RunnerUpdateRolloutState.ManifestStaged;
+                        statusMessage = "Manifest is staged. Payload download is not yet complete or is not enabled on this runner.";
+                    }
+
+                    break;
+                default:
+                    if (!desiredState.SecurityPolicy.AllowUpdateStaging)
+                    {
+                        state = RunnerUpdateRolloutState.Blocked;
+                        blockingReason = $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit update staging.";
+                        statusMessage = blockingReason;
+                    }
+                    else if (applyRequested && !applyPermitted)
+                    {
+                        state = RunnerUpdateRolloutState.Blocked;
+                        blockingReason = $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit update apply.";
+                        statusMessage = blockingReason;
+                    }
+                    else if (!isOnline)
+                    {
+                        state = RunnerUpdateRolloutState.UpdateAvailable;
+                        statusMessage = "Coordinator assigned a newer runner version, but the runner is currently offline.";
+                    }
+                    else
+                    {
+                        state = RunnerUpdateRolloutState.UpdateAvailable;
+                        statusMessage = "Coordinator assigned a newer runner version and is waiting for the runner to stage it.";
+                    }
+
+                    break;
+            }
+        }
+
+        return new RunnerUpdateRolloutStatus
+        {
+            MachineId = machineId,
+            MachineName = machineName,
+            CurrentVersion = currentVersion,
+            DesiredVersion = desiredState.DesiredRunnerVersion,
+            DesiredManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
+            DesiredManifestVersion = desiredState.DesiredUpdateManifest?.Version,
+            SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
+            State = state,
+            RunnerStageState = updateStatus?.State,
+            IsOnline = isOnline,
+            UpdateAvailable = desiredState.UpdateAvailable,
+            ApplyRequested = applyRequested,
+            ApplyPermitted = applyPermitted,
+            ApplyEligible = applyEligible,
+            StatusMessage = statusMessage,
+            BlockingReason = blockingReason,
+            FailureMessage = failureMessage,
+            StagedAt = updateStatus?.StagedAt,
+            ApplyStartedAt = updateStatus?.ApplyStartedAt,
+            AppliedAt = updateStatus?.AppliedAt
         };
     }
 }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -98,13 +98,9 @@
                             {
                                 <span> • manifest @machine.DesiredUpdateManifestId</span>
                             }
-                            @if (machine.UpdateStatus is not null)
+                            @if (machine.UpdateRollout is not null)
                             {
-                                <span> • update @machine.UpdateStatus.State</span>
-                            }
-                            @if (machine.UpdateAvailable)
-                            {
-                                <span> • update available</span>
+                                <span> • rollout @GetUpdateRolloutLabel(machine.UpdateRollout.State)</span>
                             }
                             @if (!machine.ProtocolCompatible)
                             {
@@ -115,6 +111,10 @@
                                 <span> • @GetHostPlatformLabel(machine.Platform.HostPlatform)</span>
                             }
                         </span>
+                        @if (machine.UpdateRollout is not null)
+                        {
+                            <span class="settings-card__description">@machine.UpdateRollout.StatusMessage</span>
+                        }
                     </article>
                 }
             </div>
@@ -245,6 +245,67 @@
                         <span class="settings-status-row__label">Coordinator hub</span>
                         <code class="settings-status-row__value">@GetHubUrl(SelectedMachine)</code>
                     </div>
+                    @if (SelectedRegisteredMachine?.UpdateRollout is { } rollout)
+                    {
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Update rollout</span>
+                            <strong class="settings-status-row__value">@GetUpdateRolloutLabel(rollout.State)</strong>
+                        </div>
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Desired version</span>
+                            <span class="settings-status-row__value">@rollout.DesiredVersion</span>
+                        </div>
+                        @if (!string.IsNullOrWhiteSpace(rollout.DesiredManifestId))
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Desired manifest</span>
+                                <span class="settings-status-row__value">@GetDesiredManifestLabel(rollout)</span>
+                            </div>
+                        }
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Apply intent</span>
+                            <span class="settings-status-row__value">@GetApplyIntentLabel(rollout)</span>
+                        </div>
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Rollout summary</span>
+                            <span class="settings-status-row__value">@rollout.StatusMessage</span>
+                        </div>
+                        @if (!string.IsNullOrWhiteSpace(rollout.BlockingReason))
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Blocked because</span>
+                                <span class="settings-status-row__value">@rollout.BlockingReason</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(rollout.FailureMessage))
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Failure</span>
+                                <span class="settings-status-row__value">@rollout.FailureMessage</span>
+                            </div>
+                        }
+                        @if (rollout.StagedAt is not null)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Staged at</span>
+                                <span class="settings-status-row__value">@rollout.StagedAt.Value.ToLocalTime().ToString("g")</span>
+                            </div>
+                        }
+                        @if (rollout.ApplyStartedAt is not null)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Apply started</span>
+                                <span class="settings-status-row__value">@rollout.ApplyStartedAt.Value.ToLocalTime().ToString("g")</span>
+                            </div>
+                        }
+                        @if (rollout.AppliedAt is not null)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Applied at</span>
+                                <span class="settings-status-row__value">@rollout.AppliedAt.Value.ToLocalTime().ToString("g")</span>
+                            </div>
+                        }
+                    }
                         @if (_machineCapabilities?.Platform is not null)
                         {
                         <div class="settings-status-row">
@@ -473,6 +534,10 @@
             : null;
     private bool _capabilitiesBusy =>
         SelectedMachine is not null && _capabilitiesBusyMachineIds.Contains(SelectedMachine.Id);
+    private RegisteredRunnerMachine? SelectedRegisteredMachine =>
+        SelectedMachine is null
+            ? null
+            : _registeredMachines.FirstOrDefault(machine => string.Equals(machine.MachineId, SelectedMachine.Id, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {
@@ -630,6 +695,45 @@
         RunnerHostPlatform.MacOS => "macOS",
         _ => "Unknown"
     };
+
+    private static string GetUpdateRolloutLabel(RunnerUpdateRolloutState state) => state switch
+    {
+        RunnerUpdateRolloutState.UpToDate => "Up to date",
+        RunnerUpdateRolloutState.UpdateAvailable => "Update available",
+        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
+        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
+        RunnerUpdateRolloutState.Applying => "Applying",
+        RunnerUpdateRolloutState.Applied => "Applied",
+        RunnerUpdateRolloutState.Failed => "Failed",
+        RunnerUpdateRolloutState.Blocked => "Blocked",
+        _ => state.ToString()
+    };
+
+    private static string GetApplyIntentLabel(RunnerUpdateRolloutStatus rollout)
+    {
+        if (rollout.ApplyEligible)
+        {
+            return "Apply requested and eligible";
+        }
+
+        if (rollout.ApplyRequested && rollout.ApplyPermitted)
+        {
+            return "Apply requested";
+        }
+
+        if (rollout.ApplyRequested)
+        {
+            return "Apply requested but blocked by policy";
+        }
+
+        return rollout.ApplyPermitted ? "Stage only" : "Apply disabled by policy";
+    }
+
+    private static string GetDesiredManifestLabel(RunnerUpdateRolloutStatus rollout) =>
+        string.IsNullOrWhiteSpace(rollout.DesiredManifestVersion)
+            ? rollout.DesiredManifestId ?? string.Empty
+            : $"{rollout.DesiredManifestId}@{rollout.DesiredManifestVersion}";
 
     private static string FormatTargetSummary(MachineTargetSupport target) =>
         $"{target.DisplayName} ({target.Status})";

--- a/AgentDeck.Shared/Enums/RunnerUpdateRolloutState.cs
+++ b/AgentDeck.Shared/Enums/RunnerUpdateRolloutState.cs
@@ -1,0 +1,15 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Coordinator-computed rollout state for a runner update.</summary>
+public enum RunnerUpdateRolloutState
+{
+    UpToDate,
+    UpdateAvailable,
+    ManifestStaged,
+    PayloadStaged,
+    ReadyToApply,
+    Applying,
+    Applied,
+    Failed,
+    Blocked
+}

--- a/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
+++ b/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
@@ -15,6 +15,7 @@ public sealed class RegisteredRunnerMachine
     public string? DesiredUpdateManifestId { get; init; }
     public string? DesiredWorkflowPackId { get; init; }
     public RunnerUpdateStatus? UpdateStatus { get; init; }
+    public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
     public string? RunnerUrl { get; init; }
     public DateTimeOffset RegisteredAt { get; init; } = DateTimeOffset.UtcNow;
     public DateTimeOffset LastSeenAt { get; init; } = DateTimeOffset.UtcNow;

--- a/AgentDeck.Shared/Models/RunnerUpdateRolloutStatus.cs
+++ b/AgentDeck.Shared/Models/RunnerUpdateRolloutStatus.cs
@@ -1,0 +1,28 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Coordinator-facing summary of runner update rollout and apply state.</summary>
+public sealed class RunnerUpdateRolloutStatus
+{
+    public required string MachineId { get; init; }
+    public required string MachineName { get; init; }
+    public required string CurrentVersion { get; init; }
+    public required string DesiredVersion { get; init; }
+    public string? DesiredManifestId { get; init; }
+    public string? DesiredManifestVersion { get; init; }
+    public string? SecurityPolicyVersion { get; init; }
+    public RunnerUpdateRolloutState State { get; init; } = RunnerUpdateRolloutState.UpToDate;
+    public RunnerUpdateStageState? RunnerStageState { get; init; }
+    public bool IsOnline { get; init; } = true;
+    public bool UpdateAvailable { get; init; }
+    public bool ApplyRequested { get; init; }
+    public bool ApplyPermitted { get; init; }
+    public bool ApplyEligible { get; init; }
+    public string? StatusMessage { get; init; }
+    public string? BlockingReason { get; init; }
+    public string? FailureMessage { get; init; }
+    public DateTimeOffset? StagedAt { get; init; }
+    public DateTimeOffset? ApplyStartedAt { get; init; }
+    public DateTimeOffset? AppliedAt { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Runner update staging is now a separate first-pass flow: workers can persist sta
 
 Coordinators can now also host runner artifacts directly from a local artifact root. When `Coordinator:DesiredUpdateManifest:HostedArtifactPath` is configured, the coordinator serves the file at `/artifacts/{path}`, derives the manifest `ArtifactUrl`, `Sha256`, and `ArtifactSizeBytes` from the hosted file, and can optionally generate the manifest signature from `Coordinator:DesiredUpdateManifest:PrivateKeyPem`. This makes same-origin runner update download testing possible without hard-coding placeholder checksum or size metadata.
 
+The coordinator also computes an explicit rollout/apply summary for each worker and exposes it through the machine directory plus `/api/updates/rollouts` and `/api/machines/{machineId}/updates/rollout`. That summary makes it clear whether a runner is up to date, merely update-available, manifest-staged, payload-staged, ready to apply, applying, applied, failed, or blocked, along with the coordinator's apply intent and any blocking reason.
+
 ### Control-plane security model
 
 - Runners only accept a non-HTTPS coordinator URL by default when it targets loopback and `Coordinator:AllowInsecureHttpCoordinatorForLoopback` is enabled for local development.


### PR DESCRIPTION
## Summary
- compute an explicit coordinator-owned runner update rollout snapshot for each worker
- expose rollout state through the coordinator machine directory and dedicated rollout endpoints
- surface rollout/apply status in companion Settings and document the new control-plane view

## Testing
- dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj
- dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj
- run coordinator with apply enabled, post a sample worker heartbeat, and verify `/api/machines/{machineId}/updates/rollout`

Closes #168