### PR TITLE
Move runner capability probes into a coordinator catalog

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorCapabilityCatalogOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorCapabilityCatalogOptions.cs
@@ -1,0 +1,27 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Coordinator.Configuration;
+
+public sealed class CoordinatorCapabilityCatalogOptions
+{
+    public string CatalogId { get; set; } = "default";
+    public string Version { get; set; } = "1";
+    public string DisplayName { get; set; } = "Default capability catalog";
+    public string? Description { get; set; }
+    public IReadOnlyList<CoordinatorCapabilityDefinitionOptions> Capabilities { get; set; } = [];
+}
+
+public sealed class CoordinatorCapabilityDefinitionOptions
+{
+    public string CapabilityId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Category { get; set; } = "cli";
+    public RunnerCapabilityProbeKind ProbeKind { get; set; } = RunnerCapabilityProbeKind.GenericCliVersion;
+    public IReadOnlyList<CoordinatorCapabilityProbeCommandOptions> ProbeCommands { get; set; } = [];
+}
+
+public sealed class CoordinatorCapabilityProbeCommandOptions
+{
+    public string FileName { get; set; } = string.Empty;
+    public IReadOnlyList<string> Arguments { get; set; } = [];
+}

--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -22,6 +22,8 @@ public sealed class CoordinatorOptions
 
     public CoordinatorWorkflowPackOptions DesiredWorkflowPack { get; set; } = new();
 
