### PR TITLE
Broker viewer sessions and machine remote locks

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddSingleton<IWorkerRegistryService, WorkerRegistryService>();
 builder.Services.AddSingleton<ICompanionRegistryService, CompanionRegistryService>();
 builder.Services.AddSingleton<IProjectRegistryService, ProjectRegistryService>();
 builder.Services.AddSingleton<IProjectSessionRegistryService, ProjectSessionRegistryService>();
+builder.Services.AddSingleton<IMachineRemoteControlRegistryService, MachineRemoteControlRegistryService>();
 builder.Services.AddSingleton<RunnerBrokerService>();
 builder.Services.AddSingleton<IRunnerBrokerService>(static services => services.GetRequiredService<RunnerBrokerService>());
 
@@ -151,7 +152,7 @@ app.MapPost("/api/project-sessions/{projectSessionId}/control", (string projectS
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.NotFound(new { message = ex.Message });
     }
 });
 
@@ -303,7 +304,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.NotFound(new { message = ex.Message });
     }
 });
 
@@ -413,7 +414,7 @@ app.MapPost("/api/machines/{machineId}/orchestration/jobs", async (string machin
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 
@@ -439,7 +440,7 @@ app.MapPost("/api/machines/{machineId}/orchestration/jobs/{jobId}/cancel", async
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 
@@ -456,6 +457,137 @@ app.MapGet("/api/machines/{machineId}/viewers/sessions", async (string machineId
     }
 });
 
+app.MapGet("/api/machines/{machineId}/viewers/control", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IMachineRemoteControlRegistryService remoteControl, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var gate = remoteControl.GetGate(machineId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var state = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken);
+            return state is null ? Results.NotFound() : Results.Ok(state);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.NotFound(new { message = ex.Message });
+    }
+});
+
+app.MapPost("/api/machines/{machineId}/viewers/sessions", async (string machineId, CreateMachineViewerSessionRequest? request, HttpContext httpContext, ICompanionRegistryService companions, IMachineRemoteControlRegistryService remoteControl, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    var companionId = GetCompanionId(httpContext);
+    if (string.IsNullOrWhiteSpace(companionId))
+    {
+        return Results.BadRequest(new { message = "Coordinator companion identity is required to create a remote viewer session." });
+    }
+
+    var companion = companions.GetCompanion(companionId);
+    if (companion is null)
+    {
+        return Results.BadRequest(new { message = $"Coordinator does not recognize companion '{companionId}'." });
+    }
+
+    request ??= new CreateMachineViewerSessionRequest();
+
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var gate = remoteControl.GetGate(machineId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken);
+            if (existingState is not null)
+            {
+                var currentControllerIsRequester = string.Equals(existingState.ControllerCompanionId, companionId.Trim(), StringComparison.OrdinalIgnoreCase);
+                if (!currentControllerIsRequester && !request.ForceTakeover)
+                {
+                    return Results.Conflict(new { message = BuildRemoteControlConflictMessage(existingState) });
+                }
+
+                if (!string.IsNullOrWhiteSpace(existingState.ViewerSessionId))
+                {
+                    await runners.CloseViewerSessionAsync(machineId, existingState.ViewerSessionId, GetActorId(httpContext), cancellationToken);
+                }
+
+                remoteControl.ClearState(machineId, existingState.ViewerSessionId);
+            }
+
+            var session = await runners.CreateViewerSessionAsync(machineId, request.Viewer, GetActorId(httpContext), cancellationToken);
+            remoteControl.SetState(new MachineRemoteControlState
+            {
+                MachineId = machineId.Trim(),
+                MachineName = request.Viewer.MachineName,
+                ControllerCompanionId = companion.CompanionId,
+                ControllerDisplayName = companion.DisplayName,
+                ViewerSessionId = session.Id,
+                TargetKind = session.Target.Kind,
+                TargetDisplayName = session.Target.DisplayName,
+                Provider = session.Provider,
+                ViewerStatus = session.Status,
+                ConnectionUri = session.ConnectionUri,
+                StatusMessage = session.StatusMessage,
+                AcquiredAt = DateTimeOffset.UtcNow,
+                UpdatedAt = session.UpdatedAt
+            });
+            return Results.Ok(session);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { message = ex.Message });
+    }
+});
+
+app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/close", async (string machineId, string viewerSessionId, HttpContext httpContext, ICompanionRegistryService companions, IMachineRemoteControlRegistryService remoteControl, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    var companionId = GetCompanionId(httpContext);
+    if (string.IsNullOrWhiteSpace(companionId))
+    {
+        return Results.BadRequest(new { message = "Coordinator companion identity is required to close a remote viewer session." });
+    }
+
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var gate = remoteControl.GetGate(machineId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken);
+            if (existingState is not null &&
+                string.Equals(existingState.ViewerSessionId, viewerSessionId.Trim(), StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(existingState.ControllerCompanionId, companionId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return Results.Conflict(new { message = BuildRemoteControlConflictMessage(existingState) });
+            }
+
+            var session = await runners.CloseViewerSessionAsync(machineId, viewerSessionId, GetActorId(httpContext), cancellationToken);
+            remoteControl.ClearState(machineId, viewerSessionId);
+            return session is null ? Results.NotFound() : Results.Ok(session);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { message = ex.Message });
+    }
+});
+
 app.MapGet("/api/machines/{machineId}/virtual-devices/catalogs", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try
@@ -465,7 +597,7 @@ app.MapGet("/api/machines/{machineId}/virtual-devices/catalogs", async (string m
     }
     catch (InvalidOperationException ex)
     {
-        return Results.NotFound(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 
@@ -497,7 +629,7 @@ app.MapPost("/api/machines/{machineId}/capabilities/{capabilityId}/install", asy
     }
     catch (InvalidOperationException ex)
     {
-        return Results.NotFound(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 
@@ -598,4 +730,48 @@ static ProjectSessionRecord? GetLatestProjectSession(
             string.Equals(session.MachineId, normalizedMachineId, StringComparison.OrdinalIgnoreCase))
         .OrderByDescending(session => session.UpdatedAt)
         .FirstOrDefault();
+}
+
+static string BuildRemoteControlConflictMessage(MachineRemoteControlState state) =>
+    $"Machine '{state.MachineName ?? state.MachineId}' is currently remotely controlled by companion '{state.ControllerDisplayName ?? state.ControllerCompanionId}' through viewer session '{state.ViewerSessionId}'. Use force takeover to replace that remote controller.";
+
+static async Task<MachineRemoteControlState?> ReconcileMachineRemoteControlAsync(
+    string machineId,
+    IMachineRemoteControlRegistryService remoteControl,
+    IRunnerBrokerService runners,
+    CancellationToken cancellationToken)
+{
+    var state = remoteControl.GetState(machineId);
+    if (state is null)
+    {
+        return null;
+    }
+
+    var viewers = await runners.GetViewerSessionsAsync(machineId, cancellationToken);
+    var activeViewer = viewers.FirstOrDefault(viewer =>
+        string.Equals(viewer.Id, state.ViewerSessionId, StringComparison.OrdinalIgnoreCase));
+    if (activeViewer is null || activeViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+    {
+        remoteControl.ClearState(machineId, state.ViewerSessionId);
+        return null;
+    }
+
+    var reconciled = new MachineRemoteControlState
+    {
+        MachineId = state.MachineId,
+        MachineName = activeViewer.MachineName ?? state.MachineName,
+        ControllerCompanionId = state.ControllerCompanionId,
+        ControllerDisplayName = state.ControllerDisplayName,
+        ViewerSessionId = activeViewer.Id,
+        TargetKind = activeViewer.Target.Kind,
+        TargetDisplayName = activeViewer.Target.DisplayName,
+        Provider = activeViewer.Provider,
+        ViewerStatus = activeViewer.Status,
+        ConnectionUri = activeViewer.ConnectionUri,
+        StatusMessage = activeViewer.StatusMessage,
+        AcquiredAt = state.AcquiredAt,
+        UpdatedAt = activeViewer.UpdatedAt
+    };
+
+    return remoteControl.SetState(reconciled);
 }

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -516,8 +516,6 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions", async (string machineI
                 {
                     await runners.CloseViewerSessionAsync(machineId, existingState.ViewerSessionId, GetActorId(httpContext), cancellationToken);
                 }
-
-                remoteControl.ClearState(machineId, existingState.ViewerSessionId);
             }
 
             var session = await runners.CreateViewerSessionAsync(machineId, request.Viewer, GetActorId(httpContext), cancellationToken);
@@ -546,7 +544,7 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions", async (string machineI
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 
@@ -584,7 +582,7 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/close"
     }
     catch (InvalidOperationException ex)
     {
-        return Results.Conflict(new { message = ex.Message });
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
     }
 });
 

--- a/AgentDeck.Coordinator/Services/IMachineRemoteControlRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/IMachineRemoteControlRegistryService.cs
@@ -1,0 +1,11 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Coordinator.Services;
+
+public interface IMachineRemoteControlRegistryService
+{
+    SemaphoreSlim GetGate(string machineId);
+    MachineRemoteControlState? GetState(string machineId);
+    MachineRemoteControlState SetState(MachineRemoteControlState state);
+    MachineRemoteControlState? ClearState(string machineId, string? viewerSessionId = null);
+}

--- a/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
@@ -20,6 +20,8 @@ public interface IRunnerBrokerService
     Task<OrchestrationJob?> QueueOrchestrationJobAsync(string machineId, CreateOrchestrationJobRequest request, string actorId, CancellationToken cancellationToken = default);
     Task<OrchestrationJob?> CancelOrchestrationJobAsync(string machineId, string jobId, string actorId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<RemoteViewerSession>> GetViewerSessionsAsync(string machineId, CancellationToken cancellationToken = default);
+    Task<RemoteViewerSession> CreateViewerSessionAsync(string machineId, CreateRemoteViewerSessionRequest request, string actorId, CancellationToken cancellationToken = default);
+    Task<RemoteViewerSession?> CloseViewerSessionAsync(string machineId, string viewerSessionId, string actorId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetVirtualDeviceCatalogsAsync(string machineId, CancellationToken cancellationToken = default);
     Task<VirtualDeviceLaunchResolution?> ResolveVirtualDeviceAsync(string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Coordinator/Services/MachineRemoteControlRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/MachineRemoteControlRegistryService.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Coordinator.Services;
+
+public sealed class MachineRemoteControlRegistryService : IMachineRemoteControlRegistryService
+{
+    private readonly Lock _lock = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, MachineRemoteControlState> _states = new(StringComparer.OrdinalIgnoreCase);
+
+    public SemaphoreSlim GetGate(string machineId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(machineId);
+        return _gates.GetOrAdd(machineId.Trim(), static _ => new SemaphoreSlim(1, 1));
+    }
+
+    public MachineRemoteControlState? GetState(string machineId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(machineId);
+
+        lock (_lock)
+        {
+            return _states.TryGetValue(machineId.Trim(), out var state)
+                ? Clone(state)
+                : null;
+        }
+    }
+
+    public MachineRemoteControlState SetState(MachineRemoteControlState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var normalizedMachineId = state.MachineId.Trim();
+        var normalizedState = new MachineRemoteControlState
+        {
+            MachineName = state.MachineName,
+            ControllerCompanionId = state.ControllerCompanionId.Trim(),
+            ControllerDisplayName = state.ControllerDisplayName,
+            ViewerSessionId = state.ViewerSessionId.Trim(),
+            TargetKind = state.TargetKind,
+            TargetDisplayName = state.TargetDisplayName,
+            Provider = state.Provider,
+            ViewerStatus = state.ViewerStatus,
+            ConnectionUri = state.ConnectionUri,
+            StatusMessage = state.StatusMessage,
+            AcquiredAt = state.AcquiredAt,
+            UpdatedAt = state.UpdatedAt,
+            MachineId = normalizedMachineId
+        };
+
+        lock (_lock)
+        {
+            _states[normalizedMachineId] = normalizedState;
+            return Clone(normalizedState);
+        }
+    }
+
+    public MachineRemoteControlState? ClearState(string machineId, string? viewerSessionId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(machineId);
+
+        lock (_lock)
+        {
+            var normalizedMachineId = machineId.Trim();
+            if (!_states.TryGetValue(normalizedMachineId, out var existing))
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(viewerSessionId) &&
+                !string.Equals(existing.ViewerSessionId, viewerSessionId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return Clone(existing);
+            }
+
+            _states.Remove(normalizedMachineId);
+            return null;
+        }
+    }
+
+    private static MachineRemoteControlState Clone(MachineRemoteControlState state) =>
+        new()
+        {
+            MachineId = state.MachineId,
+            MachineName = state.MachineName,
+            ControllerCompanionId = state.ControllerCompanionId,
+            ControllerDisplayName = state.ControllerDisplayName,
+            ViewerSessionId = state.ViewerSessionId,
+            TargetKind = state.TargetKind,
+            TargetDisplayName = state.TargetDisplayName,
+            Provider = state.Provider,
+            ViewerStatus = state.ViewerStatus,
+            ConnectionUri = state.ConnectionUri,
+            StatusMessage = state.StatusMessage,
+            AcquiredAt = state.AcquiredAt,
+            UpdatedAt = state.UpdatedAt
+        };
+}

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -234,6 +234,44 @@ public sealed class RunnerBrokerService : IRunnerBrokerService, IAsyncDisposable
         return await entry.HttpClient!.GetFromJsonAsync<IReadOnlyList<RemoteViewerSession>>("api/viewers/sessions", cancellationToken) ?? [];
     }
 
+    public async Task<RemoteViewerSession> CreateViewerSessionAsync(string machineId, CreateRemoteViewerSessionRequest request, string actorId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Brokering viewer create for machine {MachineName} ({MachineId}) target {TargetKind} requested by {ActorId}",
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            request.Target.Kind,
+            actorId);
+        using var response = await CreateRunnerRequest(entry, HttpMethod.Post, "api/viewers/sessions", actorId)
+            .WithJsonContent(request)
+            .SendAsync(entry.HttpClient!, cancellationToken);
+        await EnsureBrokerSuccessAsync(response, "create viewer session", cancellationToken);
+        return (await response.Content.ReadFromJsonAsync<RemoteViewerSession>(cancellationToken: cancellationToken))!;
+    }
+
+    public async Task<RemoteViewerSession?> CloseViewerSessionAsync(string machineId, string viewerSessionId, string actorId, CancellationToken cancellationToken = default)
+    {
+        var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Brokering viewer close for session {ViewerSessionId} on machine {MachineName} ({MachineId}) requested by {ActorId}",
+            viewerSessionId,
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            actorId);
+        using var response = await CreateRunnerRequest(entry, HttpMethod.Post, $"api/viewers/sessions/{Uri.EscapeDataString(viewerSessionId)}/close", actorId)
+            .SendAsync(entry.HttpClient!, cancellationToken);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureBrokerSuccessAsync(response, "close viewer session", cancellationToken);
+        return await response.Content.ReadFromJsonAsync<RemoteViewerSession>(cancellationToken: cancellationToken);
+    }
+
     public async Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetVirtualDeviceCatalogsAsync(string machineId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -53,6 +53,7 @@
                 <div class="project-machine-grid">
                     @foreach (var machine in _dashboard.Machines.OrderByDescending(machine => machine.IsOnline).ThenBy(machine => machine.MachineName, StringComparer.OrdinalIgnoreCase))
                     {
+                        var remoteControlState = GetMachineRemoteControlState(machine.MachineId);
                         <article class="project-machine-card">
                             <div class="project-machine-card__header">
                                 <div>
@@ -68,6 +69,16 @@
                             {
                                 <p class="project-template-target__note">@projectControlNotice</p>
                             }
+                            @if (GetRemoteControlNotice(machine.MachineId) is { } remoteControlNotice)
+                            {
+                                <p class="project-template-target__note">@remoteControlNotice</p>
+                            }
+                            @if (remoteControlState is not null &&
+                                IsCurrentRemoteController(remoteControlState) &&
+                                !string.IsNullOrWhiteSpace(remoteControlState.ConnectionUri))
+                            {
+                                <p class="project-template-target__note"><code>@remoteControlState.ConnectionUri</code></p>
+                            }
                             <div class="project-machine-card__targets">
                                 @foreach (var target in machine.SupportedTargets.OrderBy(target => target.DisplayName))
                                 {
@@ -82,6 +93,27 @@
                                         @onclick="() => OpenProjectAsync(machine.MachineId, navigateToSession: true)">
                                     @(_openingMachineId == machine.MachineId ? "Opening..." : "Open project")
                                 </button>
+                                <button class="btn btn-accent"
+                                        disabled="@(!machine.IsOnline || _viewerActionMachineId == machine.MachineId)"
+                                        @onclick="() => OpenDesktopViewerAsync(machine, forceTakeover: false)">
+                                    @(_viewerActionMachineId == machine.MachineId ? "Working..." : "Open desktop viewer")
+                                </button>
+                                @if (remoteControlState is not null && !IsCurrentRemoteController(remoteControlState))
+                                {
+                                    <button class="btn btn-danger"
+                                            disabled="@(!machine.IsOnline || _viewerActionMachineId == machine.MachineId)"
+                                            @onclick="() => OpenDesktopViewerAsync(machine, forceTakeover: true)">
+                                        Force take over
+                                    </button>
+                                }
+                                else if (remoteControlState is not null && IsCurrentRemoteController(remoteControlState))
+                                {
+                                    <button class="btn btn-danger"
+                                            disabled="@(_viewerActionMachineId == machine.MachineId)"
+                                            @onclick="() => CloseViewerAsync(machine.MachineId, remoteControlState.ViewerSessionId)">
+                                        Close viewer
+                                    </button>
+                                }
                             </div>
                         </article>
                     }
@@ -355,8 +387,10 @@
     private IReadOnlyList<ProjectSessionRecord> _projectSessions = [];
     private IReadOnlyList<OrchestrationJob> _projectJobs = [];
     private IReadOnlyList<RemoteViewerSession> _projectViewerSessions = [];
+    private readonly Dictionary<string, MachineRemoteControlState> _remoteControlByMachineId = new(StringComparer.OrdinalIgnoreCase);
     private bool _loading = true;
     private string? _openingMachineId;
+    private string? _viewerActionMachineId;
     private string? _queueingProfileId;
     private string? _cancellingJobId;
     private string? _coordinatorUrl;
@@ -482,6 +516,7 @@
         {
             _projectJobs = [];
             _projectViewerSessions = [];
+            _remoteControlByMachineId.Clear();
             return;
         }
 
@@ -495,6 +530,12 @@
 
         var jobs = new List<OrchestrationJob>();
         var viewers = new List<RemoteViewerSession>();
+        var remoteControlTasks = _dashboard.Machines
+            .Where(machine => machine.IsOnline)
+            .ToDictionary(
+                machine => machine.MachineId,
+                machine => TryGetMachineRemoteControlStateAsync(machine.MachineId),
+                StringComparer.OrdinalIgnoreCase);
 
         foreach (var machineId in machinesToQuery)
         {
@@ -515,6 +556,28 @@
         _projectViewerSessions = viewers
             .OrderByDescending(viewer => viewer.UpdatedAt)
             .ToArray();
+
+        await Task.WhenAll(remoteControlTasks.Values);
+        _remoteControlByMachineId.Clear();
+        foreach (var (machineId, task) in remoteControlTasks)
+        {
+            if (task.Result is { } remoteControlState)
+            {
+                _remoteControlByMachineId[machineId] = remoteControlState;
+            }
+        }
+    }
+
+    private async Task<MachineRemoteControlState?> TryGetMachineRemoteControlStateAsync(string machineId)
+    {
+        try
+        {
+            return await CoordinatorClient.GetMachineRemoteControlStateAsync(_coordinatorUrl!, machineId);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private async Task OpenProjectAsync(string machineId, bool navigateToSession)
@@ -637,6 +700,92 @@
         finally
         {
             _queueingProfileId = null;
+        }
+    }
+
+    private async Task OpenDesktopViewerAsync(CompanionMachineSummary machine, bool forceTakeover)
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            return;
+        }
+
+        _viewerActionMachineId = machine.MachineId;
+        try
+        {
+            var session = await CoordinatorClient.CreateMachineViewerSessionAsync(_coordinatorUrl, machine.MachineId, new CreateMachineViewerSessionRequest
+            {
+                ForceTakeover = forceTakeover,
+                Viewer = new CreateRemoteViewerSessionRequest
+                {
+                    MachineId = machine.MachineId,
+                    MachineName = machine.MachineName,
+                    Target = new RemoteViewerTarget
+                    {
+                        Kind = RemoteViewerTargetKind.Desktop,
+                        DisplayName = $"{machine.MachineName} desktop"
+                    }
+                }
+            });
+            if (session is null)
+            {
+                Toasts.Show("The coordinator could not create that viewer session.", ToastKind.Error);
+                return;
+            }
+
+            Toasts.Show(
+                !string.IsNullOrWhiteSpace(session.ConnectionUri)
+                    ? $"Viewer ready: {session.ConnectionUri}"
+                    : session.StatusMessage ?? $"Opened desktop viewer on {machine.MachineName}.",
+                session.Status == RemoteViewerSessionStatus.Ready ? ToastKind.Success : ToastKind.Info);
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionMachineId = null;
+        }
+    }
+
+    private async Task CloseViewerAsync(string machineId, string viewerSessionId)
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl))
+        {
+            return;
+        }
+
+        _viewerActionMachineId = machineId;
+        try
+        {
+            var session = await CoordinatorClient.CloseMachineViewerSessionAsync(_coordinatorUrl, machineId, viewerSessionId);
+            if (session is null)
+            {
+                Toasts.Show("The coordinator could no longer find that viewer session.", ToastKind.Warning);
+                await LoadAsync();
+                return;
+            }
+
+            Toasts.Show(session.StatusMessage ?? "Viewer session closed.", ToastKind.Info);
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionMachineId = null;
         }
     }
 
