### PR TITLE
Enforce project action ownership

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -161,7 +161,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
     {
         var logger = loggerFactory.CreateLogger("ProjectOpenFlow");
         TrackMachineAttachment(httpContext, companions, machineId);
-        var companionId = GetCompanionId(httpContext);
+        var companionId = GetCompanionId(httpContext)?.Trim();
 
         var project = projects.GetProject(projectId);
         if (project is null)

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -212,19 +212,20 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
             Name = $"{project.Name} ({machine.MachineName})",
             WorkingDirectory = openedWorkspace.ProjectPath
         }, cancellationToken);
-        if (!string.IsNullOrWhiteSpace(companionId))
-        {
-            companions.AttachSession(companionId, session.Id);
-        }
-
-        var projectSession = projectSessions.CreateSession(
-            project.Id,
-            project.Name,
-            machine.MachineId,
-            machine.MachineName,
-            companionId);
+        ProjectSessionRecord? projectSession = null;
         try
         {
+            if (!string.IsNullOrWhiteSpace(companionId))
+            {
+                companions.AttachSession(companionId, session.Id);
+            }
+
+            projectSession = projectSessions.CreateSession(
+                project.Id,
+                project.Name,
+                machine.MachineId,
+                machine.MachineName,
+                companionId);
             projectSession = projectSessions.RegisterSurface(projectSession.Id, new RegisterProjectSessionSurfaceRequest
             {
                 Kind = ProjectSessionSurfaceKind.Terminal,
@@ -251,11 +252,14 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
         {
             try
             {
-                projectSessions.RemoveSession(projectSession.Id);
+                if (projectSession is not null)
+                {
+                    projectSessions.RemoveSession(projectSession.Id);
+                }
             }
             catch (Exception cleanupEx)
             {
-                logger.LogWarning(cleanupEx, "Failed to remove project session {ProjectSessionId} during open-project cleanup", projectSession.Id);
+                logger.LogWarning(cleanupEx, "Failed to remove project session during open-project cleanup");
             }
 
             if (!string.IsNullOrWhiteSpace(companionId))

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -175,57 +175,54 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
             return Results.NotFound(new { message = $"Coordinator does not know runner machine '{machineId}'." });
         }
 
-        if (RejectProjectMutationIfViewer(httpContext, projectSessions, projectId, machineId) is { } rejection)
-        {
-            return rejection;
-        }
-
         var existingWorkspace = project.Workspaces.FirstOrDefault(workspace =>
             string.Equals(workspace.MachineId, machineId, StringComparison.OrdinalIgnoreCase));
-        var openedWorkspace = await runners.OpenProjectAsync(
-            machineId,
-            new OpenProjectOnRunnerRequest
-            {
-                ProjectId = project.Id,
-                ProjectName = project.Name,
-                Repository = project.Repository,
-                ExistingWorkspacePath = existingWorkspace?.ProjectPath
-            },
-            GetActorId(httpContext),
-            cancellationToken);
-
-        if (openedWorkspace is null)
-        {
-            return Results.NotFound();
-        }
-
-        var workspaceMapping = new ProjectWorkspaceMapping
-        {
-            MachineId = machine.MachineId,
-            MachineName = machine.MachineName,
-            ProjectPath = openedWorkspace.ProjectPath,
-            IsPrimary = existingWorkspace?.IsPrimary ?? false
-        };
-
-        var session = await runners.CreateSessionAsync(machineId, new CreateTerminalRequest
-        {
-            Name = $"{project.Name} ({machine.MachineName})",
-            WorkingDirectory = openedWorkspace.ProjectPath
-        }, cancellationToken);
-        ProjectSessionRecord? projectSession = null;
+        var projectSession = projectSessions.CreateSession(
+            project.Id,
+            project.Name,
+            machine.MachineId,
+            machine.MachineName,
+            companionId);
+        OpenProjectOnRunnerResult? openedWorkspace = null;
+        ProjectWorkspaceMapping? workspaceMapping = null;
+        TerminalSession? session = null;
         try
         {
+            openedWorkspace = await runners.OpenProjectAsync(
+                machineId,
+                new OpenProjectOnRunnerRequest
+                {
+                    ProjectId = project.Id,
+                    ProjectName = project.Name,
+                    Repository = project.Repository,
+                    ExistingWorkspacePath = existingWorkspace?.ProjectPath
+                },
+                GetActorId(httpContext),
+                cancellationToken);
+
+            if (openedWorkspace is null)
+            {
+                return Results.NotFound();
+            }
+
+            workspaceMapping = new ProjectWorkspaceMapping
+            {
+                MachineId = machine.MachineId,
+                MachineName = machine.MachineName,
+                ProjectPath = openedWorkspace.ProjectPath,
+                IsPrimary = existingWorkspace?.IsPrimary ?? false
+            };
+
+            session = await runners.CreateSessionAsync(machineId, new CreateTerminalRequest
+            {
+                Name = $"{project.Name} ({machine.MachineName})",
+                WorkingDirectory = openedWorkspace.ProjectPath
+            }, cancellationToken);
             if (!string.IsNullOrWhiteSpace(companionId))
             {
                 companions.AttachSession(companionId, session.Id);
             }
 
-            projectSession = projectSessions.CreateSession(
-                project.Id,
-                project.Name,
-                machine.MachineId,
-                machine.MachineName,
-                companionId);
             projectSession = projectSessions.RegisterSurface(projectSession.Id, new RegisterProjectSessionSurfaceRequest
             {
                 Kind = ProjectSessionSurfaceKind.Terminal,
@@ -252,17 +249,26 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
         {
             try
             {
-                if (projectSession is not null)
-                {
-                    projectSessions.RemoveSession(projectSession.Id);
-                }
+                projectSessions.RemoveSession(projectSession.Id);
             }
             catch (Exception cleanupEx)
             {
                 logger.LogWarning(cleanupEx, "Failed to remove project session during open-project cleanup");
             }
 
-            if (!string.IsNullOrWhiteSpace(companionId))
+            if (workspaceMapping is not null)
+            {
+                try
+                {
+                    projects.UpsertWorkspace(projectId, workspaceMapping);
+                }
+                catch (Exception cleanupEx)
+                {
+                    logger.LogWarning(cleanupEx, "Failed to persist workspace mapping for project {ProjectId} during open-project cleanup", projectId);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(companionId) && session is not null)
             {
                 try
                 {
@@ -276,11 +282,14 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
 
             try
             {
-                await runners.CloseSessionAsync(session.Id, cancellationToken);
+                if (session is not null)
+                {
+                    await runners.CloseSessionAsync(session.Id, cancellationToken);
+                }
             }
             catch (Exception cleanupEx)
             {
-                logger.LogWarning(cleanupEx, "Failed to close terminal session {SessionId} during open-project cleanup", session.Id);
+                logger.LogWarning(cleanupEx, "Failed to close terminal session during open-project cleanup");
             }
 
             ExceptionDispatchInfo.Capture(ex).Throw();

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -573,10 +573,15 @@ static IResult? RejectProjectMutationIfViewer(
 static ProjectSessionRecord? GetLatestProjectSession(
     IProjectSessionRegistryService projectSessions,
     string projectId,
-    string machineId) =>
-    projectSessions.GetSessions(projectId)
+    string machineId)
+{
+    var normalizedProjectId = projectId.Trim();
+    var normalizedMachineId = machineId.Trim();
+
+    return projectSessions.GetSessions(normalizedProjectId)
         .Where(session =>
-            string.Equals(session.ProjectId, projectId, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(session.MachineId, machineId, StringComparison.OrdinalIgnoreCase))
+            string.Equals(session.ProjectId, normalizedProjectId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(session.MachineId, normalizedMachineId, StringComparison.OrdinalIgnoreCase))
         .OrderByDescending(session => session.UpdatedAt)
         .FirstOrDefault();
+}

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -202,6 +202,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
 
             if (openedWorkspace is null)
             {
+                projectSessions.RemoveSession(projectSession.Id);
                 return Results.NotFound();
             }
 

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -399,7 +399,7 @@ app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machin
     }
     catch (InvalidOperationException ex)
     {
-        return Results.BadRequest(new { message = ex.Message });
+        return Results.Conflict(new { message = ex.Message });
     }
 });
 
@@ -425,7 +425,7 @@ app.MapPost("/api/machines/{machineId}/orchestration/jobs/{jobId}/cancel", async
     }
     catch (InvalidOperationException ex)
     {
-        return Results.BadRequest(new { message = ex.Message });
+        return Results.Conflict(new { message = ex.Message });
     }
 });
 

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -161,6 +161,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
     {
         var logger = loggerFactory.CreateLogger("ProjectOpenFlow");
         TrackMachineAttachment(httpContext, companions, machineId);
+        var companionId = GetCompanionId(httpContext);
 
         var project = projects.GetProject(projectId);
         if (project is null)
@@ -172,6 +173,11 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
         if (machine is null)
         {
             return Results.NotFound(new { message = $"Coordinator does not know runner machine '{machineId}'." });
+        }
+
+        if (RejectProjectMutationIfViewer(httpContext, projectSessions, projectId, machineId) is { } rejection)
+        {
+            return rejection;
         }
 
         var existingWorkspace = project.Workspaces.FirstOrDefault(workspace =>
@@ -206,8 +212,6 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
             Name = $"{project.Name} ({machine.MachineName})",
             WorkingDirectory = openedWorkspace.ProjectPath
         }, cancellationToken);
-
-        var companionId = GetCompanionId(httpContext);
         if (!string.IsNullOrWhiteSpace(companionId))
         {
             companions.AttachSession(companionId, session.Id);
@@ -285,7 +289,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
     }
     catch (InvalidOperationException ex)
     {
-        return Results.BadRequest(new { message = ex.Message });
+        return Results.Conflict(new { message = ex.Message });
     }
 });
 
@@ -377,11 +381,16 @@ app.MapGet("/api/machines/{machineId}/orchestration/jobs", async (string machine
     }
 });
 
-app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machineId, CreateOrchestrationJobRequest request, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machineId, CreateOrchestrationJobRequest request, HttpContext httpContext, ICompanionRegistryService companions, IProjectSessionRegistryService projectSessions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try
     {
         TrackMachineAttachment(httpContext, companions, machineId);
+        if (RejectProjectMutationIfViewer(httpContext, projectSessions, request.ProjectId, machineId) is { } rejection)
+        {
+            return rejection;
+        }
+
         return Results.Ok(await runners.QueueOrchestrationJobAsync(machineId, request, GetActorId(httpContext), cancellationToken));
     }
     catch (ArgumentException ex)
@@ -394,11 +403,23 @@ app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machin
     }
 });
 