+    public CoordinatorCapabilityCatalogOptions DesiredCapabilityCatalog { get; set; } = new();
+
     public CoordinatorSecurityPolicyOptions SecurityPolicy { get; set; } = new();
 
     public bool ApplyStagedUpdate { get; set; }

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -762,6 +762,11 @@ app.MapGet("/api/runner-definitions/workflow-packs/{packId}", (string packId, IR
         ? Results.Ok(pack)
         : Results.NotFound());
 
+app.MapGet("/api/runner-definitions/capability-catalogs/{catalogId}", (string catalogId, IRunnerDefinitionCatalogService catalog) =>
+    catalog.GetCapabilityCatalog(catalogId) is { } capabilityCatalog
+        ? Results.Ok(capabilityCatalog)
+        : Results.NotFound());
+
 app.MapPost("/api/cluster/workers/register", (RegisterRunnerMachineRequest request, IWorkerRegistryService registry) =>
 {
     try

--- a/AgentDeck.Coordinator/Services/IRunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/IRunnerDefinitionCatalogService.cs
@@ -8,7 +8,11 @@ public interface IRunnerDefinitionCatalogService
 
     RunnerWorkflowPack GetDesiredWorkflowPack();
 
+    RunnerCapabilityCatalog GetDesiredCapabilityCatalog();
+
     RunnerUpdateManifest? GetUpdateManifest(string manifestId);
 
     RunnerWorkflowPack? GetWorkflowPack(string packId);
+
+    RunnerCapabilityCatalog? GetCapabilityCatalog(string catalogId);
 }

--- a/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
@@ -8,6 +8,7 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
 {
     private readonly RunnerUpdateManifest _desiredUpdateManifest;
     private readonly RunnerWorkflowPack _desiredWorkflowPack;
+    private readonly RunnerCapabilityCatalog _desiredCapabilityCatalog;
 
     public RunnerDefinitionCatalogService(
         IOptions<CoordinatorOptions> coordinatorOptions,
@@ -16,6 +17,7 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
         var options = coordinatorOptions.Value;
         var desiredUpdateManifest = options.DesiredUpdateManifest ?? new CoordinatorUpdateManifestOptions();
         var desiredWorkflowPack = options.DesiredWorkflowPack ?? new CoordinatorWorkflowPackOptions();
+        var desiredCapabilityCatalog = options.DesiredCapabilityCatalog ?? new CoordinatorCapabilityCatalogOptions();
         var securityPolicy = options.SecurityPolicy ?? new CoordinatorSecurityPolicyOptions();
         var hostedArtifact = ResolveHostedArtifact(options, desiredUpdateManifest, artifactService);
 
@@ -83,11 +85,42 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                 })
                 .ToArray()
         };
+
+        _desiredCapabilityCatalog = new RunnerCapabilityCatalog
+        {
+            CatalogId = NormalizeRequired(desiredCapabilityCatalog.CatalogId, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:CatalogId"),
+            Version = NormalizeRequired(desiredCapabilityCatalog.Version, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Version"),
+            DisplayName = NormalizeRequired(desiredCapabilityCatalog.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:DisplayName"),
+            Description = NormalizeOptional(desiredCapabilityCatalog.Description),
+            Capabilities = (desiredCapabilityCatalog.Capabilities ?? [])
+                .Where(capability => !string.IsNullOrWhiteSpace(capability.CapabilityId))
+                .Select(capability => new RunnerCapabilityDefinition
+                {
+                    CapabilityId = NormalizeRequired(capability.CapabilityId, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Capabilities:CapabilityId"),
+                    DisplayName = NormalizeRequired(capability.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Capabilities:DisplayName"),
+                    Category = NormalizeRequired(capability.Category, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Capabilities:Category"),
+                    ProbeKind = capability.ProbeKind,
+                    ProbeCommands = (capability.ProbeCommands ?? [])
+                        .Where(command => !string.IsNullOrWhiteSpace(command.FileName))
+                        .Select(command => new RunnerCapabilityProbeCommand
+                        {
+                            FileName = NormalizeRequired(command.FileName, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Capabilities:ProbeCommands:FileName"),
+                            Arguments = (command.Arguments ?? [])
+                                .Where(argument => !string.IsNullOrWhiteSpace(argument))
+                                .Select(argument => argument.Trim())
+                                .ToArray()
+                        })
+                        .ToArray()
+                })
+                .ToArray()
+        };
     }
 
     public RunnerUpdateManifest GetDesiredUpdateManifest() => _desiredUpdateManifest;
 
     public RunnerWorkflowPack GetDesiredWorkflowPack() => _desiredWorkflowPack;
+
+    public RunnerCapabilityCatalog GetDesiredCapabilityCatalog() => _desiredCapabilityCatalog;
 
     public RunnerUpdateManifest? GetUpdateManifest(string manifestId) =>
         string.Equals(_desiredUpdateManifest.ManifestId, manifestId, StringComparison.OrdinalIgnoreCase)
@@ -97,6 +130,11 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     public RunnerWorkflowPack? GetWorkflowPack(string packId) =>
         string.Equals(_desiredWorkflowPack.PackId, packId, StringComparison.OrdinalIgnoreCase)
             ? _desiredWorkflowPack
+            : null;
+
+    public RunnerCapabilityCatalog? GetCapabilityCatalog(string catalogId) =>
+        string.Equals(_desiredCapabilityCatalog.CatalogId, catalogId, StringComparison.OrdinalIgnoreCase)
+            ? _desiredCapabilityCatalog
             : null;
 
     private static string? NormalizeOptional(string? value) =>

--- a/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
@@ -138,9 +138,12 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 ProtocolVersion = machine.ProtocolVersion,
                 WorkflowCatalogVersion = machine.WorkflowCatalogVersion,
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
+                CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
+                CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
                 SecurityPolicyVersion = machine.SecurityPolicyVersion,
                 DesiredUpdateManifestId = machine.DesiredUpdateManifestId,
                 DesiredWorkflowPackId = machine.DesiredWorkflowPackId,
+                DesiredCapabilityCatalogId = machine.DesiredCapabilityCatalogId,
                 UpdateStatus = machine.UpdateStatus,
                 UpdateRollout = machine.UpdateRollout,
                 WorkflowPackStatus = null,
@@ -192,9 +195,12 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 ProtocolVersion = request.ProtocolVersion,
                 WorkflowCatalogVersion = NormalizeOptional(request.WorkflowCatalogVersion),
                 WorkflowCatalogStatus = request.WorkflowCatalogStatus,
+                CapabilityCatalogVersion = NormalizeOptional(request.CapabilityCatalogVersion),
+                CapabilityCatalogStatus = request.CapabilityCatalogStatus,
                 SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
                 DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
                 DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
+                DesiredCapabilityCatalogId = desiredState.DesiredCapabilityCatalog?.DefinitionId,
                 UpdateStatus = request.UpdateStatus,
                 UpdateRollout = updateRollout,
                 WorkflowPackStatus = request.WorkflowPackStatus,
@@ -277,9 +283,12 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 ProtocolVersion = machine.ProtocolVersion,
                 WorkflowCatalogVersion = machine.WorkflowCatalogVersion,
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
+                CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
+                CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
                 SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
                 DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
                 DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
+                DesiredCapabilityCatalogId = desiredState.DesiredCapabilityCatalog?.DefinitionId,
                 UpdateStatus = machine.UpdateStatus,
                 UpdateRollout = BuildUpdateRollout(
                     machine.MachineId,
@@ -327,10 +336,12 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
         var normalizedAgentVersion = Normalize(agentVersion);
         var desiredManifest = _definitions.GetDesiredUpdateManifest();
         var desiredWorkflowPack = _definitions.GetDesiredWorkflowPack();
+        var desiredCapabilityCatalog = _definitions.GetDesiredCapabilityCatalog();
         var desiredVersion = NormalizeOptional(_coordinatorOptions.DesiredRunnerVersion)
             ?? NormalizeOptional(desiredManifest.Version)
             ?? normalizedAgentVersion;
         var workflowCatalogVersion = NormalizeOptional(_coordinatorOptions.WorkflowCatalogVersion);
+        var capabilityCatalogVersion = NormalizeOptional(desiredCapabilityCatalog.Version);
         var protocolCompatible = protocolVersion >= _coordinatorOptions.MinimumSupportedProtocolVersion &&
                                  protocolVersion <= _coordinatorOptions.MaximumSupportedProtocolVersion;
         var securityPolicyAllowsApply = _coordinatorOptions.SecurityPolicy?.AllowUpdateApply ?? false;
@@ -377,7 +388,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 DefinitionId = desiredWorkflowPack.PackId,
                 Version = desiredWorkflowPack.Version
             },
+            DesiredCapabilityCatalog = new RunnerDefinitionReference
+            {
+                DefinitionId = desiredCapabilityCatalog.CatalogId,
+                Version = desiredCapabilityCatalog.Version
+            },
             WorkflowCatalogVersion = workflowCatalogVersion,
+            CapabilityCatalogVersion = capabilityCatalogVersion,
             UpdateAvailable = updateAvailable,
             ApplyUpdate = applyUpdate,
             ProtocolCompatible = protocolCompatible,

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -53,6 +53,82 @@
         }
       ]
     },
+    "DesiredCapabilityCatalog": {
+      "CatalogId": "default-capabilities",
+      "Version": "1",
+      "DisplayName": "Default Capability Catalog",
+      "Description": "Coordinator-authored capability probes for the built-in runner tool and SDK checks.",
+      "Capabilities": [
+        {
+          "CapabilityId": "gh",
+          "DisplayName": "GitHub CLI",
+          "Category": "cli",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "gh",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "copilot",
+          "DisplayName": "GitHub Copilot CLI",
+          "Category": "cli",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "copilot",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "node",
+          "DisplayName": "Node.js",
+          "Category": "sdk",
+          "ProbeKind": "NodeVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "node",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "python",
+          "DisplayName": "Python",
+          "Category": "sdk",
+          "ProbeKind": "PythonVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "python",
+              "Arguments": [ "--version" ]
+            },
+            {
+              "FileName": "python3",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "dotnet",
+          "DisplayName": ".NET SDK",
+          "Category": "sdk",
+          "ProbeKind": "DotNetSdk",
+          "ProbeCommands": [
+            {
+              "FileName": "dotnet",
+              "Arguments": [ "--version" ]
+            },
+            {
+              "FileName": "dotnet",
+              "Arguments": [ "--list-sdks" ]
+            }
+          ]
+        }
+      ]
+    },
     "SecurityPolicy": {
       "PolicyVersion": "1",
       "AllowUpdateStaging": true,

--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -31,6 +31,8 @@ public sealed class CompanionMachineSummary
     public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
+    public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
+    public string? CapabilityCatalogVersion { get; init; }
     public IReadOnlyList<MachineTargetSupport> SupportedTargets { get; init; } = [];
     public IReadOnlyList<RemoteViewerProviderCapability> RemoteViewerProviders { get; init; } = [];
 }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -86,6 +86,10 @@
                             {
                                 <span> • workflow @machine.WorkflowCatalogVersion</span>
                             }
+                            @if (!string.IsNullOrWhiteSpace(machine.CapabilityCatalogVersion))
+                            {
+                                <span> • capabilities @machine.CapabilityCatalogVersion</span>
+                            }
                             @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
                             {
                                 <span> • security @machine.SecurityPolicyVersion</span>
@@ -395,6 +399,35 @@
                                 <div class="settings-status-row">
                                     <span class="settings-status-row__label">Workflow catalog summary</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.StatusMessage</span>
+                                </div>
+                            }
+                        }
+                        @if (SelectedRegisteredMachine?.CapabilityCatalogStatus is { } capabilityCatalogStatus &&
+                             capabilityCatalogStatus.State != RunnerCapabilityCatalogState.Unknown)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Capability catalog state</span>
+                                <span class="settings-status-row__value">@GetCapabilityCatalogStateLabel(capabilityCatalogStatus.State)</span>
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.LocalCatalogVersion))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Local capability catalog</span>
+                                    <span class="settings-status-row__value">@capabilityCatalogStatus.LocalCatalogVersion</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.DesiredCatalogVersion))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Desired capability catalog</span>
+                                    <span class="settings-status-row__value">@capabilityCatalogStatus.DesiredCatalogVersion</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.StatusMessage))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Capability catalog summary</span>
+                                    <span class="settings-status-row__value">@capabilityCatalogStatus.StatusMessage</span>
                                 </div>
                             }
                         }
