### PR TITLE
Execute coordinator-assigned workflow packs on runners

### DIFF
--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
@@ -14,14 +15,20 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
     private readonly Lock _lock = new();
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);
     private readonly WorkerCoordinatorOptions _options;
+    private readonly IMachineCapabilityService _capabilities;
+    private readonly IMachineSetupService _machineSetup;
     private readonly ILogger<RunnerWorkflowPackService> _logger;
     private RunnerWorkflowPackStatus? _currentStatus;
 
     public RunnerWorkflowPackService(
         IOptions<WorkerCoordinatorOptions> options,
+        IMachineCapabilityService capabilities,
+        IMachineSetupService machineSetup,
         ILogger<RunnerWorkflowPackService> logger)
     {
         _options = options.Value;
+        _capabilities = capabilities;
+        _machineSetup = machineSetup;
         _logger = logger;
         _currentStatus = LoadPersistedStatus();
     }
@@ -126,29 +133,37 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
                 Directory.CreateDirectory(packDirectory);
                 var packPath = Path.Combine(packDirectory, "workflow-pack.json");
                 await WriteTextAtomicallyAsync(packPath, JsonSerializer.Serialize(pack, JsonOptions), cancellationToken);
+                var fetchedAt = DateTimeOffset.UtcNow;
+                var execution = await ExecuteWorkflowPackAsync(pack, cancellationToken);
 
                 return await UpdateStatusAsync(new RunnerWorkflowPackStatus
                 {
-                    State = RunnerWorkflowPackState.Ready,
+                    State = execution.Succeeded ? RunnerWorkflowPackState.Ready : RunnerWorkflowPackState.Failed,
                     PackId = pack.PackId,
                     PackVersion = pack.Version,
                     LocalPackPath = packPath,
-                    FetchedAt = DateTimeOffset.UtcNow,
-                    StatusMessage = $"Workflow pack {pack.PackId}@{pack.Version} is available for future runner-side execution."
+                    FetchedAt = fetchedAt,
+                    StatusMessage = execution.Succeeded ? execution.Message : null,
+                    FailureMessage = execution.Succeeded ? null : execution.Message
                 }, cancellationToken);
             }
             catch (Exception ex)
             {
+                if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+
                 _logger.LogWarning(ex, "Failed to reconcile desired workflow pack {PackId}@{PackVersion}", desiredPackId, desiredPackVersion);
-                    return await UpdateStatusAsync(new RunnerWorkflowPackStatus
-                    {
-                        State = RunnerWorkflowPackState.Failed,
-                        PackId = desiredPackId,
-                        PackVersion = desiredPackVersion,
-                        LocalPackPath = GetRetainedLocalPackPath(currentStatus, desiredPackId, desiredPackVersion),
-                        FetchedAt = GetRetainedFetchedAt(currentStatus, desiredPackId, desiredPackVersion),
-                        FailureMessage = ex.Message
-                    }, cancellationToken);
+                return await UpdateStatusAsync(new RunnerWorkflowPackStatus
+                {
+                    State = RunnerWorkflowPackState.Failed,
+                    PackId = desiredPackId,
+                    PackVersion = desiredPackVersion,
+                    LocalPackPath = GetRetainedLocalPackPath(currentStatus, desiredPackId, desiredPackVersion),
+                    FetchedAt = GetRetainedFetchedAt(currentStatus, desiredPackId, desiredPackVersion),
+                    FailureMessage = ex.Message
+                }, CancellationToken.None);
             }
         }
         finally
@@ -323,6 +338,236 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
         }
     }
 
