### PR TITLE
Surface runner control-plane status on the dashboard

### DIFF
--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -26,6 +26,9 @@ public sealed class CompanionMachineSummary
     public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Unknown;
     public string? AgentVersion { get; init; }
     public DateTimeOffset LastSeenAt { get; init; }
+    public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
+    public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }
+    public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
     public IReadOnlyList<MachineTargetSupport> SupportedTargets { get; init; } = [];
 }
 

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -128,9 +128,12 @@
                                     <div class="project-machine-card__targets">
                                         @if (machine.UpdateRollout is { } rollout)
                                         {
-                                            <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetUpdateRolloutChipClass(rollout.State))">
+                                            @if (ShouldShowUpdateRolloutChip(rollout.State))
+                                            {
+                                                <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetUpdateRolloutChipClass(rollout.State))">
                                                 Update @GetUpdateRolloutLabel(rollout.State)
-                                            </span>
+                                                </span>
+                                            }
                                         }
                                         @if (machine.WorkflowPackStatus is { } workflowPackStatus &&
                                              workflowPackStatus.State != RunnerWorkflowPackState.None)
@@ -326,11 +329,14 @@
     };
 
     private static bool HasControlPlaneSignals(CompanionMachineSummary machine) =>
-        machine.UpdateRollout is not null ||
+        (machine.UpdateRollout is not null && ShouldShowUpdateRolloutChip(machine.UpdateRollout.State)) ||
         (machine.WorkflowPackStatus is not null && machine.WorkflowPackStatus.State != RunnerWorkflowPackState.None) ||
         (machine.WorkflowCatalogStatus is not null && machine.WorkflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown);
 
     private static string GetControlPlaneChipClass(string stateClass) => stateClass;
+
+    private static bool ShouldShowUpdateRolloutChip(RunnerUpdateRolloutState state) =>
+        state is not (RunnerUpdateRolloutState.UpToDate or RunnerUpdateRolloutState.Applied);
 
     private static string GetUpdateRolloutLabel(RunnerUpdateRolloutState state) => state switch
     {

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -123,6 +123,31 @@
                                         <span>• companion connected</span>
                                     }
                                 </p>
+                                @if (HasControlPlaneSignals(machine))
+                                {
+                                    <div class="project-machine-card__targets">
+                                        @if (machine.UpdateRollout is { } rollout)
+                                        {
+                                            <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetUpdateRolloutChipClass(rollout.State))">
+                                                Update @GetUpdateRolloutLabel(rollout.State)
+                                            </span>
+                                        }
+                                        @if (machine.WorkflowPackStatus is { } workflowPackStatus &&
+                                             workflowPackStatus.State != RunnerWorkflowPackState.None)
+                                        {
+                                            <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowPackChipClass(workflowPackStatus.State))">
+                                                Workflow pack @GetWorkflowPackStateLabel(workflowPackStatus.State)
+                                            </span>
+                                        }
+                                        @if (machine.WorkflowCatalogStatus is { } workflowCatalogStatus &&
+                                             workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
+                                        {
+                                            <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowCatalogChipClass(workflowCatalogStatus.State))">
+                                                Catalog @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
+                                            </span>
+                                        }
+                                    </div>
+                                }
                                 <div class="project-machine-card__targets">
                                     @foreach (var target in machine.SupportedTargets.OrderBy(target => target.DisplayName))
                                     {
@@ -298,6 +323,68 @@
         MachineTargetSupportStatus.Supported => "supported",
         MachineTargetSupportStatus.RequiresSetup => "setup",
         _ => "unsupported"
+    };
+
+    private static bool HasControlPlaneSignals(CompanionMachineSummary machine) =>
+        machine.UpdateRollout is not null ||
+        (machine.WorkflowPackStatus is not null && machine.WorkflowPackStatus.State != RunnerWorkflowPackState.None) ||
+        (machine.WorkflowCatalogStatus is not null && machine.WorkflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown);
+
+    private static string GetControlPlaneChipClass(string stateClass) => stateClass;
+
+    private static string GetUpdateRolloutLabel(RunnerUpdateRolloutState state) => state switch
+    {
+        RunnerUpdateRolloutState.UpToDate => "Up to date",
+        RunnerUpdateRolloutState.UpdateAvailable => "Update available",
+        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
+        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
+        RunnerUpdateRolloutState.Applying => "Applying",
+        RunnerUpdateRolloutState.Applied => "Applied",
+        RunnerUpdateRolloutState.Failed => "Failed",
+        RunnerUpdateRolloutState.Blocked => "Blocked",
+        _ => state.ToString()
+    };
+
+    private static string GetUpdateRolloutChipClass(RunnerUpdateRolloutState state) => state switch
+    {
+        RunnerUpdateRolloutState.UpToDate or RunnerUpdateRolloutState.Applied => "supported",
+        RunnerUpdateRolloutState.UpdateAvailable or
+        RunnerUpdateRolloutState.ManifestStaged or
+        RunnerUpdateRolloutState.PayloadStaged or
+        RunnerUpdateRolloutState.ReadyToApply or
+        RunnerUpdateRolloutState.Applying => "setup",
+        _ => "unsupported"
+    };
+
+    private static string GetWorkflowPackStateLabel(RunnerWorkflowPackState state) => state switch
+    {
+        RunnerWorkflowPackState.Ready => "Ready",
+        RunnerWorkflowPackState.Blocked => "Blocked",
+        RunnerWorkflowPackState.Failed => "Failed",
+        _ => "Unknown"
+    };
+
+    private static string GetWorkflowPackChipClass(RunnerWorkflowPackState state) => state switch
+    {
+        RunnerWorkflowPackState.Ready => "supported",
+        RunnerWorkflowPackState.Blocked => "setup",
+        RunnerWorkflowPackState.Failed => "unsupported",
+        _ => "setup"
+    };
+
+    private static string GetWorkflowCatalogStateLabel(RunnerWorkflowCatalogState state) => state switch
+    {
+        RunnerWorkflowCatalogState.Matched => "Matched",
+        RunnerWorkflowCatalogState.Mismatched => "Mismatched",
+        _ => "Unknown"
+    };
+
+    private static string GetWorkflowCatalogChipClass(RunnerWorkflowCatalogState state) => state switch
+    {
+        RunnerWorkflowCatalogState.Matched => "supported",
+        RunnerWorkflowCatalogState.Mismatched => "unsupported",
+        _ => "setup"
     };
 
     private static string GetRepositoryLabel(ProjectDefinition definition)

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -81,6 +81,9 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                 HostPlatform = machine.Platform?.HostPlatform ?? RunnerHostPlatform.Unknown,
                 AgentVersion = machine.AgentVersion,
                 LastSeenAt = machine.LastSeenAt,
+                UpdateRollout = machine.UpdateRollout,
+                WorkflowPackStatus = machine.WorkflowPackStatus,
+                WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
                 SupportedTargets = machine.SupportedTargets
             })
             .ToArray();


### PR DESCRIPTION
## Summary
- extend dashboard machine summaries with update rollout plus workflow pack and workflow catalog status from the existing coordinator machine directory payload
- show compact control-plane status chips on machine cards and highlight blocked, failed, and mismatched states
- keep the slice read-only and UI-only without adding new APIs or workflow execution behavior

Closes #202