@@ -897,6 +930,14 @@
     {
         RunnerWorkflowCatalogState.Matched => "Matched",
         RunnerWorkflowCatalogState.Mismatched => "Mismatched",
+        _ => "Unknown"
+    };
+
+    private static string GetCapabilityCatalogStateLabel(RunnerCapabilityCatalogState state) => state switch
+    {
+        RunnerCapabilityCatalogState.Matched => "Matched",
+        RunnerCapabilityCatalogState.Mismatched => "Mismatched",
+        RunnerCapabilityCatalogState.Failed => "Failed",
         _ => "Unknown"
     };
 

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -86,6 +86,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                 UpdateRollout = machine.UpdateRollout,
                 WorkflowPackStatus = machine.WorkflowPackStatus,
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
+                CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
+                CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
                 SupportedTargets = machine.SupportedTargets,
                 RemoteViewerProviders = machine.RemoteViewerProviders
             })

--- a/AgentDeck.Runner/Configuration/WorkerCoordinatorOptions.cs
+++ b/AgentDeck.Runner/Configuration/WorkerCoordinatorOptions.cs
@@ -34,6 +34,9 @@ public sealed class WorkerCoordinatorOptions
     /// <summary>Optional local root for coordinator-assigned workflow pack metadata.</summary>
     public string? WorkflowPackRoot { get; set; }
 
+    /// <summary>Optional local root for the reconciled coordinator capability catalog.</summary>
+    public string? CapabilityCatalogRoot { get; set; }
+
     /// <summary>Allow plain HTTP only when the configured coordinator resolves to a loopback host.</summary>
     public bool AllowInsecureHttpCoordinatorForLoopback { get; set; } = true;
 

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddSingleton<IRunnerAuditService, RunnerAuditService>();
 builder.Services.AddSingleton<IRunnerTrustPolicy, RunnerTrustPolicy>();
 builder.Services.AddSingleton<IRunnerUpdateStagingService, RunnerUpdateStagingService>();
 builder.Services.AddSingleton<IRunnerWorkflowCatalogService, RunnerWorkflowCatalogService>();
+builder.Services.AddSingleton<IRunnerCapabilityCatalogService, RunnerCapabilityCatalogService>();
 builder.Services.AddSingleton<IRunnerWorkflowPackService, RunnerWorkflowPackService>();
 builder.Services.AddSingleton<IVsCodeDebugSessionService, VsCodeDebugSessionService>();
 builder.Services.AddSingleton<IVirtualDeviceCatalogService, VirtualDeviceCatalogService>();