-app.MapPost("/api/machines/{machineId}/orchestration/jobs/{jobId}/cancel", async (string machineId, string jobId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+app.MapPost("/api/machines/{machineId}/orchestration/jobs/{jobId}/cancel", async (string machineId, string jobId, HttpContext httpContext, ICompanionRegistryService companions, IProjectSessionRegistryService projectSessions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try
     {
         TrackMachineAttachment(httpContext, companions, machineId);
+        var existingJob = (await runners.GetOrchestrationJobsAsync(machineId, cancellationToken))
+            .FirstOrDefault(job => string.Equals(job.Id, jobId, StringComparison.OrdinalIgnoreCase));
+        if (existingJob is null)
+        {
+            return Results.NotFound();
+        }
+
+        if (RejectProjectMutationIfViewer(httpContext, projectSessions, existingJob.ProjectId, machineId) is { } rejection)
+        {
+            return rejection;
+        }
+
         var job = await runners.CancelOrchestrationJobAsync(machineId, jobId, GetActorId(httpContext), cancellationToken);
         return job is null ? Results.NotFound() : Results.Ok(job);
     }
@@ -522,3 +543,40 @@ static void TrackMachineAttachment(HttpContext httpContext, ICompanionRegistrySe
         companions.AttachMachine(companionId, machineId);
     }
 }
+
+static IResult? RejectProjectMutationIfViewer(
+    HttpContext httpContext,
+    IProjectSessionRegistryService projectSessions,
+    string projectId,
+    string machineId)
+{
+    var companionId = GetCompanionId(httpContext);
+    if (string.IsNullOrWhiteSpace(companionId))
+    {
+        return Results.BadRequest(new { message = "Coordinator companion identity is required to mutate a live project session." });
+    }
+
+    var existingSession = GetLatestProjectSession(projectSessions, projectId, machineId);
+    if (existingSession is null ||
+        string.IsNullOrWhiteSpace(existingSession.CompanionId) ||
+        string.Equals(existingSession.CompanionId, companionId.Trim(), StringComparison.OrdinalIgnoreCase))
+    {
+        return null;
+    }
+
+    return Results.Conflict(new
+    {
+        message = $"Project '{projectId}' on machine '{machineId}' is currently controlled by companion '{existingSession.CompanionId}'. Take control of session '{existingSession.Id}' before mutating it."
+    });
+}
+
+static ProjectSessionRecord? GetLatestProjectSession(
+    IProjectSessionRegistryService projectSessions,
+    string projectId,
+    string machineId) =>
+    projectSessions.GetSessions(projectId)
+        .Where(session =>
+            string.Equals(session.ProjectId, projectId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(session.MachineId, machineId, StringComparison.OrdinalIgnoreCase))
+        .OrderByDescending(session => session.UpdatedAt)
+        .FirstOrDefault();

--- a/AgentDeck.Coordinator/Services/ProjectSessionRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/ProjectSessionRegistryService.cs
@@ -59,13 +59,15 @@ public sealed class ProjectSessionRegistryService : IProjectSessionRegistryServi
         ArgumentException.ThrowIfNullOrWhiteSpace(projectName);
 
         var now = DateTimeOffset.UtcNow;
+        var normalizedProjectId = projectId.Trim();
+        var normalizedMachineId = Normalize(machineId);
         var normalizedCompanionId = Normalize(companionId);
         var session = new ProjectSessionRecord
         {
             Id = Guid.NewGuid().ToString("N"),
-            ProjectId = projectId.Trim(),
+            ProjectId = normalizedProjectId,
             ProjectName = projectName.Trim(),
-            MachineId = Normalize(machineId),
+            MachineId = normalizedMachineId,
             MachineName = Normalize(machineName),
             CompanionId = normalizedCompanionId,
             ControlUpdatedAt = now,
@@ -76,6 +78,20 @@ public sealed class ProjectSessionRegistryService : IProjectSessionRegistryServi
 
         lock (_lock)
         {
+            var conflictingSession = _sessions.Values
+                .Where(existing =>
+                    string.Equals(existing.ProjectId, normalizedProjectId, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.MachineId, normalizedMachineId, StringComparison.OrdinalIgnoreCase) &&
+                    !string.IsNullOrWhiteSpace(existing.CompanionId) &&
+                    !string.Equals(existing.CompanionId, normalizedCompanionId, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(existing => existing.UpdatedAt)
+                .FirstOrDefault();
+            if (conflictingSession is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Project '{normalizedProjectId}' on machine '{normalizedMachineId}' is currently controlled by companion '{conflictingSession.CompanionId}'. Take control of session '{conflictingSession.Id}' before opening another live session on that machine.");
+            }
+
             _sessions[session.Id] = session;
         }
 

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -4,6 +4,7 @@
 @inject IConnectionSettingsService SettingsService
 @inject ISessionStateService SessionState
 @inject IActiveSessionService ActiveSession
+@inject IAgentDeckClient AgentClient
 @inject IToastService Toasts
 @inject NavigationManager Nav
 
@@ -63,6 +64,10 @@
                                 </span>
                             </div>
                             <p class="project-machine-card__meta">@GetMachineTargetSummary(machine)</p>
+                            @if (GetProjectControlNotice(machine.MachineId) is { } projectControlNotice)
+                            {
+                                <p class="project-template-target__note">@projectControlNotice</p>
+                            }
                             <div class="project-machine-card__targets">
                                 @foreach (var target in machine.SupportedTargets.OrderBy(target => target.DisplayName))
                                 {
@@ -73,7 +78,7 @@
                             </div>
                             <div class="project-machine-card__actions">
                                 <button class="btn btn-primary"
-                                        disabled="@(!machine.IsOnline || _openingMachineId == machine.MachineId)"
+                                        disabled="@(!machine.IsOnline || _openingMachineId == machine.MachineId || !CanMutateProjectOnMachine(machine.MachineId))"
                                         @onclick="() => OpenProjectAsync(machine.MachineId, navigateToSession: true)">
                                     @(_openingMachineId == machine.MachineId ? "Opening..." : "Open project")
                                 </button>
@@ -143,6 +148,11 @@
                                 else
                                 {
                                     <p class="project-template-target__note">@GetMachineStatusMessage(profile, availableMachines.Count)</p>
+                                }
+
+                                @if (!string.IsNullOrWhiteSpace(selectedMachineId) && GetProjectControlNotice(selectedMachineId) is { } projectControlNotice)
+                                {
+                                    <p class="project-template-target__note">@projectControlNotice</p>
                                 }
 
                                 @if (!string.IsNullOrWhiteSpace(profile.Notes))
@@ -215,6 +225,10 @@
                                         <button class="btn btn-danger" @onclick="() => CancelJobAsync(job)">Cancel</button>
                                     }
                                 </div>
+                                @if (!CanMutateProjectOnMachine(job.TargetMachineId) && GetProjectControlNotice(job.TargetMachineId) is { } jobControlNotice)
+                                {
+                                    <p class="project-template-target__note">@jobControlNotice</p>
+                                }
                             </article>
                         }
                     </div>
@@ -529,6 +543,10 @@
                 Nav.NavigateTo($"/project-sessions/{Uri.EscapeDataString(result.ProjectSession.Id)}");
             }
         }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
         catch (Exception ex)
         {
             Toasts.Show(ex.Message, ToastKind.Error);
@@ -608,6 +626,10 @@
             Toasts.Show($"Queued {profile.DisplayName} on {machine?.MachineName ?? machineId}.", ToastKind.Success);
             await LoadAsync();
         }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
         catch (Exception ex)
         {
             Toasts.Show(ex.Message, ToastKind.Error);
@@ -659,9 +681,20 @@
         _cancellingJobId = job.Id;
         try
         {
-            await CoordinatorClient.CancelMachineOrchestrationJobAsync(_coordinatorUrl, job.TargetMachineId, job.Id);
+            var cancelledJob = await CoordinatorClient.CancelMachineOrchestrationJobAsync(_coordinatorUrl, job.TargetMachineId, job.Id);
+            if (cancelledJob is null)
+            {
+                Toasts.Show("The coordinator could no longer find that job to cancel.", ToastKind.Warning);
+                await LoadAsync();
+                return;
+            }
+
             Toasts.Show($"Cancellation requested for {job.LaunchProfileName}.", ToastKind.Info);
             await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
         }
         catch (Exception ex)
         {
@@ -781,7 +814,9 @@
     private string GetControllerSummary(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.CompanionId)
             ? "No controller companion recorded"
-            : $"Controller {session.CompanionId}";
+            : IsCurrentCompanionController(session)
+                ? "You control this session"
+                : $"Controller {session.CompanionId}";
 
     private string GetProjectSessionMeta(ProjectSessionRecord session)
     {
@@ -827,7 +862,50 @@
 
     private bool CanCancelJob(OrchestrationJob job) =>
         _cancellingJobId != job.Id &&
-        job.Status is OrchestrationJobStatus.Queued or OrchestrationJobStatus.Preparing or OrchestrationJobStatus.Dispatching or OrchestrationJobStatus.Running;
+        job.Status is OrchestrationJobStatus.Queued or OrchestrationJobStatus.Preparing or OrchestrationJobStatus.Dispatching or OrchestrationJobStatus.Running &&
+        CanMutateProjectOnMachine(job.TargetMachineId);
+
+    private bool CanMutateProjectOnMachine(string? machineId)
+    {
+        var session = GetLatestProjectSessionForMachine(machineId);
+        return session is null ||
+               string.IsNullOrWhiteSpace(session.CompanionId) ||
+               IsCurrentCompanionController(session);
+    }
+
+    private string? GetProjectControlNotice(string? machineId)
+    {
+        var session = GetLatestProjectSessionForMachine(machineId);
+        if (session is null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(session.CompanionId))
+        {
+            return $"Live session {GetShortId(session.Id)} exists on this machine, but no controller companion is currently recorded.";
+        }
+
+        return IsCurrentCompanionController(session)
+            ? $"You control live session {GetShortId(session.Id)} on this machine."
+            : $"View-only while {session.CompanionId} controls live session {GetShortId(session.Id)} on this machine.";
+    }
+
+    private ProjectSessionRecord? GetLatestProjectSessionForMachine(string? machineId) =>
+        string.IsNullOrWhiteSpace(machineId)
+            ? null
+            : _projectSessions
+                .Where(session => string.Equals(session.MachineId, machineId, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(session => session.UpdatedAt)
+                .FirstOrDefault();
+
+    private bool IsCurrentCompanionController(ProjectSessionRecord session) =>
+        !string.IsNullOrWhiteSpace(session.CompanionId) &&
+        !string.IsNullOrWhiteSpace(AgentClient.CompanionId) &&
+        string.Equals(session.CompanionId, AgentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
+
+    private static string GetShortId(string value) =>
+        value.Length <= 8 ? value : value[..8];
 
     private static string GetPlatformLabel(RunnerHostPlatform platform) => platform switch
     {

--- a/AgentDeck.Core/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/CoordinatorApiClient.cs
@@ -97,10 +97,16 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
                 return null;
             }
 
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Project '{projectId}' on machine '{machineId}' rejected the requested action.");
+            }
+
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<OpenProjectOnMachineResult>(cancellationToken: cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Coordinator project open failed for {ProjectId} on {MachineId}", projectId, machineId);
             throw;
@@ -222,10 +228,16 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
                 return null;
             }
 
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' rejected the requested orchestration action.");
+            }
+
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Coordinator orchestration queue failed for machine {MachineId}", machineId);
             throw;
@@ -247,10 +259,16 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
                 return null;
             }
 
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' rejected cancellation for job '{jobId}'.");
+            }
+
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<OrchestrationJob>(cancellationToken: cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Coordinator orchestration cancel failed for machine {MachineId} job {JobId}", machineId, jobId);
             throw;


### PR DESCRIPTION
## Summary
- reject project-mutating actions when a different companion controls the live project session on that machine
- translate coordinator conflicts into companion warnings instead of generic HTTP failures
- disable conflicting open/run/debug/cancel actions in the project page and explain why they are unavailable

## Testing
- dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj

Closes #170