+    private async Task<WorkflowPackExecutionResult> ExecuteWorkflowPackAsync(RunnerWorkflowPack pack, CancellationToken cancellationToken)
+    {
+        if (pack.Steps.Count == 0)
+        {
+            return WorkflowPackExecutionResult.Success($"Workflow pack {pack.PackId}@{pack.Version} contains no steps to execute.");
+        }
+
+        var messages = new List<string>(pack.Steps.Count);
+        foreach (var step in pack.Steps)
+        {
+            var result = await ExecuteStepAsync(step, cancellationToken);
+            if (!result.Succeeded)
+            {
+                return WorkflowPackExecutionResult.Failure($"{GetStepDisplayName(step)} failed. {result.Message}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(result.Message))
+            {
+                messages.Add($"{GetStepDisplayName(step)}: {result.Message}");
+            }
+        }
+
+        var summary = $"Workflow pack {pack.PackId}@{pack.Version} executed {pack.Steps.Count} step(s) successfully.";
+        if (messages.Count == 0)
+        {
+            return WorkflowPackExecutionResult.Success(summary);
+        }
+
+        return WorkflowPackExecutionResult.Success($"{summary} {string.Join("; ", messages)}");
+    }
+
+    private async Task<WorkflowPackExecutionResult> ExecuteStepAsync(RunnerWorkflowStep step, CancellationToken cancellationToken)
+    {
+        return step.Kind switch
+        {
+            RunnerWorkflowStepKind.VerifyInstalledTool => await VerifyInstalledToolAsync(step, cancellationToken),
+            RunnerWorkflowStepKind.RunCommand => await ExecuteNamedCommandAsync(step, cancellationToken),
+            _ => WorkflowPackExecutionResult.Failure(
+                $"Workflow step kind '{step.Kind}' is not supported by this runner yet.")
+        };
+    }
+
+    private async Task<WorkflowPackExecutionResult> VerifyInstalledToolAsync(RunnerWorkflowStep step, CancellationToken cancellationToken)
+    {
+        var toolId = GetInput(step, "tool");
+        var probeCommand = GetInput(step, "command");
+        var failIfMissing = GetBooleanInput(step, "failIfMissing");
+        if (string.IsNullOrWhiteSpace(toolId) && string.IsNullOrWhiteSpace(probeCommand))
+        {
+            return WorkflowPackExecutionResult.Failure(
+                "VerifyInstalledTool requires either a 'tool' input or a 'command' input.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(toolId))
+        {
+            var snapshot = await _capabilities.GetSnapshotAsync(cancellationToken);
+            var capability = snapshot.Capabilities.FirstOrDefault(candidate =>
+                string.Equals(candidate.Id, toolId, StringComparison.OrdinalIgnoreCase));
+            if (capability?.Status == MachineCapabilityStatus.Installed)
+            {
+                var versionText = string.IsNullOrWhiteSpace(capability.Version) ? string.Empty : $" {capability.Version}";
+                return WorkflowPackExecutionResult.Success($"{capability.Name} detected{versionText}.");
+            }
+
+            if (capability is not null && string.IsNullOrWhiteSpace(probeCommand))
+            {
+                var message = string.IsNullOrWhiteSpace(capability.Message)
+                    ? $"{capability.Name} is not installed."
+                    : $"{capability.Name} is not installed. {capability.Message}";
+                return failIfMissing
+                    ? WorkflowPackExecutionResult.Failure(message)
+                    : WorkflowPackExecutionResult.Success(message);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(probeCommand))
+        {
+            var missingMessage = $"Tool '{toolId}' is not installed.";
+            return failIfMissing
+                ? WorkflowPackExecutionResult.Failure(missingMessage)
+                : WorkflowPackExecutionResult.Success(missingMessage);
+        }
+
+        var probeResult = await RunShellCommandAsync(probeCommand, cancellationToken);
+        if (probeResult.Succeeded)
+        {
+            return WorkflowPackExecutionResult.Success($"Probe command '{probeCommand}' succeeded.");
+        }
+
+        var failureMessage = FirstMeaningfulLine(probeResult.StandardError, probeResult.StandardOutput)
+            ?? $"Probe command '{probeCommand}' exited with code {probeResult.ExitCode}.";
+        return failIfMissing
+            ? WorkflowPackExecutionResult.Failure(failureMessage)
+            : WorkflowPackExecutionResult.Success($"Probe command '{probeCommand}' did not detect the tool yet.");
+    }
+
+    private async Task<WorkflowPackExecutionResult> ExecuteNamedCommandAsync(RunnerWorkflowStep step, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(step.CommandText))
+        {
+            return WorkflowPackExecutionResult.Failure("RunCommand requires a command identifier.");
+        }
+
+        MachineCapabilityInstallResult result;
+        switch (NormalizeCommandIdentifier(step.CommandText))
+        {
+            case "install-gh":
+            case "install-github-cli":
+                result = await _machineSetup.InstallCapabilityAsync("gh", cancellationToken: cancellationToken);
+                break;
+            case "install-copilot":
+            case "install-copilot-cli":
+                result = await _machineSetup.InstallCapabilityAsync("copilot", cancellationToken: cancellationToken);
+                break;
+            case "install-node":
+            case "install-nodejs":
+                result = await _machineSetup.InstallCapabilityAsync("node", GetInput(step, "version"), cancellationToken);
+                break;
+            case "install-python":
+                result = await _machineSetup.InstallCapabilityAsync("python", GetInput(step, "version"), cancellationToken);
+                break;
+            case "install-dotnet":
+            case "install-dotnet-sdk":
+                result = await _machineSetup.InstallCapabilityAsync("dotnet", GetInput(step, "version"), cancellationToken);
+                break;
+            case "update-gh":
+            case "update-github-cli":
+                result = await _machineSetup.UpdateCapabilityAsync("gh", cancellationToken);
+                break;
+            case "update-copilot":
+            case "update-copilot-cli":
+                result = await _machineSetup.UpdateCapabilityAsync("copilot", cancellationToken);
+                break;
+            default:
+                return WorkflowPackExecutionResult.Failure(
+                    $"Workflow command '{step.CommandText}' is not supported by this runner.");
+        }
+
+        if (result.Succeeded)
+        {
+            return WorkflowPackExecutionResult.Success(result.Message ?? $"{result.CapabilityName} {result.Action} succeeded.");
+        }
+
+        var failureMessage = FirstMeaningfulLine(result.StandardError, result.StandardOutput)
+            ?? result.Message
+            ?? $"{result.CapabilityName} {result.Action} failed with exit code {result.ExitCode}.";
+        return WorkflowPackExecutionResult.Failure(failureMessage);
+    }
+
+    private static async Task<ShellCommandResult> RunShellCommandAsync(string commandText, CancellationToken cancellationToken)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("powershell.exe")
+            : new ProcessStartInfo("/bin/sh");
+
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add(commandText);
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-lc");
+            startInfo.ArgumentList.Add(commandText);
+        }
+
+        startInfo.UseShellExecute = false;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.CreateNoWindow = true;
+
+        using var process = new Process { StartInfo = startInfo };
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            return new ShellCommandResult(false, -1, string.Empty, ex.Message);
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new ShellCommandResult(
+            process.ExitCode == 0,
+            process.ExitCode,
+            await standardOutputTask,
+            await standardErrorTask);
+    }
+
+    private static string? GetInput(RunnerWorkflowStep step, string key) =>
+        step.Inputs.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
+
+    private static bool GetBooleanInput(RunnerWorkflowStep step, string key) =>
+        step.Inputs.TryGetValue(key, out var value) &&
+        bool.TryParse(value, out var parsed) &&
+        parsed;
+
+    private static string NormalizeCommandIdentifier(string commandText) => commandText.Trim().ToLowerInvariant();
+
+    private static string GetStepDisplayName(RunnerWorkflowStep step) =>
+        string.IsNullOrWhiteSpace(step.DisplayName) ? step.StepId : step.DisplayName.Trim();
+
+    private static string? FirstMeaningfulLine(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var line = value
+                .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate));
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                return line;
+            }
+        }
+
+        return null;
+    }
+
     private static string SanitizePathComponent(string value)
     {
         var invalidChars = Path.GetInvalidFileNameChars();
@@ -335,4 +580,13 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
 
         return new string(builder, 0, index);
     }
