### PR TITLE
Add runtime viewer control handoff

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -608,8 +608,8 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/contro
         try
         {
             var mode = (request ?? new UpdateProjectSessionControlRequest()).Mode;
-            var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken);
             var viewers = await runners.GetViewerSessionsAsync(machineId, cancellationToken);
+            var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken, viewers);
             var targetViewer = viewers.FirstOrDefault(viewer =>
                 string.Equals(viewer.Id, viewerSessionId.Trim(), StringComparison.OrdinalIgnoreCase));
             if (targetViewer is null || targetViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
@@ -841,7 +841,8 @@ static async Task<MachineRemoteControlState?> ReconcileMachineRemoteControlAsync
     string machineId,
     IMachineRemoteControlRegistryService remoteControl,
     IRunnerBrokerService runners,
-    CancellationToken cancellationToken)
+    CancellationToken cancellationToken,
+    IReadOnlyList<RemoteViewerSession>? viewers = null)
 {
     var state = remoteControl.GetState(machineId);
     if (state is null)
@@ -849,7 +850,7 @@ static async Task<MachineRemoteControlState?> ReconcileMachineRemoteControlAsync
         return null;
     }
 
-    var viewers = await runners.GetViewerSessionsAsync(machineId, cancellationToken);
+    viewers ??= await runners.GetViewerSessionsAsync(machineId, cancellationToken);
     var activeViewer = viewers.FirstOrDefault(viewer =>
         string.Equals(viewer.Id, state.ViewerSessionId, StringComparison.OrdinalIgnoreCase));
     if (activeViewer is null || activeViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -586,6 +586,88 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/close"
     }
 });
 