--- a/AgentDeck.Runner/Services/IRunnerCapabilityCatalogService.cs
+++ b/AgentDeck.Runner/Services/IRunnerCapabilityCatalogService.cs
@@ -1,0 +1,15 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public interface IRunnerCapabilityCatalogService
+{
+    Task<RunnerCapabilityCatalog?> GetCurrentCatalogAsync(CancellationToken cancellationToken = default);
+
+    Task<RunnerCapabilityCatalogStatus?> GetCurrentStatusAsync(CancellationToken cancellationToken = default);
+
+    Task<RunnerCapabilityCatalogStatus> ReconcileDesiredCapabilityCatalogAsync(
+        HttpClient coordinatorClient,
+        RunnerDesiredState desiredState,
+        CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Runner/Services/MachineCapabilityService.cs
+++ b/AgentDeck.Runner/Services/MachineCapabilityService.cs
@@ -9,15 +9,18 @@ namespace AgentDeck.Runner.Services;
 /// <inheritdoc />
 public sealed partial class MachineCapabilityService : IMachineCapabilityService
 {
+    private readonly IRunnerCapabilityCatalogService _capabilityCatalog;
     private readonly ILogger<MachineCapabilityService> _logger;
     private readonly IVirtualDeviceCatalogService _virtualDevices;
     private readonly IRemoteViewerSessionService _viewers;
 
     public MachineCapabilityService(
+        IRunnerCapabilityCatalogService capabilityCatalog,
         IVirtualDeviceCatalogService virtualDevices,
         IRemoteViewerSessionService viewers,
         ILogger<MachineCapabilityService> logger)
     {
+        _capabilityCatalog = capabilityCatalog;
         _virtualDevices = virtualDevices;
         _viewers = viewers;
         _logger = logger;
@@ -25,14 +28,10 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
 
     public async Task<MachineCapabilitiesSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
     {
-        var capabilities = new List<MachineCapability>
-        {
-            await DetectCliAsync("gh", "GitHub CLI", [new ProbeCommand("gh", ["--version"])], ParseFirstLineVersion, cancellationToken),
-            await DetectCliAsync("copilot", "GitHub Copilot CLI", [new ProbeCommand("copilot", ["--version"])], ParseFirstLineVersion, cancellationToken),
-            await DetectNodeAsync(cancellationToken),
-            await DetectPythonAsync(cancellationToken),
-            await DetectDotNetAsync(cancellationToken)
-        };
+        var catalog = await _capabilityCatalog.GetCurrentCatalogAsync(cancellationToken);
+        var capabilities = catalog is null
+            ? []
+            : await DetectCapabilitiesAsync(catalog, cancellationToken);
         var catalogs = await _virtualDevices.GetCatalogsAsync(cancellationToken);
 
         return new MachineCapabilitiesSnapshot
@@ -43,6 +42,19 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
             RemoteViewerProviders = _viewers.GetAvailableProviders(),
             Capabilities = capabilities
         };
+    }
+
+    private async Task<IReadOnlyList<MachineCapability>> DetectCapabilitiesAsync(
+        RunnerCapabilityCatalog catalog,
+        CancellationToken cancellationToken)
+    {
+        var capabilities = new List<MachineCapability>(catalog.Capabilities.Count);
+        foreach (var definition in catalog.Capabilities)
+        {
+            capabilities.Add(await DetectCapabilityAsync(definition, cancellationToken));
+        }
+
+        return capabilities;
     }
 
     private static MachinePlatformProfile BuildPlatformProfile()
@@ -200,13 +212,31 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
         return RunnerHostPlatform.Unknown;
     }
 
+    private async Task<MachineCapability> DetectCapabilityAsync(
+        RunnerCapabilityDefinition definition,
+        CancellationToken cancellationToken)
+    {
+        return definition.ProbeKind switch
+        {
+            RunnerCapabilityProbeKind.GenericCliVersion => await DetectCliAsync(definition, definition.ProbeCommands, ParseFirstLineVersion, cancellationToken),
+            RunnerCapabilityProbeKind.NodeVersion => await DetectSingleCommandVersionAsync(definition, ParseTrimmedOutput, "Detected via {0}", cancellationToken),
+            RunnerCapabilityProbeKind.PythonVersion => await DetectPythonAsync(definition, cancellationToken),
+            RunnerCapabilityProbeKind.DotNetSdk => await DetectDotNetAsync(definition, cancellationToken),
+            _ => CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, $"Unsupported probe kind '{definition.ProbeKind}'.")
+        };
+    }
+
     private async Task<MachineCapability> DetectCliAsync(
-        string id,
-        string name,
-        IReadOnlyList<ProbeCommand> commands,
+        RunnerCapabilityDefinition definition,
+        IReadOnlyList<RunnerCapabilityProbeCommand> commands,
         Func<string, string, string?> versionParser,
         CancellationToken cancellationToken)
     {
+        if (commands.Count == 0)
+        {
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, "Capability catalog did not define any probe commands.");
+        }
+
         string? lastError = null;
         var sawExecutionFailure = false;
 
@@ -230,9 +260,9 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
             var installedVersions = string.IsNullOrWhiteSpace(version) ? [] : new[] { version };
             return new MachineCapability
             {
-                Id = id,
-                Name = name,
-                Category = "cli",
+                Id = definition.CapabilityId,
+                Name = definition.DisplayName,
+                Category = definition.Category,
                 Status = MachineCapabilityStatus.Installed,
                 Version = version,
                 InstalledVersions = installedVersions,
@@ -242,48 +272,63 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
 
         return new MachineCapability
         {
-            Id = id,
-            Name = name,
-            Category = "cli",
+            Id = definition.CapabilityId,
+            Name = definition.DisplayName,
+            Category = definition.Category,
             Status = sawExecutionFailure ? MachineCapabilityStatus.Error : MachineCapabilityStatus.Missing,
             Message = lastError ?? "Not installed."
         };
     }
 
-    private async Task<MachineCapability> DetectNodeAsync(CancellationToken cancellationToken)
+    private async Task<MachineCapability> DetectSingleCommandVersionAsync(
+        RunnerCapabilityDefinition definition,
+        Func<string, string, string?> versionParser,
+        string successMessageFormat,
+        CancellationToken cancellationToken)
     {
-        var result = await RunCommandAsync("node", ["--version"], cancellationToken);
+        var command = definition.ProbeCommands.FirstOrDefault();
+        if (command is null)
+        {
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, "Capability catalog did not define any probe commands.");
+        }
+
+        var result = await RunCommandAsync(command.FileName, command.Arguments, cancellationToken);
         if (result.StartFailed)
         {
-            return CreateMissingCapability("node", "Node.js", "sdk", result.ErrorMessage);
+            return CreateMissingCapability(definition.CapabilityId, definition.DisplayName, definition.Category, result.ErrorMessage);
         }
 
         if (!result.Succeeded)
         {
-            return CreateErrorCapability("node", "Node.js", "sdk", result.StandardError, result.StandardOutput);
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, result.StandardError, result.StandardOutput);
         }
 