+
+    private readonly record struct WorkflowPackExecutionResult(bool Succeeded, string Message)
+    {
+        public static WorkflowPackExecutionResult Success(string message) => new(true, message);
+
+        public static WorkflowPackExecutionResult Failure(string message) => new(false, message);
+    }
+
+    private readonly record struct ShellCommandResult(bool Succeeded, int ExitCode, string StandardOutput, string StandardError);
 }

--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -548,14 +548,14 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
 
         var standardOutputTask = process.StandardOutput.ReadToEndAsync();
         var standardErrorTask = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
+        await Task.WhenAll(standardOutputTask, standardErrorTask, process.WaitForExitAsync());
         cancellationToken.ThrowIfCancellationRequested();
 
         return new ShellCommandResult(
             process.ExitCode == 0,
             process.ExitCode,
-            await standardOutputTask,
-            await standardErrorTask);
+            standardOutputTask.Result,
+            standardErrorTask.Result);
     }
 
     private static string? GetInput(RunnerWorkflowStep step, string key) =>

--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -84,6 +84,16 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
                 return currentStatus;
             }
 
+            if (currentStatus?.State == RunnerWorkflowPackState.Failed &&
+                currentStatus.ExecutionAttempted &&
+                string.Equals(currentStatus.PackId, desiredPackId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(currentStatus.PackVersion, desiredPackVersion, StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(currentStatus.LocalPackPath) &&
+                File.Exists(currentStatus.LocalPackPath))
+            {
+                return currentStatus;
+            }
+
             try
             {
                 var pack = await coordinatorClient.GetFromJsonAsync<RunnerWorkflowPack>(
@@ -139,6 +149,7 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
                 return await UpdateStatusAsync(new RunnerWorkflowPackStatus
                 {
                     State = execution.Succeeded ? RunnerWorkflowPackState.Ready : RunnerWorkflowPackState.Failed,
+                    ExecutionAttempted = true,
                     PackId = pack.PackId,
                     PackVersion = pack.Version,
                     LocalPackPath = packPath,
@@ -521,9 +532,24 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
             return new ShellCommandResult(false, -1, string.Empty, ex.Message);
         }
 
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
+        using var cancellationRegistration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+            }
+        });
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        cancellationToken.ThrowIfCancellationRequested();
 
         return new ShellCommandResult(
             process.ExitCode == 0,

--- a/AgentDeck.Shared/Models/RunnerWorkflowPackStatus.cs
+++ b/AgentDeck.Shared/Models/RunnerWorkflowPackStatus.cs
@@ -6,6 +6,7 @@ namespace AgentDeck.Shared.Models;
 public sealed class RunnerWorkflowPackStatus
 {
     public RunnerWorkflowPackState State { get; init; } = RunnerWorkflowPackState.None;
+    public bool ExecutionAttempted { get; init; }
     public string? PackId { get; init; }
     public string? PackVersion { get; init; }
     public string? LocalPackPath { get; init; }

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The coordinator now also publishes first-pass runner definition contracts:
 - update manifests at `/api/runner-definitions/update-manifests/{manifestId}`
 - workflow packs at `/api/runner-definitions/workflow-packs/{packId}`
 
-The desired-state heartbeat can point to a specific update manifest and workflow pack so later slices can add real artifact download/apply behavior and workflow-pack execution without changing the protocol shape again.
+The desired-state heartbeat can point to a specific update manifest and workflow pack so later slices can add real artifact download/apply behavior and deepen workflow-pack execution without changing the protocol shape again.
 
 Runner update staging is now a separate first-pass flow: workers can persist staged update metadata for an assigned manifest, and optionally download the referenced payload when `Coordinator:DownloadUpdatePayload` is enabled. When `Coordinator:ApplyStagedUpdate` is also enabled and policy allows apply, the runner launches a detached helper that waits for the current process to exit, extracts the trusted staged zip into a candidate install directory, preserves local `appsettings*.json`, and restarts from that candidate install. The runner reports structured update state back through its coordinator heartbeat so the control plane can distinguish between update-available, staged, applying, applied, and failed states.
 
@@ -223,7 +223,7 @@ Coordinators can now also host runner artifacts directly from a local artifact r
 
 The coordinator also computes an explicit rollout/apply summary for each worker and exposes it through the machine directory plus `/api/updates/rollouts` and `/api/machines/{machineId}/updates/rollout`. It now also accepts per-machine apply-intent overrides at `/api/machines/{machineId}/updates/apply-intent`, so the companion Settings page can request apply, force stage-only behavior, or restore coordinator-default apply intent per runner. The rollout summary makes it clear whether a runner is up to date, merely update-available, manifest-staged, payload-staged, ready to apply, applying, applied, failed, or blocked, along with the coordinator's apply intent and any blocking reason.
 
-Workflow packs now also have a first-pass runner status path: worker runners reconcile the desired workflow pack reference from coordinator desired state, persist the fetched pack metadata locally, and report a `Ready`, `Blocked`, or `Failed` workflow-pack status back through the machine directory without executing the pack yet.
+Workflow packs now also have a first-pass runner execution path: worker runners reconcile the desired workflow pack reference from coordinator desired state, persist the fetched pack metadata locally, and when policy allows they execute supported verification/setup steps by reusing the existing runner machine-setup primitives. The runner reports the resulting `Ready`, `Blocked`, or `Failed` workflow-pack status back through the machine directory, including explicit failures for unsupported step kinds or command identifiers.
 
 Workflow catalog versioning now also has explicit compatibility signaling: worker runners advertise a configured local workflow catalog version, reconcile it against the coordinator's desired catalog version, and report `Matched`, `Mismatched`, or `Unknown` catalog status through the machine directory.
 


### PR DESCRIPTION
## Summary
- execute coordinator-assigned workflow packs on runners after reconciliation instead of only caching them
- reuse the existing machine capability and machine setup services for first-pass verification and install/update step support
- report explicit workflow-pack execution success or failure through the existing status path and document the new behavior

Closes #206