@@ -860,6 +1009,23 @@
     private static string GetDeviceSelectionLabel(VirtualDeviceLaunchSelection selection) =>
         selection.DisplayName ?? selection.DeviceId ?? selection.ProfileId ?? "Device selection";
 
+    private MachineRemoteControlState? GetMachineRemoteControlState(string machineId) =>
+        _remoteControlByMachineId.TryGetValue(machineId, out var state) ? state : null;
+
+    private string? GetRemoteControlNotice(string machineId)
+    {
+        var state = GetMachineRemoteControlState(machineId);
+        if (state is null)
+        {
+            return null;
+        }
+
+        var targetLabel = state.TargetDisplayName ?? "Remote viewer";
+        return IsCurrentRemoteController(state)
+            ? $"{targetLabel} is currently controlled by you."
+            : $"{targetLabel} is currently controlled by {state.ControllerDisplayName ?? state.ControllerCompanionId}. Open will be rejected unless you force takeover.";
+    }
+
     private bool CanCancelJob(OrchestrationJob job) =>
         _cancellingJobId != job.Id &&
         job.Status is OrchestrationJobStatus.Queued or OrchestrationJobStatus.Preparing or OrchestrationJobStatus.Dispatching or OrchestrationJobStatus.Running &&
@@ -903,6 +1069,10 @@
         !string.IsNullOrWhiteSpace(session.CompanionId) &&
         !string.IsNullOrWhiteSpace(AgentClient.CompanionId) &&
         string.Equals(session.CompanionId, AgentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsCurrentRemoteController(MachineRemoteControlState state) =>
+        !string.IsNullOrWhiteSpace(AgentClient.CompanionId) &&
+        string.Equals(state.ControllerCompanionId, AgentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
 
     private static string GetShortId(string value) =>
         value.Length <= 8 ? value : value[..8];

--- a/AgentDeck.Core/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/CoordinatorApiClient.cs
@@ -292,6 +292,109 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         }
     }
 