-        var version = NormalizeVersion(ParseTrimmedOutput(result.StandardOutput, result.StandardError));
+        var version = NormalizeVersion(versionParser(result.StandardOutput, result.StandardError));
         return new MachineCapability
         {
-            Id = "node",
-            Name = "Node.js",
-            Category = "sdk",
+            Id = definition.CapabilityId,
+            Name = definition.DisplayName,
+            Category = definition.Category,
             Status = MachineCapabilityStatus.Installed,
             Version = version,
             InstalledVersions = version is null ? [] : [version],
-            Message = "Detected via node"
+            Message = string.Format(successMessageFormat, command.FileName)
         };
     }
 
-    private async Task<MachineCapability> DetectPythonAsync(CancellationToken cancellationToken)
+    private async Task<MachineCapability> DetectPythonAsync(RunnerCapabilityDefinition definition, CancellationToken cancellationToken)
     {
+        if (definition.ProbeCommands.Count == 0)
+        {
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, "Capability catalog did not define any probe commands.");
+        }
+
         var installedVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         string? primaryVersion = null;
         string? lastError = null;
         var sawExecutionFailure = false;
 
-        foreach (var command in new[] { new ProbeCommand("python", ["--version"]), new ProbeCommand("python3", ["--version"]) })
+        foreach (var command in definition.ProbeCommands)
         {
             var result = await RunCommandAsync(command.FileName, command.Arguments, cancellationToken);
             if (result.StartFailed)
@@ -343,9 +388,9 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
             var sortedVersions = SortVersionsDescending(installedVersions);
             return new MachineCapability
             {
-                Id = "python",
-                Name = "Python",
-                Category = "sdk",
+                Id = definition.CapabilityId,
+                Name = definition.DisplayName,
+                Category = definition.Category,
                 Status = MachineCapabilityStatus.Installed,
                 Version = primaryVersion ?? sortedVersions.FirstOrDefault(),
                 InstalledVersions = sortedVersions,
@@ -357,25 +402,32 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
 
         return new MachineCapability
         {
-            Id = "python",
-            Name = "Python",
-            Category = "sdk",
+            Id = definition.CapabilityId,
+            Name = definition.DisplayName,
+            Category = definition.Category,
             Status = sawExecutionFailure ? MachineCapabilityStatus.Error : MachineCapabilityStatus.Missing,
             Message = lastError ?? "Not installed."
         };
     }
 
-    private async Task<MachineCapability> DetectDotNetAsync(CancellationToken cancellationToken)
+    private async Task<MachineCapability> DetectDotNetAsync(RunnerCapabilityDefinition definition, CancellationToken cancellationToken)
     {
-        var currentResult = await RunCommandAsync("dotnet", ["--version"], cancellationToken);
+        var commands = definition.ProbeCommands;
+        if (commands.Count == 0)
+        {
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, "Capability catalog did not define any probe commands.");
+        }
+
+        var currentCommand = commands[0];
+        var currentResult = await RunCommandAsync(currentCommand.FileName, currentCommand.Arguments, cancellationToken);
         if (currentResult.StartFailed)
         {
-            return CreateMissingCapability("dotnet", ".NET SDK", "sdk", currentResult.ErrorMessage);
+            return CreateMissingCapability(definition.CapabilityId, definition.DisplayName, definition.Category, currentResult.ErrorMessage);
         }
 
         if (!currentResult.Succeeded)
         {
-            return CreateErrorCapability("dotnet", ".NET SDK", "sdk", currentResult.StandardError, currentResult.StandardOutput);
+            return CreateErrorCapability(definition.CapabilityId, definition.DisplayName, definition.Category, currentResult.StandardError, currentResult.StandardOutput);
         }
 
         var currentVersion = NormalizeVersion(ParseTrimmedOutput(currentResult.StandardOutput, currentResult.StandardError));
@@ -385,21 +437,25 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
             installedVersions.Add(currentVersion);
         }
 