+app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/control", async (string machineId, string viewerSessionId, UpdateProjectSessionControlRequest? request, HttpContext httpContext, ICompanionRegistryService companions, IMachineRemoteControlRegistryService remoteControl, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
+{
+    var companionId = GetCompanionId(httpContext);
+    if (string.IsNullOrWhiteSpace(companionId))
+    {
+        return Results.BadRequest(new { message = "Coordinator companion identity is required to update remote viewer control." });
+    }
+
+    var companion = companions.GetCompanion(companionId);
+    if (companion is null)
+    {
+        return Results.BadRequest(new { message = $"Coordinator does not recognize companion '{companionId}'." });
+    }
+
+    try
+    {
+        TrackMachineAttachment(httpContext, companions, machineId);
+        var gate = remoteControl.GetGate(machineId);
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            var mode = (request ?? new UpdateProjectSessionControlRequest()).Mode;
+            var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken);
+            var viewers = await runners.GetViewerSessionsAsync(machineId, cancellationToken);
+            var targetViewer = viewers.FirstOrDefault(viewer =>
+                string.Equals(viewer.Id, viewerSessionId.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (targetViewer is null || targetViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+            {
+                return Results.NotFound(new { message = $"Machine '{machineId}' no longer exposes viewer session '{viewerSessionId}'." });
+            }
+
+            var normalizedCompanionId = companionId.Trim();
+            var sameRequesterControlsMachine = existingState is not null &&
+                string.Equals(existingState.ControllerCompanionId, normalizedCompanionId, StringComparison.OrdinalIgnoreCase);
+            var acquiredAt = existingState is not null &&
+                string.Equals(existingState.ControllerCompanionId, normalizedCompanionId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(existingState.ViewerSessionId, targetViewer.Id, StringComparison.OrdinalIgnoreCase)
+                ? existingState.AcquiredAt
+                : DateTimeOffset.UtcNow;
+
+            switch (mode)
+            {
+                case ProjectSessionControlRequestMode.Request:
+                    if (existingState is not null && !sameRequesterControlsMachine)
+                    {
+                        return Results.Conflict(new { message = BuildRemoteControlConflictMessage(existingState) });
+                    }
+
+                    return Results.Ok(remoteControl.SetState(BuildRemoteControlState(machineId, targetViewer, companion, acquiredAt)));
+
+                case ProjectSessionControlRequestMode.ForceTakeover:
+                    return Results.Ok(remoteControl.SetState(BuildRemoteControlState(machineId, targetViewer, companion, acquiredAt)));
+
+                case ProjectSessionControlRequestMode.Yield:
+                    if (existingState is null ||
+                        !string.Equals(existingState.ViewerSessionId, targetViewer.Id, StringComparison.OrdinalIgnoreCase) ||
+                        !string.Equals(existingState.ControllerCompanionId, normalizedCompanionId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return Results.Conflict(new
+                        {
+                            message = $"Companion '{normalizedCompanionId}' does not currently control viewer session '{targetViewer.Id}' on machine '{machineId}'."
+                        });
+                    }
+
+                    remoteControl.ClearState(machineId, targetViewer.Id);
+                    return Results.Ok(new { yielded = true });
+
+                default:
+                    return Results.BadRequest(new { message = $"Remote viewer control mode '{mode}' is not supported." });
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Json(new { message = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
+    }
+});
+
 app.MapGet("/api/machines/{machineId}/virtual-devices/catalogs", async (string machineId, HttpContext httpContext, ICompanionRegistryService companions, IRunnerBrokerService runners, CancellationToken cancellationToken) =>
 {
     try
@@ -732,6 +814,28 @@ static ProjectSessionRecord? GetLatestProjectSession(
 
 static string BuildRemoteControlConflictMessage(MachineRemoteControlState state) =>
     $"Machine '{state.MachineName ?? state.MachineId}' is currently remotely controlled by companion '{state.ControllerDisplayName ?? state.ControllerCompanionId}' through viewer session '{state.ViewerSessionId}'. Use force takeover to replace that remote controller.";
+
+static MachineRemoteControlState BuildRemoteControlState(
+    string machineId,
+    RemoteViewerSession viewer,
+    RegisteredCompanion companion,
+    DateTimeOffset acquiredAt) =>
+    new()
+    {
+        MachineId = machineId.Trim(),
+        MachineName = viewer.MachineName,
+        ControllerCompanionId = companion.CompanionId,
+        ControllerDisplayName = companion.DisplayName,
+        ViewerSessionId = viewer.Id,
+        TargetKind = viewer.Target.Kind,
+        TargetDisplayName = viewer.Target.DisplayName,
+        Provider = viewer.Provider,
+        ViewerStatus = viewer.Status,
+        ConnectionUri = viewer.ConnectionUri,
+        StatusMessage = viewer.StatusMessage,
+        AcquiredAt = acquiredAt,
+        UpdatedAt = viewer.UpdatedAt
+    };
 
 static async Task<MachineRemoteControlState?> ReconcileMachineRemoteControlAsync(
     string machineId,

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -284,6 +284,7 @@
                     <div class="project-list">
                         @foreach (var viewer in _projectViewerSessions.OrderByDescending(viewer => viewer.UpdatedAt))
                         {
+                            var remoteControlState = string.IsNullOrWhiteSpace(viewer.MachineId) ? null : GetMachineRemoteControlState(viewer.MachineId);
                             <article class="project-list-card">
                                 <div class="project-runtime-card__body">
                                     <div class="project-session-card__header">
@@ -301,6 +302,46 @@
                                     else if (!string.IsNullOrWhiteSpace(viewer.StatusMessage))
                                     {
                                         <p class="project-template-target__note">@viewer.StatusMessage</p>
+                                    }
+                                    @if (GetViewerControlNotice(viewer) is { } viewerControlNotice)
+                                    {
+                                        <p class="project-template-target__note">@viewerControlNotice</p>
+                                    }
+                                </div>
+                                <div class="project-runtime-card__actions">
+                                    @if (!string.IsNullOrWhiteSpace(viewer.MachineId) && CanControlViewer(viewer))
+                                    {
+                                        @if (remoteControlState is not null &&
+                                             string.Equals(remoteControlState.ViewerSessionId, viewer.Id, StringComparison.OrdinalIgnoreCase) &&
+                                             IsCurrentRemoteController(remoteControlState))
+                                        {
+                                            <button class="btn btn-accent"
+                                                    disabled="@(_viewerActionViewerId == viewer.Id)"
+                                                    @onclick="() => UpdateExistingViewerControlAsync(viewer, ProjectSessionControlRequestMode.Yield)">
+                                                Yield control
+                                            </button>
+                                            <button class="btn btn-danger"
+                                                    disabled="@(_viewerActionViewerId == viewer.Id)"
+                                                    @onclick="() => CloseViewerAsync(viewer.MachineId!, viewer.Id)">
+                                                Close viewer
+                                            </button>
+                                        }
+                                        else if (remoteControlState is not null && !IsCurrentRemoteController(remoteControlState))
+                                        {
+                                            <button class="btn btn-danger"
+                                                    disabled="@(_viewerActionViewerId == viewer.Id)"
+                                                    @onclick="() => UpdateExistingViewerControlAsync(viewer, ProjectSessionControlRequestMode.ForceTakeover)">
+                                                Force take over
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button class="btn btn-accent"
+                                                    disabled="@(_viewerActionViewerId == viewer.Id)"
+                                                    @onclick="() => UpdateExistingViewerControlAsync(viewer, ProjectSessionControlRequestMode.Request)">
+                                                Take control
+                                            </button>
+                                        }
                                     }
                                 </div>
                             </article>
@@ -391,6 +432,7 @@
     private bool _loading = true;
     private string? _openingMachineId;
     private string? _viewerActionMachineId;
+    private string? _viewerActionViewerId;
     private string? _queueingProfileId;
     private string? _cancellingJobId;
     private string? _coordinatorUrl;
@@ -751,6 +793,43 @@
         finally
         {
             _viewerActionMachineId = null;
+            _viewerActionViewerId = null;
+        }
+    }
+
+    private async Task UpdateExistingViewerControlAsync(RemoteViewerSession viewer, ProjectSessionControlRequestMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl) || string.IsNullOrWhiteSpace(viewer.MachineId))
+        {
+            return;
+        }
+
+        _viewerActionMachineId = viewer.MachineId;
+        _viewerActionViewerId = viewer.Id;
+        try
+        {
+            await CoordinatorClient.UpdateMachineViewerControlAsync(_coordinatorUrl, viewer.MachineId, viewer.Id, mode);
+            Toasts.Show(mode switch
+            {
+                ProjectSessionControlRequestMode.Request => $"You now control {viewer.Target.DisplayName}.",
+                ProjectSessionControlRequestMode.ForceTakeover => $"You took control of {viewer.Target.DisplayName}.",
+                ProjectSessionControlRequestMode.Yield => $"Yielded control of {viewer.Target.DisplayName}.",
+                _ => "Updated viewer control."
+            }, mode == ProjectSessionControlRequestMode.Yield ? ToastKind.Info : ToastKind.Success);
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionMachineId = null;
+            _viewerActionViewerId = null;
         }
     }
 
@@ -762,6 +841,7 @@
         }
 
         _viewerActionMachineId = machineId;
+        _viewerActionViewerId = viewerSessionId;
         try
         {
             var session = await CoordinatorClient.CloseMachineViewerSessionAsync(_coordinatorUrl, machineId, viewerSessionId);
@@ -786,6 +866,7 @@
         finally
         {
             _viewerActionMachineId = null;
+            _viewerActionViewerId = null;
         }
     }
 
@@ -1025,6 +1106,36 @@
             ? $"{targetLabel} is currently controlled by you."
             : $"{targetLabel} is currently controlled by {state.ControllerDisplayName ?? state.ControllerCompanionId}. Open will be rejected unless you force takeover.";
     }
+
+    private string? GetViewerControlNotice(RemoteViewerSession viewer)
+    {
+        if (string.IsNullOrWhiteSpace(viewer.MachineId))
+        {
+            return null;
+        }
+
+        var state = GetMachineRemoteControlState(viewer.MachineId);
+        if (state is null)
+        {
+            return null;
+        }
+
+        var controllerLabel = state.ControllerDisplayName ?? state.ControllerCompanionId;
+        var activeTarget = state.TargetDisplayName ?? "another viewer";
+        if (string.Equals(state.ViewerSessionId, viewer.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            return IsCurrentRemoteController(state)
+                ? "You currently control this viewer session."
+                : $"{controllerLabel} currently controls this viewer session.";
+        }
+
+        return IsCurrentRemoteController(state)
+            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote target."
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this viewer requires force takeover.";
+    }
+
+    private static bool CanControlViewer(RemoteViewerSession viewer) =>
+        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
 
     private bool CanCancelJob(OrchestrationJob job) =>
         _cancellingJobId != job.Id &&

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -131,6 +131,13 @@
                                     <dt>Viewer</dt>
                                     <dd>@GetViewerSummary(_activeSurface.Viewer)</dd>
                                 </div>
+                                @if (GetActiveViewerControlNotice() is { } viewerControlNotice)
+                                {
+                                    <div>
+                                        <dt>Remote control</dt>
+                                        <dd>@viewerControlNotice</dd>
+                                    </div>
+                                }
                                 @if (!string.IsNullOrWhiteSpace(_activeSurface.Viewer.ConnectionUri))
                                 {
                                     <div>
@@ -149,6 +156,40 @@
                         else if (_activeSurface.Job is not null || _activeSurface.Viewer is not null)
                         {
                             <p class="surface-details-card__note">This runtime tab is derived from the current machine orchestration/viewer state for this project session.</p>
+                        }
+                        @if (_activeSurface.Viewer is not null && CanControlActiveViewer())
+                        {
+                            <div class="project-runtime-card__actions">
+                                @if (IsActiveViewerControlledByCurrentCompanion())
+                                {
+                                    <button class="btn btn-accent"
+                                            disabled="@_viewerActionInProgress"
+                                            @onclick="() => UpdateActiveViewerControlAsync(ProjectSessionControlRequestMode.Yield)">
+                                        Yield control
+                                    </button>
+                                    <button class="btn btn-danger"
+                                            disabled="@_viewerActionInProgress"
+                                            @onclick="CloseActiveViewerAsync">
+                                        Close viewer
+                                    </button>
+                                }
+                                else if (HasAnotherCompanionControllingMachine())
+                                {
+                                    <button class="btn btn-danger"
+                                            disabled="@_viewerActionInProgress"
+                                            @onclick="() => UpdateActiveViewerControlAsync(ProjectSessionControlRequestMode.ForceTakeover)">
+                                        Force take over
+                                    </button>
+                                }
+                                else
+                                {
+                                    <button class="btn btn-accent"
+                                            disabled="@_viewerActionInProgress"
+                                            @onclick="() => UpdateActiveViewerControlAsync(ProjectSessionControlRequestMode.Request)">
+                                        Take control
+                                    </button>
+                                }
+                            </div>
                         }
                     </div>
                 }
@@ -170,7 +211,9 @@
     private IReadOnlyList<SurfaceTab> _surfaceTabs = [];
     private IReadOnlyList<OrchestrationJob> _runtimeJobs = [];
     private IReadOnlyList<RemoteViewerSession> _runtimeViewers = [];
+    private MachineRemoteControlState? _remoteControlState;
     private string? _runtimeLoadError;
+    private bool _viewerActionInProgress;
 
     protected override void OnInitialized()
     {
@@ -246,15 +289,17 @@
         if (_projectSession is null ||
             string.IsNullOrWhiteSpace(_coordinatorUrl) ||
             string.IsNullOrWhiteSpace(_projectSession.MachineId))
-        {
-            _runtimeJobs = [];
-            _runtimeViewers = [];
-            return;
-        }
+            {
+                _runtimeJobs = [];
+                _runtimeViewers = [];
+                _remoteControlState = null;
+                return;
+            }
 
         var jobsTask = CoordinatorClient.GetMachineOrchestrationJobsAsync(_coordinatorUrl, _projectSession.MachineId);
         var viewersTask = CoordinatorClient.GetMachineViewerSessionsAsync(_coordinatorUrl, _projectSession.MachineId);
-        await Task.WhenAll(jobsTask, viewersTask);
+        var remoteControlTask = TryGetMachineRemoteControlStateAsync(_projectSession.MachineId);
+        await Task.WhenAll(jobsTask, viewersTask, remoteControlTask);
 
         _runtimeJobs = jobsTask.Result
             .Where(job => string.Equals(job.ProjectId, _projectSession.ProjectId, StringComparison.OrdinalIgnoreCase))
@@ -268,6 +313,19 @@
                 (!string.IsNullOrWhiteSpace(viewer.Target.JobId) && jobIds.Contains(viewer.Target.JobId)))
             .OrderByDescending(viewer => viewer.UpdatedAt)
             .ToArray();
+        _remoteControlState = remoteControlTask.Result;
+    }
+
+    private async Task<MachineRemoteControlState?> TryGetMachineRemoteControlStateAsync(string machineId)
+    {
+        try
+        {
+            return await CoordinatorClient.GetMachineRemoteControlStateAsync(_coordinatorUrl!, machineId);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private void BuildSurfaceTabs()
@@ -527,6 +585,123 @@
             Toasts.Show(ex.Message, ToastKind.Error);
         }
     }
+
+    private async Task UpdateActiveViewerControlAsync(ProjectSessionControlRequestMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl) ||
+            string.IsNullOrWhiteSpace(_activeSurface?.MachineId) ||
+            _activeSurface.Viewer is null)
+        {
+            return;
+        }
+
+        _viewerActionInProgress = true;
+        try
+        {
+            await CoordinatorClient.UpdateMachineViewerControlAsync(_coordinatorUrl, _activeSurface.MachineId, _activeSurface.Viewer.Id, mode);
+            Toasts.Show(mode switch
+            {
+                ProjectSessionControlRequestMode.Request => $"You now control {_activeSurface.Viewer.Target.DisplayName}.",
+                ProjectSessionControlRequestMode.ForceTakeover => $"You took control of {_activeSurface.Viewer.Target.DisplayName}.",
+                ProjectSessionControlRequestMode.Yield => $"Yielded control of {_activeSurface.Viewer.Target.DisplayName}.",
+                _ => "Updated viewer control."
+            }, mode == ProjectSessionControlRequestMode.Yield ? ToastKind.Info : ToastKind.Success);
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionInProgress = false;
+        }
+    }
+
+    private async Task CloseActiveViewerAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_coordinatorUrl) ||
+            string.IsNullOrWhiteSpace(_activeSurface?.MachineId) ||
+            _activeSurface.Viewer is null)
+        {
+            return;
+        }
+
+        _viewerActionInProgress = true;
+        try
+        {
+            var session = await CoordinatorClient.CloseMachineViewerSessionAsync(_coordinatorUrl, _activeSurface.MachineId, _activeSurface.Viewer.Id);
+            if (session is null)
+            {
+                Toasts.Show("The coordinator could no longer find that viewer session.", ToastKind.Warning);
+            }
+            else
+            {
+                Toasts.Show(session.StatusMessage ?? "Viewer session closed.", ToastKind.Info);
+            }
+
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionInProgress = false;
+        }
+    }
+
+    private string? GetActiveViewerControlNotice()
+    {
+        if (_activeSurface?.Viewer is null)
+        {
+            return null;
+        }
+
+        if (_remoteControlState is null)
+        {
+            return null;
+        }
+
+        var controllerLabel = _remoteControlState.ControllerDisplayName ?? _remoteControlState.ControllerCompanionId;
+        var activeTarget = _remoteControlState.TargetDisplayName ?? "another viewer";
+        if (string.Equals(_remoteControlState.ViewerSessionId, _activeSurface.Viewer.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            return IsActiveViewerControlledByCurrentCompanion()
+                ? "You currently control this viewer session."
+                : $"{controllerLabel} currently controls this viewer session.";
+        }
+
+        return IsCurrentRemoteController(_remoteControlState)
+            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote target."
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this viewer requires force takeover.";
+    }
+
+    private bool CanControlActiveViewer() =>
+        _activeSurface?.Viewer is not null &&
+        _activeSurface.Viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+
+    private bool IsActiveViewerControlledByCurrentCompanion() =>
+        _activeSurface?.Viewer is not null &&
+        _remoteControlState is not null &&
+        string.Equals(_remoteControlState.ViewerSessionId, _activeSurface.Viewer.Id, StringComparison.OrdinalIgnoreCase) &&
+        IsCurrentRemoteController(_remoteControlState);
+
+    private bool HasAnotherCompanionControllingMachine() =>
+        _remoteControlState is not null && !IsCurrentRemoteController(_remoteControlState);
+
+    private bool IsCurrentRemoteController(MachineRemoteControlState state) =>
+        !string.IsNullOrWhiteSpace(AgentClient.CompanionId) &&
+        string.Equals(state.ControllerCompanionId, AgentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
 
     public async ValueTask DisposeAsync()
     {

--- a/AgentDeck.Core/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/CoordinatorApiClient.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Json;
+using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Logging;
 
@@ -391,6 +392,47 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         catch (Exception ex) when (ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Coordinator viewer close failed for machine {MachineId} viewer {ViewerSessionId}", machineId, viewerSessionId);
+            throw;
+        }
+    }
+
+    public async Task UpdateMachineViewerControlAsync(string coordinatorUrl, string machineId, string viewerSessionId, ProjectSessionControlRequestMode mode, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompanionIdentityAsync(coordinatorUrl, cancellationToken);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsJsonAsync(
+                $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/sessions/{Uri.EscapeDataString(viewerSessionId)}/control",
+                new UpdateProjectSessionControlRequest
+                {
+                    Mode = mode
+                },
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' no longer exposes viewer '{viewerSessionId}'.");
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Machine '{machineId}' rejected control changes for viewer '{viewerSessionId}'.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new HttpRequestException(
+                    message ?? $"Coordinator viewer control update failed with HTTP {(int)response.StatusCode}.",
+                    inner: null,
+                    response.StatusCode);
+            }
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Coordinator viewer control update failed for machine {MachineId} viewer {ViewerSessionId}", machineId, viewerSessionId);
             throw;
         }
     }

--- a/AgentDeck.Core/Services/ICoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/ICoordinatorApiClient.cs
@@ -1,3 +1,4 @@
+using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 
 namespace AgentDeck.Core.Services;
@@ -32,6 +33,8 @@ public interface ICoordinatorApiClient
     Task<MachineRemoteControlState?> GetMachineRemoteControlStateAsync(string coordinatorUrl, string machineId, CancellationToken cancellationToken = default);
 
     Task<RemoteViewerSession?> CreateMachineViewerSessionAsync(string coordinatorUrl, string machineId, CreateMachineViewerSessionRequest request, CancellationToken cancellationToken = default);
+
+    Task UpdateMachineViewerControlAsync(string coordinatorUrl, string machineId, string viewerSessionId, ProjectSessionControlRequestMode mode, CancellationToken cancellationToken = default);
 
     Task<RemoteViewerSession?> CloseMachineViewerSessionAsync(string coordinatorUrl, string machineId, string viewerSessionId, CancellationToken cancellationToken = default);
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Project sessions now also model single-controller plus multi-viewer collaboratio
 
 The coordinator now also brokers machine-level remote viewer ownership through `/api/machines/{machineId}/viewers/control` plus coordinator-owned viewer create/close endpoints. Desktop viewer requests now go through the coordinator instead of direct runner access, the coordinator records which companion currently controls remoting on that machine, and conflicting interactive viewer requests are rejected with a clear conflict unless the caller explicitly forces takeover.
 
+That machine-level remote-control model now also applies to existing runtime viewer sessions. Companions can request, force-take-over, or yield control of a runner-created VS Code, emulator, simulator, desktop, or window viewer through `/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/control`, so project and project-session surfaces can show actionable controller state instead of only passive viewer metadata.
+
 The runner also now exposes a first-pass orchestration job API, separate from terminal sessions, so coordinator-managed run/debug work can be queued, tracked by lifecycle status, associated with a target machine, and enriched with step/log data before full cross-machine dispatch is implemented.
 
 That orchestration layer now has real local execution paths for both direct-command run jobs and the first VS Code-backed debug jobs. Direct-command jobs build and launch on the runner, stream PTY output into job logs, and let cancellation stop the underlying process.


### PR DESCRIPTION
## Summary
- add coordinator-owned request/force-take-over/yield control flow for existing viewer sessions on a machine
- surface runtime viewer controller state and actions on the project page and the project-session surface page
- document that the machine remote lock model now applies to runner-created runtime viewer surfaces too

## Testing
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj --no-restore
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj --no-restore
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj --no-restore

Closes #176