### PR TITLE
Surface runner protocol and security policy status on the dashboard

### DIFF
--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -26,6 +26,8 @@ public sealed class CompanionMachineSummary
     public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Unknown;
     public string? AgentVersion { get; init; }
     public DateTimeOffset LastSeenAt { get; init; }
+    public bool ProtocolCompatible { get; init; } = true;
+    public string? SecurityPolicyVersion { get; init; }
     public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -122,10 +122,20 @@
                                     {
                                         <span>• companion connected</span>
                                     }
+                                    @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
+                                    {
+                                        <span>• security @machine.SecurityPolicyVersion</span>
+                                    }
                                 </p>
                                 @if (HasControlPlaneSignals(machine))
                                 {
                                     <div class="project-machine-card__targets">
+                                        @if (!machine.ProtocolCompatible)
+                                        {
+                                            <span class="project-target-chip project-target-chip--unsupported">
+                                                Protocol incompatible
+                                            </span>
+                                        }
                                         @if (machine.UpdateRollout is { } rollout)
                                         {
                                             @if (ShouldShowUpdateRolloutChip(rollout.State))
@@ -329,6 +339,7 @@
     };
 
     private static bool HasControlPlaneSignals(CompanionMachineSummary machine) =>
+        !machine.ProtocolCompatible ||
         (machine.UpdateRollout is not null && ShouldShowUpdateRolloutChip(machine.UpdateRollout.State)) ||
         (machine.WorkflowPackStatus is not null && machine.WorkflowPackStatus.State != RunnerWorkflowPackState.None) ||
         (machine.WorkflowCatalogStatus is not null && machine.WorkflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown);

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -81,6 +81,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                 HostPlatform = machine.Platform?.HostPlatform ?? RunnerHostPlatform.Unknown,
                 AgentVersion = machine.AgentVersion,
                 LastSeenAt = machine.LastSeenAt,
+                ProtocolCompatible = machine.ProtocolCompatible,
+                SecurityPolicyVersion = machine.SecurityPolicyVersion,
                 UpdateRollout = machine.UpdateRollout,
                 WorkflowPackStatus = machine.WorkflowPackStatus,
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,


### PR DESCRIPTION
## Summary
- extend dashboard machine summaries with protocol compatibility and security policy version from the existing coordinator machine directory payload
- show protocol incompatibility as an actionable chip and include security policy version in machine metadata
- keep the slice read-only and UI-only without adding new APIs or protocol behavior

Closes #204