+    public async Task<MachineRemoteControlState?> GetMachineRemoteControlStateAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.GetAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/control",
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MachineRemoteControlState>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator remote control lookup failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<RemoteViewerSession?> CreateMachineViewerSessionAsync(string coordinatorUrl, string machineId, CreateMachineViewerSessionRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsJsonAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/sessions",
+                request,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' rejected the requested viewer action.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new HttpRequestException(
+                    message ?? $"Coordinator viewer create failed with HTTP {(int)response.StatusCode}.",
+                    inner: null,
+                    response.StatusCode);
+            }
+
+            return await response.Content.ReadFromJsonAsync<RemoteViewerSession>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Coordinator viewer create failed for machine {MachineId}", machineId);
+            throw;
+        }
+    }
+
+    public async Task<RemoteViewerSession?> CloseMachineViewerSessionAsync(string coordinatorUrl, string machineId, string viewerSessionId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/sessions/{Uri.EscapeDataString(viewerSessionId)}/close",
+                content: null,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' rejected closing viewer '{viewerSessionId}'.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new HttpRequestException(
+                    message ?? $"Coordinator viewer close failed with HTTP {(int)response.StatusCode}.",
+                    inner: null,
+                    response.StatusCode);
+            }
+
+            return await response.Content.ReadFromJsonAsync<RemoteViewerSession>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Coordinator viewer close failed for machine {MachineId} viewer {ViewerSessionId}", machineId, viewerSessionId);
+            throw;
+        }
+    }
+
     public async Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetMachineVirtualDeviceCatalogsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default)
     {
         await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);

