### PR TITLE
Surface viewer transport readiness in machine capabilities

### DIFF
--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -425,6 +425,13 @@
                                 <span class="settings-status-row__value">@string.Join(", ", _machineCapabilities.SupportedTargets.Select(FormatTargetSummary))</span>
                             </div>
                         }
+                        @if (_machineCapabilities.RemoteViewerProviders.Count > 0)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Viewer transports</span>
+                                <span class="settings-status-row__value">@string.Join(", ", _machineCapabilities.RemoteViewerProviders.Select(GetViewerProviderSummary))</span>
+                            </div>
+                        }
                         }
                     </div>
                 </div>
@@ -474,6 +481,35 @@
                             <strong>@GetCapabilityCount(MachineCapabilityStatus.Error)</strong>
                         </div>
                     </div>
+
+                    @if (_machineCapabilities.RemoteViewerProviders.Count > 0)
+                    {
+                        <div class="capability-grid capability-grid--settings">
+                            @foreach (var provider in _machineCapabilities.RemoteViewerProviders.OrderBy(provider => provider.Provider))
+                            {
+                                <article class="capability-card">
+                                    <div class="capability-card__header">
+                                        <div>
+                                            <h3>@provider.DisplayName</h3>
+                                            <p>VIEWER TRANSPORT</p>
+                                        </div>
+                                        <span class="capability-status capability-status--installed">
+                                            @provider.Provider
+                                        </span>
+                                    </div>
+                                    <p><strong>Targets:</strong> @string.Join(", ", provider.SupportedTargets.Select(GetViewerTargetLabel))</p>
+                                    @if (provider.RequiresInteractiveDesktop)
+                                    {
+                                        <p class="capability-card__message">Requires an interactive desktop session.</p>
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(provider.Notes))
+                                    {
+                                        <p class="capability-card__message">@provider.Notes</p>
+                                    }
+                                </article>
+                            }
+                        </div>
+                    }
 
                     <div class="capability-grid capability-grid--settings">
                         @foreach (var capability in _machineCapabilities.Capabilities.OrderBy(capability => capability.Category).ThenBy(capability => capability.Name))
@@ -866,6 +902,21 @@
 
     private static string FormatTargetSummary(MachineTargetSupport target) =>
         $"{target.DisplayName} ({target.Status})";
+
+    private static string GetViewerProviderSummary(RemoteViewerProviderCapability provider) =>
+        provider.Provider == RemoteViewerProviderKind.Managed
+            ? $"{provider.DisplayName} (AgentDeck-managed)"
+            : provider.DisplayName;
+
+    private static string GetViewerTargetLabel(RemoteViewerTargetKind kind) => kind switch
+    {
+        RemoteViewerTargetKind.Desktop => "Desktop",
+        RemoteViewerTargetKind.Window => "Window",
+        RemoteViewerTargetKind.Emulator => "Emulator",
+        RemoteViewerTargetKind.Simulator => "Simulator",
+        RemoteViewerTargetKind.VsCode => "VS Code",
+        _ => kind.ToString()
+    };
 
     private string GetHubUrl(RunnerMachineSettings machine) =>
         string.IsNullOrWhiteSpace(_settings.CoordinatorUrl)

--- a/AgentDeck.Runner/Services/MachineCapabilityService.cs
+++ b/AgentDeck.Runner/Services/MachineCapabilityService.cs
@@ -11,12 +11,15 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
 {
     private readonly ILogger<MachineCapabilityService> _logger;
     private readonly IVirtualDeviceCatalogService _virtualDevices;
+    private readonly IRemoteViewerSessionService _viewers;
 
     public MachineCapabilityService(
         IVirtualDeviceCatalogService virtualDevices,
+        IRemoteViewerSessionService viewers,
         ILogger<MachineCapabilityService> logger)
     {
         _virtualDevices = virtualDevices;
+        _viewers = viewers;
         _logger = logger;
     }
 
@@ -37,6 +40,7 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
             CapturedAt = DateTimeOffset.UtcNow,
             Platform = BuildPlatformProfile(),
             SupportedTargets = BuildSupportedTargets(capabilities, catalogs),
+            RemoteViewerProviders = _viewers.GetAvailableProviders(),
             Capabilities = capabilities
         };
     }

--- a/AgentDeck.Shared/Models/MachineCapabilitiesSnapshot.cs
+++ b/AgentDeck.Shared/Models/MachineCapabilitiesSnapshot.cs
@@ -6,5 +6,6 @@ public sealed class MachineCapabilitiesSnapshot
     public DateTimeOffset CapturedAt { get; init; } = DateTimeOffset.UtcNow;
     public MachinePlatformProfile Platform { get; init; } = new();
     public IReadOnlyList<MachineTargetSupport> SupportedTargets { get; init; } = [];
+    public IReadOnlyList<RemoteViewerProviderCapability> RemoteViewerProviders { get; init; } = [];
     public IReadOnlyList<MachineCapability> Capabilities { get; init; } = [];
 }

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The **Machine Setup** section can detect whether the selected machine has these 
 
 For each capability, AgentDeck shows whether it is installed, missing, or errored, plus version information when available.
 
-Machine capability snapshots now also include host-platform metadata and structured target-readiness data for future orchestration work. The first explicit MAUI target assumption is **Linux**, which is treated as a supported runtime target when generated projects reference `OpenMaui.Controls.Linux`.
+Machine capability snapshots now also include host-platform metadata, structured target-readiness data, and available remote-viewing provider capabilities. That lets the Settings page show whether a machine has the AgentDeck-managed viewer helper transport configured versus only platform/native fallback providers. The first explicit MAUI target assumption is **Linux**, which is treated as a supported runtime target when generated projects reference `OpenMaui.Controls.Linux`.
 
 ### Installing Missing Tools
 


### PR DESCRIPTION
## Summary
- add remote-viewing provider capabilities to machine capability snapshots
- include runner viewer providers in capability snapshots
- surface viewer transport availability in Settings machine setup

## Testing
- dotnet build AgentDeck.Shared\AgentDeck.Shared.csproj
- dotnet build AgentDeck.Runner\AgentDeck.Runner.csproj
- dotnet build AgentDeck.Coordinator\AgentDeck.Coordinator.csproj
- dotnet build AgentDeck.Core\AgentDeck.Core.csproj