### PR TITLE
Align session and active viewer handoff

### DIFF
--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -568,13 +568,36 @@
             return;
         }
 
+        var activeViewerMachineId = _activeSurface?.MachineId;
+        var activeViewer = _activeSurface?.Viewer;
+        var shouldSyncActiveViewer =
+            activeViewer is not null &&
+            !string.IsNullOrWhiteSpace(activeViewerMachineId) &&
+            activeViewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed &&
+            (mode is ProjectSessionControlRequestMode.Request or ProjectSessionControlRequestMode.ForceTakeover ||
+             IsActiveViewerControlledByCurrentCompanion());
+
         try
         {
             await CoordinatorClient.UpdateProjectSessionControlAsync(_coordinatorUrl, _projectSession.Id, new UpdateProjectSessionControlRequest
             {
                 Mode = mode
             });
+
+            string? viewerSyncWarning = null;
+            if (shouldSyncActiveViewer)
+            {
+                viewerSyncWarning = await TrySyncActiveViewerAfterSessionControlAsync(
+                    activeViewerMachineId!,
+                    activeViewer!,
+                    mode);
+            }
+
             await LoadAsync();
+            if (!string.IsNullOrWhiteSpace(viewerSyncWarning))
+            {
+                Toasts.Show(viewerSyncWarning, ToastKind.Warning);
+            }
         }
         catch (InvalidOperationException ex)
         {
@@ -583,6 +606,26 @@
         catch (Exception ex)
         {
             Toasts.Show(ex.Message, ToastKind.Error);
+        }
+    }
+
+    private async Task<string?> TrySyncActiveViewerAfterSessionControlAsync(
+        string machineId,
+        RemoteViewerSession viewer,
+        ProjectSessionControlRequestMode mode)
+    {
+        try
+        {
+            await CoordinatorClient.UpdateMachineViewerControlAsync(_coordinatorUrl!, machineId, viewer.Id, mode);
+            return null;
+        }
+        catch (InvalidOperationException ex)
+        {
+            return $"Project-session control updated, but viewer handoff for {viewer.Target.DisplayName} did not: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            return $"Project-session control updated, but syncing viewer control for {viewer.Target.DisplayName} failed: {ex.Message}";
         }
     }
 


### PR DESCRIPTION
## Summary
- synchronize project-session control changes with the active viewer surface on the project-session page
- yield active viewer control when yielding the session if the current companion owns that viewer
- surface warning toasts when session handoff succeeds but viewer handoff does not

## Testing
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj --no-restore
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj --no-restore
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj --no-restore

Closes #178