--- a/AgentDeck.Core/Services/ICoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/ICoordinatorApiClient.cs
@@ -29,6 +29,12 @@ public interface ICoordinatorApiClient
 
     Task<IReadOnlyList<RemoteViewerSession>> GetMachineViewerSessionsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
 
+    Task<MachineRemoteControlState?> GetMachineRemoteControlStateAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
+
+    Task<RemoteViewerSession?> CreateMachineViewerSessionAsync(string coordinatorUrl, string machineId, CreateMachineViewerSessionRequest request, CancellationToken cancellationToken = default);
+
+    Task<RemoteViewerSession?> CloseMachineViewerSessionAsync(string coordinatorUrl, string machineId, string viewerSessionId, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>> GetMachineVirtualDeviceCatalogsAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
 
     Task<VirtualDeviceLaunchResolution?> ResolveMachineVirtualDeviceAsync(string coordinatorUrl, string machineId, VirtualDeviceLaunchSelection selection, CancellationToken cancellationToken = default);

--- a/AgentDeck.Shared/Models/CreateMachineViewerSessionRequest.cs
+++ b/AgentDeck.Shared/Models/CreateMachineViewerSessionRequest.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Coordinator-brokered request to create a viewer session on a machine.</summary>
+public sealed class CreateMachineViewerSessionRequest
+{
+    public CreateRemoteViewerSessionRequest Viewer { get; init; } = new();
+    public bool ForceTakeover { get; init; }
+}

--- a/AgentDeck.Shared/Models/MachineRemoteControlState.cs
+++ b/AgentDeck.Shared/Models/MachineRemoteControlState.cs
@@ -1,0 +1,21 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Coordinator-owned machine-level remote control ownership snapshot.</summary>
+public sealed class MachineRemoteControlState
+{
+    public required string MachineId { get; init; } = string.Empty;
+    public string? MachineName { get; init; }
+    public required string ControllerCompanionId { get; init; } = string.Empty;
+    public string? ControllerDisplayName { get; init; }
+    public required string ViewerSessionId { get; init; } = string.Empty;
+    public RemoteViewerTargetKind TargetKind { get; init; } = RemoteViewerTargetKind.Desktop;
+    public string? TargetDisplayName { get; init; }
+    public RemoteViewerProviderKind Provider { get; init; } = RemoteViewerProviderKind.Auto;
+    public RemoteViewerSessionStatus ViewerStatus { get; init; } = RemoteViewerSessionStatus.Requested;
+    public string? ConnectionUri { get; init; }
+    public string? StatusMessage { get; init; }
+    public DateTimeOffset AcquiredAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ The coordinator now also keeps a first-pass project-session surface registry at 
 
 Project sessions now also model single-controller plus multi-viewer collaboration. The coordinator tracks attached companions, the active controller, and control-handoff state so only one companion can send terminal control input for a project-backed terminal at a time while other companions stay view-only until they request, force, or yield control through `/api/project-sessions/{projectSessionId}/attachments`, `/detach`, and `/control`.
 
+The coordinator now also brokers machine-level remote viewer ownership through `/api/machines/{machineId}/viewers/control` plus coordinator-owned viewer create/close endpoints. Desktop viewer requests now go through the coordinator instead of direct runner access, the coordinator records which companion currently controls remoting on that machine, and conflicting interactive viewer requests are rejected with a clear conflict unless the caller explicitly forces takeover.
+
 The runner also now exposes a first-pass orchestration job API, separate from terminal sessions, so coordinator-managed run/debug work can be queued, tracked by lifecycle status, associated with a target machine, and enriched with step/log data before full cross-machine dispatch is implemented.
 
 That orchestration layer now has real local execution paths for both direct-command run jobs and the first VS Code-backed debug jobs. Direct-command jobs build and launch on the runner, stream PTY output into job logs, and let cancellation stop the underlying process.


### PR DESCRIPTION
## Summary
- broker viewer session create/close flows through the coordinator and track machine-level remote controller ownership
- add coordinator conflict and force-takeover behavior for interactive machine remoting
- surface desktop viewer open, takeover, close, and ownership state in the project page

## Testing
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj --no-restore
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj --no-restore
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj --no-restore

Closes #174