-        var listResult = await RunCommandAsync("dotnet", ["--list-sdks"], cancellationToken);
-        if (!listResult.StartFailed && listResult.Succeeded)
+        if (commands.Count > 1)
         {
-            foreach (var version in ParseVersions(listResult.StandardOutput))
+            var listCommand = commands[1];
+            var listResult = await RunCommandAsync(listCommand.FileName, listCommand.Arguments, cancellationToken);
+            if (!listResult.StartFailed && listResult.Succeeded)
             {
-                installedVersions.Add(version);
+                foreach (var version in ParseVersions(listResult.StandardOutput))
+                {
+                    installedVersions.Add(version);
+                }
             }
         }
 
         var sortedVersions = SortVersionsDescending(installedVersions);
         return new MachineCapability
         {
-            Id = "dotnet",
-            Name = ".NET SDK",
-            Category = "sdk",
+            Id = definition.CapabilityId,
+            Name = definition.DisplayName,
+            Category = definition.Category,
             Status = MachineCapabilityStatus.Installed,
             Version = currentVersion ?? sortedVersions.FirstOrDefault(),
             InstalledVersions = sortedVersions,
@@ -602,8 +658,6 @@ public sealed partial class MachineCapabilityService : IMachineCapabilityService
 
     [GeneratedRegex(@"^python(?:3\.\d+)?(?:\.exe)?$", RegexOptions.IgnoreCase)]
     private static partial Regex PythonCommandPattern();
-
-    private sealed record ProbeCommand(string FileName, IReadOnlyList<string> Arguments);
 
     private sealed class ProbeResult
     {

--- a/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
@@ -1,0 +1,278 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AgentDeck.Runner.Configuration;
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class RunnerCapabilityCatalogService : IRunnerCapabilityCatalogService, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    private readonly WorkerCoordinatorOptions _options;
+    private readonly SemaphoreSlim _reconcileGate = new(1, 1);
+    private readonly ILogger<RunnerCapabilityCatalogService> _logger;
+    private RunnerCapabilityCatalog? _currentCatalog;
+    private RunnerCapabilityCatalogStatus _currentStatus;
+
+    public RunnerCapabilityCatalogService(
+        IOptions<WorkerCoordinatorOptions> options,
+        ILogger<RunnerCapabilityCatalogService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _currentCatalog = LoadPersistedCatalog();
+        _currentStatus = NormalizePersistedState(_currentCatalog, LoadPersistedStatus());
+    }
+
+    public async Task<RunnerCapabilityCatalog?> GetCurrentCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            return _currentCatalog;
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public async Task<RunnerCapabilityCatalogStatus?> GetCurrentStatusAsync(CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            return _currentStatus;
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public async Task<RunnerCapabilityCatalogStatus> ReconcileDesiredCapabilityCatalogAsync(
+        HttpClient coordinatorClient,
+        RunnerDesiredState desiredState,
+        CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            var localCatalogVersion = _currentCatalog?.Version;
+            if (desiredState.DesiredCapabilityCatalog is null || string.IsNullOrWhiteSpace(desiredState.CapabilityCatalogVersion))
+            {
+                _currentStatus = await PersistStatusAsync(new RunnerCapabilityCatalogStatus
+                {
+                    State = RunnerCapabilityCatalogState.Unknown,
+                    CatalogId = _currentCatalog?.CatalogId,
+                    LocalCatalogVersion = localCatalogVersion,
+                    StatusMessage = "Coordinator did not provide a desired capability catalog."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+
+            var desiredCatalogId = desiredState.DesiredCapabilityCatalog.DefinitionId;
+            var desiredCatalogVersion = desiredState.DesiredCapabilityCatalog.Version;
+            if (_currentCatalog is not null &&
+                string.Equals(_currentCatalog.CatalogId, desiredCatalogId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_currentCatalog.Version, desiredCatalogVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                _currentStatus = await PersistStatusAsync(new RunnerCapabilityCatalogStatus
+                {
+                    State = RunnerCapabilityCatalogState.Matched,
+                    CatalogId = _currentCatalog.CatalogId,
+                    LocalCatalogVersion = _currentCatalog.Version,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = $"Runner capability catalog {_currentCatalog.Version} matches the coordinator."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+
+            try
+            {
+                var catalog = await coordinatorClient.GetFromJsonAsync<RunnerCapabilityCatalog>(
+                    $"api/runner-definitions/capability-catalogs/{Uri.EscapeDataString(desiredCatalogId)}",
+                    cancellationToken);
+
+                if (catalog is null)
+                {
+                    throw new InvalidOperationException("Coordinator returned an empty capability catalog response.");
+                }
+
+                if (!string.Equals(catalog.CatalogId, desiredCatalogId, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Coordinator capability catalog id '{catalog.CatalogId}' did not match desired catalog '{desiredCatalogId}'.");
+                }
+
+                if (!string.Equals(catalog.Version, desiredCatalogVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Coordinator capability catalog version '{catalog.Version}' did not match desired version '{desiredCatalogVersion}'.");
+                }
+
+                Directory.CreateDirectory(GetCapabilityCatalogRoot());
+                await WriteTextAtomicallyAsync(GetCatalogPath(), JsonSerializer.Serialize(catalog, JsonOptions), cancellationToken);
+                _currentCatalog = catalog;
+                _currentStatus = await PersistStatusAsync(new RunnerCapabilityCatalogStatus
+                {
+                    State = RunnerCapabilityCatalogState.Matched,
+                    CatalogId = catalog.CatalogId,
+                    LocalCatalogVersion = catalog.Version,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = $"Runner capability catalog {catalog.Version} matches the coordinator."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to reconcile desired capability catalog {CatalogId}@{CatalogVersion}", desiredCatalogId, desiredCatalogVersion);
+                _currentStatus = await PersistStatusAsync(new RunnerCapabilityCatalogStatus
+                {
+                    State = RunnerCapabilityCatalogState.Failed,
+                    CatalogId = desiredCatalogId,
+                    LocalCatalogVersion = localCatalogVersion,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = ex.Message
+                }, cancellationToken);
+                return _currentStatus;
+            }
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public void Dispose() => _reconcileGate.Dispose();
+
+    private async Task<RunnerCapabilityCatalogStatus> PersistStatusAsync(RunnerCapabilityCatalogStatus status, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(GetCapabilityCatalogRoot());
+        await WriteTextAtomicallyAsync(GetStatusPath(), JsonSerializer.Serialize(status, JsonOptions), cancellationToken);
+        return status;
+    }
+
+    private RunnerCapabilityCatalog? LoadPersistedCatalog()
+    {
+        var path = GetCatalogPath();
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<RunnerCapabilityCatalog>(File.ReadAllText(path), JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load persisted capability catalog from {CatalogPath}", path);
+            return null;
+        }
+    }
+
+    private RunnerCapabilityCatalogStatus? LoadPersistedStatus()
+    {
+        var path = GetStatusPath();
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<RunnerCapabilityCatalogStatus>(File.ReadAllText(path), JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load persisted capability catalog status from {StatusPath}", path);
+            return null;
+        }
+    }
+
+    private RunnerCapabilityCatalogStatus NormalizePersistedState(
+        RunnerCapabilityCatalog? catalog,
+        RunnerCapabilityCatalogStatus? status)
+    {
+        if (catalog is null)
+        {
+            if (status is not null)
+            {
+                _logger.LogWarning("Discarding persisted capability catalog status because no persisted catalog was available.");
+            }
+
+            return new RunnerCapabilityCatalogStatus
+            {
+                State = RunnerCapabilityCatalogState.Unknown,
+                StatusMessage = "Runner has not reconciled a coordinator capability catalog yet."
+            };
+        }
+
+        if (status is null)
+        {
+            return new RunnerCapabilityCatalogStatus
+            {
+                State = RunnerCapabilityCatalogState.Unknown,
+                CatalogId = catalog.CatalogId,
+                LocalCatalogVersion = catalog.Version,
+                StatusMessage = $"Loaded persisted capability catalog {catalog.CatalogId}@{catalog.Version}."
+            };
+        }
+
+        var catalogMatchesStatus =
+            string.Equals(status.CatalogId, catalog.CatalogId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(status.LocalCatalogVersion, catalog.Version, StringComparison.OrdinalIgnoreCase);
+
+        if (catalogMatchesStatus)
+        {
+            return status;
+        }
+
+        _logger.LogWarning(
+            "Discarding inconsistent persisted capability catalog status for {CatalogId}@{CatalogVersion}; status referenced {StatusCatalogId}@{StatusCatalogVersion}.",
+            catalog.CatalogId,
+            catalog.Version,
+            status.CatalogId,
+            status.LocalCatalogVersion);
+
+        return new RunnerCapabilityCatalogStatus
+        {
+            State = RunnerCapabilityCatalogState.Unknown,
+            CatalogId = catalog.CatalogId,
+            LocalCatalogVersion = catalog.Version,
+            DesiredCatalogVersion = status.DesiredCatalogVersion,
+            StatusMessage = $"Loaded persisted capability catalog {catalog.CatalogId}@{catalog.Version}; coordinator reconciliation will refresh status."
+        };
+    }
+
+    private string GetCapabilityCatalogRoot()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.CapabilityCatalogRoot))
+        {
+            return Path.GetFullPath(_options.CapabilityCatalogRoot);
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "AgentDeck",
+            "worker",
+            "capability-catalog");
+    }
+
+    private string GetCatalogPath() => Path.Combine(GetCapabilityCatalogRoot(), "current-capability-catalog.json");
+
+    private string GetStatusPath() => Path.Combine(GetCapabilityCatalogRoot(), "current-capability-catalog-status.json");
+
+    private static async Task WriteTextAtomicallyAsync(string path, string content, CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(path) ?? throw new InvalidOperationException($"Path '{path}' has no parent directory.");
+        Directory.CreateDirectory(directory);
+        var tempPath = Path.Combine(directory, $"{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/AgentDeck.Runner/Services/WorkerCoordinatorRegistrationService.cs
+++ b/AgentDeck.Runner/Services/WorkerCoordinatorRegistrationService.cs
@@ -13,6 +13,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
     private readonly IMachineCapabilityService _capabilities;
     private readonly IRunnerUpdateStagingService _updateStaging;
     private readonly IRunnerWorkflowCatalogService _workflowCatalog;
+    private readonly IRunnerCapabilityCatalogService _capabilityCatalog;
     private readonly IRunnerWorkflowPackService _workflowPacks;
     private readonly ILogger<WorkerCoordinatorRegistrationService> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -22,6 +23,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
         IMachineCapabilityService capabilities,
         IRunnerUpdateStagingService updateStaging,
         IRunnerWorkflowCatalogService workflowCatalog,
+        IRunnerCapabilityCatalogService capabilityCatalog,
         IRunnerWorkflowPackService workflowPacks,
         IHttpClientFactory httpClientFactory,
         ILogger<WorkerCoordinatorRegistrationService> logger)
@@ -30,6 +32,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
         _capabilities = capabilities;
         _updateStaging = updateStaging;
         _workflowCatalog = workflowCatalog;
+        _capabilityCatalog = capabilityCatalog;
         _workflowPacks = workflowPacks;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
@@ -73,6 +76,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
 
                 var snapshot = await _capabilities.GetSnapshotAsync(stoppingToken);
                 var workflowCatalogStatus = await _workflowCatalog.GetCurrentStatusAsync(stoppingToken);
+                var capabilityCatalogStatus = await _capabilityCatalog.GetCurrentStatusAsync(stoppingToken);
                 var updateStatus = await _updateStaging.GetCurrentStatusAsync(stoppingToken);
                 var workflowPackStatus = await _workflowPacks.GetCurrentStatusAsync(stoppingToken);
                 var request = new RegisterRunnerMachineRequest
@@ -86,6 +90,8 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                         ? "1"
                         : _coordinatorOptions.WorkflowCatalogVersion.Trim(),
                     WorkflowCatalogStatus = workflowCatalogStatus,
+                    CapabilityCatalogVersion = capabilityCatalogStatus?.LocalCatalogVersion,
+                    CapabilityCatalogStatus = capabilityCatalogStatus,
                     UpdateStatus = updateStatus,
                     WorkflowPackStatus = workflowPackStatus,
                     RunnerUrl = string.IsNullOrWhiteSpace(_coordinatorOptions.AdvertisedRunnerUrl)
@@ -106,6 +112,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                 if (registration?.DesiredState is { } desiredState)
                 {
                     var catalogStatus = await _workflowCatalog.ReconcileDesiredWorkflowCatalogAsync(desiredState, stoppingToken);
+                    var capabilityCatalogStatusAfterReconcile = await _capabilityCatalog.ReconcileDesiredCapabilityCatalogAsync(httpClient, desiredState, stoppingToken);
                     if (!desiredState.ProtocolCompatible)
                     {
                         _logger.LogWarning(
@@ -125,6 +132,15 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                             catalogStatus.DesiredCatalogVersion,
                             request.MachineName,
                             catalogStatus.LocalCatalogVersion);
+                    }
+
+                    if (capabilityCatalogStatusAfterReconcile.State == RunnerCapabilityCatalogState.Failed)
+                    {
+                        _logger.LogWarning(
+                            "Coordinator {CoordinatorUrl} capability catalog reconcile failed for runner {MachineName}: {StatusMessage}",
+                            coordinatorUrl,
+                            request.MachineName,
+                            capabilityCatalogStatusAfterReconcile.StatusMessage);
                     }
 
                     if (desiredState.UpdateAvailable)

--- a/AgentDeck.Shared/Enums/RunnerCapabilityCatalogState.cs
+++ b/AgentDeck.Shared/Enums/RunnerCapabilityCatalogState.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+public enum RunnerCapabilityCatalogState
+{
+    Unknown,
+    Matched,
+    Mismatched,
+    Failed
+}

--- a/AgentDeck.Shared/Enums/RunnerCapabilityProbeKind.cs
+++ b/AgentDeck.Shared/Enums/RunnerCapabilityProbeKind.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+public enum RunnerCapabilityProbeKind
+{
+    GenericCliVersion,
+    NodeVersion,
+    PythonVersion,
+    DotNetSdk
+}

--- a/AgentDeck.Shared/Models/RegisterRunnerMachineRequest.cs
+++ b/AgentDeck.Shared/Models/RegisterRunnerMachineRequest.cs
@@ -12,6 +12,8 @@ public sealed class RegisterRunnerMachineRequest
     public int ProtocolVersion { get; init; } = 1;
     public string? WorkflowCatalogVersion { get; init; }
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
+    public string? CapabilityCatalogVersion { get; init; }
+    public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
     public RunnerUpdateStatus? UpdateStatus { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }
     public string? RunnerUrl { get; init; }

--- a/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
+++ b/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
@@ -12,9 +12,12 @@ public sealed class RegisteredRunnerMachine
     public int ProtocolVersion { get; init; } = 1;
     public string? WorkflowCatalogVersion { get; init; }
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
+    public string? CapabilityCatalogVersion { get; init; }
+    public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
     public string? SecurityPolicyVersion { get; init; }
     public string? DesiredUpdateManifestId { get; init; }
     public string? DesiredWorkflowPackId { get; init; }
+    public string? DesiredCapabilityCatalogId { get; init; }
     public RunnerUpdateStatus? UpdateStatus { get; init; }
     public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }

--- a/AgentDeck.Shared/Models/RunnerCapabilityCatalog.cs
+++ b/AgentDeck.Shared/Models/RunnerCapabilityCatalog.cs
@@ -1,0 +1,27 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerCapabilityCatalog
+{
+    public required string CatalogId { get; init; }
+    public required string Version { get; init; }
+    public required string DisplayName { get; init; }
+    public string? Description { get; init; }
+    public IReadOnlyList<RunnerCapabilityDefinition> Capabilities { get; init; } = [];
+}
+
+public sealed class RunnerCapabilityDefinition
+{
+    public required string CapabilityId { get; init; }
+    public required string DisplayName { get; init; }
+    public required string Category { get; init; }
+    public RunnerCapabilityProbeKind ProbeKind { get; init; }
+    public IReadOnlyList<RunnerCapabilityProbeCommand> ProbeCommands { get; init; } = [];
+}
+
+public sealed class RunnerCapabilityProbeCommand
+{
+    public required string FileName { get; init; }
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/RunnerCapabilityCatalogStatus.cs
+++ b/AgentDeck.Shared/Models/RunnerCapabilityCatalogStatus.cs
@@ -1,0 +1,12 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerCapabilityCatalogStatus
+{
+    public RunnerCapabilityCatalogState State { get; init; } = RunnerCapabilityCatalogState.Unknown;
+    public string? CatalogId { get; init; }
+    public string? LocalCatalogVersion { get; init; }
+    public string? DesiredCatalogVersion { get; init; }
+    public string? StatusMessage { get; init; }
+}

--- a/AgentDeck.Shared/Models/RunnerDesiredState.cs
+++ b/AgentDeck.Shared/Models/RunnerDesiredState.cs
@@ -9,7 +9,9 @@ public sealed class RunnerDesiredState
     public required RunnerControlPlaneSecurityPolicy SecurityPolicy { get; init; }
     public RunnerDefinitionReference? DesiredUpdateManifest { get; init; }
     public RunnerDefinitionReference? DesiredWorkflowPack { get; init; }
+    public RunnerDefinitionReference? DesiredCapabilityCatalog { get; init; }
     public string? WorkflowCatalogVersion { get; init; }
+    public string? CapabilityCatalogVersion { get; init; }
     public bool UpdateAvailable { get; init; }
     public bool ApplyUpdate { get; init; }
     public bool ProtocolCompatible { get; init; } = true;

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Workflow packs now also have a first-pass runner execution path: worker runners 
 
 Workflow catalog versioning now also has explicit compatibility signaling: worker runners advertise a configured local workflow catalog version, reconcile it against the coordinator's desired catalog version, and report `Matched`, `Mismatched`, or `Unknown` catalog status through the machine directory.
 
+Capability detection is now also moving under the coordinator-owned control plane: the coordinator can publish a versioned capability catalog that defines the ordered capability probe list and probe commands for built-in tool/SDK checks, runners persist and reconcile that catalog locally, and machine capability snapshots now execute from the reconciled catalog instead of hardcoding the top-level probe list inside `MachineCapabilityService`. The companion Settings page surfaces the runner's capability-catalog version/status alongside the existing workflow-catalog and workflow-pack control-plane state.
+
 ### Control-plane security model
 
 - Runners only accept a non-HTTPS coordinator URL by default when it targets loopback and `Coordinator:AllowInsecureHttpCoordinatorForLoopback` is enabled for local development.


### PR DESCRIPTION
## Summary
- add a coordinator-published capability catalog definition and runner reconcile flow
- drive machine capability snapshots from the reconciled catalog instead of a hardcoded top-level probe list
- surface capability-catalog version and status through the machine directory and Settings UI

Closes #222