### PR TITLE
Move machine setup recipes into a coordinator catalog

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -24,6 +24,8 @@ public sealed class CoordinatorOptions
 
     public CoordinatorCapabilityCatalogOptions DesiredCapabilityCatalog { get; set; } = new();
 
+    public CoordinatorSetupCatalogOptions DesiredSetupCatalog { get; set; } = new();
+
     public CoordinatorSecurityPolicyOptions SecurityPolicy { get; set; } = new();
 
     public bool ApplyStagedUpdate { get; set; }

--- a/AgentDeck.Coordinator/Configuration/CoordinatorSetupCatalogOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorSetupCatalogOptions.cs
@@ -1,0 +1,39 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Coordinator.Configuration;
+
+public sealed class CoordinatorSetupCatalogOptions
+{
+    public string CatalogId { get; set; } = "default-setup";
+    public string Version { get; set; } = "1";
+    public string DisplayName { get; set; } = "Default Setup Catalog";
+    public string? Description { get; set; }
+    public IReadOnlyList<CoordinatorSetupCapabilityOptions> Capabilities { get; set; } = [];
+}
+
+public sealed class CoordinatorSetupCapabilityOptions
+{
+    public string CapabilityId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public IReadOnlyList<CoordinatorSetupActionOptions> Actions { get; set; } = [];
+}
+
+public sealed class CoordinatorSetupActionOptions
+{
+    public string Action { get; set; } = "install";
+    public IReadOnlyList<CoordinatorSetupRecipeOptions> Recipes { get; set; } = [];
+}
+
+public sealed class CoordinatorSetupRecipeOptions
+{
+    public RunnerHostPlatform Platform { get; set; } = RunnerHostPlatform.Unknown;
+    public RunnerSetupRecipeExecutionKind ExecutionKind { get; set; } = RunnerSetupRecipeExecutionKind.PlatformShell;
+    public string? MatchVersionPattern { get; set; }
+    public bool MatchWhenVersionMissing { get; set; }
+    public string? DefaultVersion { get; set; }
+    public string? CommandText { get; set; }
+    public string? FileName { get; set; }
+    public IReadOnlyList<string> Arguments { get; set; } = [];
+    public IReadOnlyList<string> RequiredCommands { get; set; } = [];
+    public string? RequiredCommandsMessage { get; set; }
+}

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -767,6 +767,11 @@ app.MapGet("/api/runner-definitions/capability-catalogs/{catalogId}", (string ca
         ? Results.Ok(capabilityCatalog)
         : Results.NotFound());
 
+app.MapGet("/api/runner-definitions/setup-catalogs/{catalogId}", (string catalogId, IRunnerDefinitionCatalogService catalog) =>
+    catalog.GetSetupCatalog(catalogId) is { } setupCatalog
+        ? Results.Ok(setupCatalog)
+        : Results.NotFound());
+
 app.MapPost("/api/cluster/workers/register", (RegisterRunnerMachineRequest request, IWorkerRegistryService registry) =>
 {
     try

--- a/AgentDeck.Coordinator/Services/IRunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/IRunnerDefinitionCatalogService.cs
@@ -10,9 +10,13 @@ public interface IRunnerDefinitionCatalogService
 
     RunnerCapabilityCatalog GetDesiredCapabilityCatalog();
 
+    RunnerSetupCatalog GetDesiredSetupCatalog();
+
     RunnerUpdateManifest? GetUpdateManifest(string manifestId);
 
     RunnerWorkflowPack? GetWorkflowPack(string packId);
 
     RunnerCapabilityCatalog? GetCapabilityCatalog(string catalogId);
+
+    RunnerSetupCatalog? GetSetupCatalog(string catalogId);
 }

--- a/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
@@ -9,6 +9,7 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     private readonly RunnerUpdateManifest _desiredUpdateManifest;
     private readonly RunnerWorkflowPack _desiredWorkflowPack;
     private readonly RunnerCapabilityCatalog _desiredCapabilityCatalog;
+    private readonly RunnerSetupCatalog _desiredSetupCatalog;
 
     public RunnerDefinitionCatalogService(
         IOptions<CoordinatorOptions> coordinatorOptions,
@@ -18,6 +19,7 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
         var desiredUpdateManifest = options.DesiredUpdateManifest ?? new CoordinatorUpdateManifestOptions();
         var desiredWorkflowPack = options.DesiredWorkflowPack ?? new CoordinatorWorkflowPackOptions();
         var desiredCapabilityCatalog = options.DesiredCapabilityCatalog ?? new CoordinatorCapabilityCatalogOptions();
+        var desiredSetupCatalog = options.DesiredSetupCatalog ?? new CoordinatorSetupCatalogOptions();
         var securityPolicy = options.SecurityPolicy ?? new CoordinatorSecurityPolicyOptions();
         var hostedArtifact = ResolveHostedArtifact(options, desiredUpdateManifest, artifactService);
 
@@ -114,6 +116,50 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                 })
                 .ToArray()
         };
+
+        _desiredSetupCatalog = new RunnerSetupCatalog
+        {
+            CatalogId = NormalizeRequired(desiredSetupCatalog.CatalogId, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:CatalogId"),
+            Version = NormalizeRequired(desiredSetupCatalog.Version, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:Version"),
+            DisplayName = NormalizeRequired(desiredSetupCatalog.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:DisplayName"),
+            Description = NormalizeOptional(desiredSetupCatalog.Description),
+            Capabilities = (desiredSetupCatalog.Capabilities ?? [])
+                .Where(capability => !string.IsNullOrWhiteSpace(capability.CapabilityId))
+                .Select(capability => new RunnerSetupCapabilityDefinition
+                {
+                    CapabilityId = NormalizeRequired(capability.CapabilityId, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:Capabilities:CapabilityId"),
+                    DisplayName = NormalizeRequired(capability.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:Capabilities:DisplayName"),
+                    Actions = (capability.Actions ?? [])
+                        .Where(action => !string.IsNullOrWhiteSpace(action.Action))
+                        .Select(action => new RunnerSetupActionDefinition
+                        {
+                            Action = NormalizeRequired(action.Action, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:Capabilities:Actions:Action"),
+                            Recipes = (action.Recipes ?? [])
+                                .Select(recipe => new RunnerSetupRecipe
+                                {
+                                    Platform = recipe.Platform,
+                                    ExecutionKind = recipe.ExecutionKind,
+                                    MatchVersionPattern = NormalizeOptional(recipe.MatchVersionPattern),
+                                    MatchWhenVersionMissing = recipe.MatchWhenVersionMissing,
+                                    DefaultVersion = NormalizeOptional(recipe.DefaultVersion),
+                                    CommandText = NormalizeOptional(recipe.CommandText),
+                                    FileName = NormalizeOptional(recipe.FileName),
+                                    Arguments = (recipe.Arguments ?? [])
+                                        .Where(argument => !string.IsNullOrWhiteSpace(argument))
+                                        .Select(argument => argument.Trim())
+                                        .ToArray(),
+                                    RequiredCommands = (recipe.RequiredCommands ?? [])
+                                        .Where(command => !string.IsNullOrWhiteSpace(command))
+                                        .Select(command => command.Trim())
+                                        .ToArray(),
+                                    RequiredCommandsMessage = NormalizeOptional(recipe.RequiredCommandsMessage)
+                                })
+                                .ToArray()
+                        })
+                        .ToArray()
+                })
+                .ToArray()
+        };
     }
 
     public RunnerUpdateManifest GetDesiredUpdateManifest() => _desiredUpdateManifest;
@@ -121,6 +167,8 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     public RunnerWorkflowPack GetDesiredWorkflowPack() => _desiredWorkflowPack;
 
     public RunnerCapabilityCatalog GetDesiredCapabilityCatalog() => _desiredCapabilityCatalog;
+
+    public RunnerSetupCatalog GetDesiredSetupCatalog() => _desiredSetupCatalog;
 
     public RunnerUpdateManifest? GetUpdateManifest(string manifestId) =>
         string.Equals(_desiredUpdateManifest.ManifestId, manifestId, StringComparison.OrdinalIgnoreCase)
@@ -135,6 +183,11 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     public RunnerCapabilityCatalog? GetCapabilityCatalog(string catalogId) =>
         string.Equals(_desiredCapabilityCatalog.CatalogId, catalogId, StringComparison.OrdinalIgnoreCase)
             ? _desiredCapabilityCatalog
+            : null;
+
+    public RunnerSetupCatalog? GetSetupCatalog(string catalogId) =>
+        string.Equals(_desiredSetupCatalog.CatalogId, catalogId, StringComparison.OrdinalIgnoreCase)
+            ? _desiredSetupCatalog
             : null;
 
     private static string? NormalizeOptional(string? value) =>

--- a/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
+++ b/AgentDeck.Coordinator/Services/WorkerRegistryService.cs
@@ -140,10 +140,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
                 CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
                 CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
+                SetupCatalogVersion = machine.SetupCatalogVersion,
+                SetupCatalogStatus = machine.SetupCatalogStatus,
                 SecurityPolicyVersion = machine.SecurityPolicyVersion,
                 DesiredUpdateManifestId = machine.DesiredUpdateManifestId,
                 DesiredWorkflowPackId = machine.DesiredWorkflowPackId,
                 DesiredCapabilityCatalogId = machine.DesiredCapabilityCatalogId,
+                DesiredSetupCatalogId = machine.DesiredSetupCatalogId,
                 UpdateStatus = machine.UpdateStatus,
                 UpdateRollout = machine.UpdateRollout,
                 WorkflowPackStatus = null,
@@ -197,10 +200,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 WorkflowCatalogStatus = request.WorkflowCatalogStatus,
                 CapabilityCatalogVersion = NormalizeOptional(request.CapabilityCatalogVersion),
                 CapabilityCatalogStatus = request.CapabilityCatalogStatus,
+                SetupCatalogVersion = NormalizeOptional(request.SetupCatalogVersion),
+                SetupCatalogStatus = request.SetupCatalogStatus,
                 SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
                 DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
                 DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
                 DesiredCapabilityCatalogId = desiredState.DesiredCapabilityCatalog?.DefinitionId,
+                DesiredSetupCatalogId = desiredState.DesiredSetupCatalog?.DefinitionId,
                 UpdateStatus = request.UpdateStatus,
                 UpdateRollout = updateRollout,
                 WorkflowPackStatus = request.WorkflowPackStatus,
@@ -285,10 +291,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
                 CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
                 CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
+                SetupCatalogVersion = machine.SetupCatalogVersion,
+                SetupCatalogStatus = machine.SetupCatalogStatus,
                 SecurityPolicyVersion = desiredState.SecurityPolicy.PolicyVersion,
                 DesiredUpdateManifestId = desiredState.DesiredUpdateManifest?.DefinitionId,
                 DesiredWorkflowPackId = desiredState.DesiredWorkflowPack?.DefinitionId,
                 DesiredCapabilityCatalogId = desiredState.DesiredCapabilityCatalog?.DefinitionId,
+                DesiredSetupCatalogId = desiredState.DesiredSetupCatalog?.DefinitionId,
                 UpdateStatus = machine.UpdateStatus,
                 UpdateRollout = BuildUpdateRollout(
                     machine.MachineId,
@@ -337,11 +346,13 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
         var desiredManifest = _definitions.GetDesiredUpdateManifest();
         var desiredWorkflowPack = _definitions.GetDesiredWorkflowPack();
         var desiredCapabilityCatalog = _definitions.GetDesiredCapabilityCatalog();
+        var desiredSetupCatalog = _definitions.GetDesiredSetupCatalog();
         var desiredVersion = NormalizeOptional(_coordinatorOptions.DesiredRunnerVersion)
             ?? NormalizeOptional(desiredManifest.Version)
             ?? normalizedAgentVersion;
         var workflowCatalogVersion = NormalizeOptional(_coordinatorOptions.WorkflowCatalogVersion);
         var capabilityCatalogVersion = NormalizeOptional(desiredCapabilityCatalog.Version);
+        var setupCatalogVersion = NormalizeOptional(desiredSetupCatalog.Version);
         var protocolCompatible = protocolVersion >= _coordinatorOptions.MinimumSupportedProtocolVersion &&
                                  protocolVersion <= _coordinatorOptions.MaximumSupportedProtocolVersion;
         var securityPolicyAllowsApply = _coordinatorOptions.SecurityPolicy?.AllowUpdateApply ?? false;
@@ -393,8 +404,14 @@ public sealed class WorkerRegistryService : IWorkerRegistryService
                 DefinitionId = desiredCapabilityCatalog.CatalogId,
                 Version = desiredCapabilityCatalog.Version
             },
+            DesiredSetupCatalog = new RunnerDefinitionReference
+            {
+                DefinitionId = desiredSetupCatalog.CatalogId,
+                Version = desiredSetupCatalog.Version
+            },
             WorkflowCatalogVersion = workflowCatalogVersion,
             CapabilityCatalogVersion = capabilityCatalogVersion,
+            SetupCatalogVersion = setupCatalogVersion,
             UpdateAvailable = updateAvailable,
             ApplyUpdate = applyUpdate,
             ProtocolCompatible = protocolCompatible,

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -129,6 +129,240 @@
         }
       ]
     },
+    "DesiredSetupCatalog": {
+      "CatalogId": "default-setup",
+      "Version": "1",
+      "DisplayName": "Default Setup Catalog",
+      "Description": "Coordinator-authored install and update recipes for the built-in runner capabilities.",
+      "Capabilities": [
+        {
+          "CapabilityId": "gh",
+          "DisplayName": "GitHub CLI",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "winget install --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "apt-get update && apt-get install -y gh",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            },
+            {
+              "Action": "update",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "winget upgrade --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "apt-get update && apt-get install -y --only-upgrade gh",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "copilot",
+          "DisplayName": "GitHub Copilot CLI",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "DirectCommand",
+                  "FileName": "npm",
+                  "Arguments": [ "install", "-g", "@github/copilot" ],
+                  "RequiredCommands": [ "npm" ],
+                  "RequiredCommandsMessage": "npm is required to install GitHub Copilot CLI. Install Node.js first."
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            },
+            {
+              "Action": "update",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "DirectCommand",
+                  "FileName": "npm",
+                  "Arguments": [ "update", "-g", "@github/copilot" ],
+                  "RequiredCommands": [ "npm" ],
+                  "RequiredCommandsMessage": "npm is required to update GitHub Copilot CLI. Install Node.js first."
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "node",
+          "DisplayName": "Node.js",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "CommandText": "winget install --id OpenJS.NodeJS.LTS -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^20($|\\.)",
+                  "CommandText": "winget install --id OpenJS.NodeJS.LTS -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+$",
+                  "CommandText": "winget install --id OpenJS.NodeJS -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+\\.\\d+",
+                  "CommandText": "winget install --id OpenJS.NodeJS -e --accept-package-agreements --accept-source-agreements --version \"{requestedVersion}\"",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "DefaultVersion": "22",
+                  "CommandText": "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl ca-certificates; fi && curl -fsSL https://deb.nodesource.com/setup_{major}.x | bash - && apt-get install -y nodejs",
+                  "RequiredCommands": [ "apt-get" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+",
+                  "CommandText": "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl ca-certificates; fi && curl -fsSL https://deb.nodesource.com/setup_{major}.x | bash - && apt-get install -y nodejs",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "python",
+          "DisplayName": "Python",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "DefaultVersion": "3.12",
+                  "CommandText": "winget install --id Python.Python.{requestedVersion} -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+(\\.\\d+)?$",
+                  "CommandText": "winget install --id Python.Python.{requestedVersion} -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "CommandText": "apt-get update && apt-get install -y python3 python3-pip python3-venv pipx",
+                  "RequiredCommands": [ "apt-get" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+(\\.\\d+)?$",
+                  "CommandText": "apt-get update && apt-get install -y python{requestedVersion} python{requestedVersion}-venv python3-pip",
+                  "RequiredCommands": [ "apt-get" ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "dotnet",
+          "DisplayName": ".NET SDK",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "DefaultVersion": "10.0",
+                  "CommandText": "winget install --id Microsoft.DotNet.SDK.{major} -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+\\.\\d+$",
+                  "CommandText": "winget install --id Microsoft.DotNet.SDK.{major} -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+\\.\\d+\\.\\d+$",
+                  "CommandText": "winget install --id Microsoft.DotNet.SDK.{major} -e --accept-package-agreements --accept-source-agreements --version \"{requestedVersion}\"",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchWhenVersionMissing": true,
+                  "DefaultVersion": "10.0",
+                  "CommandText": "wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-{requestedVersion}",
+                  "RequiredCommands": [ "apt-get", "wget", "dpkg" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "MatchVersionPattern": "^\\d+\\.\\d+$",
+                  "CommandText": "wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-{requestedVersion}",
+                  "RequiredCommands": [ "apt-get", "wget", "dpkg" ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "SecurityPolicy": {
       "PolicyVersion": "1",
       "AllowUpdateStaging": true,

--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -33,6 +33,8 @@ public sealed class CompanionMachineSummary
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
     public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
     public string? CapabilityCatalogVersion { get; init; }
+    public RunnerSetupCatalogStatus? SetupCatalogStatus { get; init; }
+    public string? SetupCatalogVersion { get; init; }
     public IReadOnlyList<MachineTargetSupport> SupportedTargets { get; init; } = [];
     public IReadOnlyList<RemoteViewerProviderCapability> RemoteViewerProviders { get; init; } = [];
 }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -90,6 +90,10 @@
                             {
                                 <span> • capabilities @machine.CapabilityCatalogVersion</span>
                             }
+                            @if (!string.IsNullOrWhiteSpace(machine.SetupCatalogVersion))
+                            {
+                                <span> • setup @machine.SetupCatalogVersion</span>
+                            }
                             @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
                             {
                                 <span> • security @machine.SecurityPolicyVersion</span>
@@ -428,6 +432,35 @@
                                 <div class="settings-status-row">
                                     <span class="settings-status-row__label">Capability catalog summary</span>
                                     <span class="settings-status-row__value">@capabilityCatalogStatus.StatusMessage</span>
+                                </div>
+                            }
+                        }
+                        @if (SelectedRegisteredMachine?.SetupCatalogStatus is { } setupCatalogStatus &&
+                             setupCatalogStatus.State != RunnerSetupCatalogState.Unknown)
+                        {
+                            <div class="settings-status-row">
+                                <span class="settings-status-row__label">Setup catalog state</span>
+                                <span class="settings-status-row__value">@GetSetupCatalogStateLabel(setupCatalogStatus.State)</span>
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.LocalCatalogVersion))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Local setup catalog</span>
+                                    <span class="settings-status-row__value">@setupCatalogStatus.LocalCatalogVersion</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.DesiredCatalogVersion))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Desired setup catalog</span>
+                                    <span class="settings-status-row__value">@setupCatalogStatus.DesiredCatalogVersion</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.StatusMessage))
+                            {
+                                <div class="settings-status-row">
+                                    <span class="settings-status-row__label">Setup catalog summary</span>
+                                    <span class="settings-status-row__value">@setupCatalogStatus.StatusMessage</span>
                                 </div>
                             }
                         }
@@ -938,6 +971,13 @@
         RunnerCapabilityCatalogState.Matched => "Matched",
         RunnerCapabilityCatalogState.Mismatched => "Mismatched",
         RunnerCapabilityCatalogState.Failed => "Failed",
+        _ => "Unknown"
+    };
+
+    private static string GetSetupCatalogStateLabel(RunnerSetupCatalogState state) => state switch
+    {
+        RunnerSetupCatalogState.Matched => "Matched",
+        RunnerSetupCatalogState.Failed => "Failed",
         _ => "Unknown"
     };
 

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -88,6 +88,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                 WorkflowCatalogStatus = machine.WorkflowCatalogStatus,
                 CapabilityCatalogStatus = machine.CapabilityCatalogStatus,
                 CapabilityCatalogVersion = machine.CapabilityCatalogVersion,
+                SetupCatalogStatus = machine.SetupCatalogStatus,
+                SetupCatalogVersion = machine.SetupCatalogVersion,
                 SupportedTargets = machine.SupportedTargets,
                 RemoteViewerProviders = machine.RemoteViewerProviders
             })

--- a/AgentDeck.Runner/Configuration/WorkerCoordinatorOptions.cs
+++ b/AgentDeck.Runner/Configuration/WorkerCoordinatorOptions.cs
@@ -37,6 +37,9 @@ public sealed class WorkerCoordinatorOptions
     /// <summary>Optional local root for the reconciled coordinator capability catalog.</summary>
     public string? CapabilityCatalogRoot { get; set; }
 
+    /// <summary>Optional local root for the reconciled coordinator setup catalog.</summary>
+    public string? SetupCatalogRoot { get; set; }
+
     /// <summary>Allow plain HTTP only when the configured coordinator resolves to a loopback host.</summary>
     public bool AllowInsecureHttpCoordinatorForLoopback { get; set; } = true;
 

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddSingleton<IRunnerTrustPolicy, RunnerTrustPolicy>();
 builder.Services.AddSingleton<IRunnerUpdateStagingService, RunnerUpdateStagingService>();
 builder.Services.AddSingleton<IRunnerWorkflowCatalogService, RunnerWorkflowCatalogService>();
 builder.Services.AddSingleton<IRunnerCapabilityCatalogService, RunnerCapabilityCatalogService>();
+builder.Services.AddSingleton<IRunnerSetupCatalogService, RunnerSetupCatalogService>();
 builder.Services.AddSingleton<IRunnerWorkflowPackService, RunnerWorkflowPackService>();
 builder.Services.AddSingleton<IVsCodeDebugSessionService, VsCodeDebugSessionService>();
 builder.Services.AddSingleton<IVirtualDeviceCatalogService, VirtualDeviceCatalogService>();

--- a/AgentDeck.Runner/Services/IRunnerSetupCatalogService.cs
+++ b/AgentDeck.Runner/Services/IRunnerSetupCatalogService.cs
@@ -1,0 +1,15 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public interface IRunnerSetupCatalogService
+{
+    Task<RunnerSetupCatalog?> GetCurrentCatalogAsync(CancellationToken cancellationToken = default);
+
+    Task<RunnerSetupCatalogStatus?> GetCurrentStatusAsync(CancellationToken cancellationToken = default);
+
+    Task<RunnerSetupCatalogStatus> ReconcileDesiredSetupCatalogAsync(
+        HttpClient coordinatorClient,
+        RunnerDesiredState desiredState,
+        CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
+using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 
 namespace AgentDeck.Runner.Services;
@@ -6,241 +8,182 @@ namespace AgentDeck.Runner.Services;
 /// <inheritdoc />
 public sealed class MachineSetupService : IMachineSetupService
 {
+    private readonly IRunnerSetupCatalogService _setupCatalog;
     private readonly ILogger<MachineSetupService> _logger;
 
-    public MachineSetupService(ILogger<MachineSetupService> logger)
+    public MachineSetupService(
+        IRunnerSetupCatalogService setupCatalog,
+        ILogger<MachineSetupService> logger)
     {
+        _setupCatalog = setupCatalog;
         _logger = logger;
     }
 
-    public async Task<MachineCapabilityInstallResult> InstallCapabilityAsync(string capabilityId, string? version = null, CancellationToken cancellationToken = default)
-    {
-        var request = capabilityId.Trim().ToLowerInvariant();
-        var requestedVersion = NormalizeVersion(version);
+    public Task<MachineCapabilityInstallResult> InstallCapabilityAsync(string capabilityId, string? version = null, CancellationToken cancellationToken = default) =>
+        ExecuteCapabilityActionAsync(capabilityId, "install", version, cancellationToken);
 
-        return request switch
+    public Task<MachineCapabilityInstallResult> UpdateCapabilityAsync(string capabilityId, CancellationToken cancellationToken = default) =>
+        ExecuteCapabilityActionAsync(capabilityId, "update", cancellationToken: cancellationToken);
+
+    private async Task<MachineCapabilityInstallResult> ExecuteCapabilityActionAsync(
+        string capabilityId,
+        string action,
+        string? requestedVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedCapabilityId = NormalizeValue(capabilityId);
+        if (normalizedCapabilityId is null)
         {
-            "gh" => await InstallGitHubCliAsync(cancellationToken),
-            "copilot" => await InstallCopilotCliAsync(cancellationToken),
-            "node" => await InstallNodeAsync(requestedVersion, cancellationToken),
-            "python" => await InstallPythonAsync(requestedVersion, cancellationToken),
-            "dotnet" => await InstallDotNetAsync(requestedVersion, cancellationToken),
-            _ => CreateFailureResult(request, capabilityId, "install", requestedVersion, $"Installing '{capabilityId}' is not supported.")
+            return CreateFailureResult("unknown", capabilityId, action, requestedVersion, "Capability id is required.");
+        }
+
+        var catalog = await _setupCatalog.GetCurrentCatalogAsync(cancellationToken);
+        if (catalog is null)
+        {
+            return CreateFailureResult(
+                normalizedCapabilityId,
+                capabilityId,
+                action,
+                requestedVersion,
+                "Runner has not reconciled a setup catalog from the coordinator yet.");
+        }
+
+        var capability = catalog.Capabilities.FirstOrDefault(candidate =>
+            string.Equals(candidate.CapabilityId, normalizedCapabilityId, StringComparison.OrdinalIgnoreCase));
+        if (capability is null)
+        {
+            return CreateFailureResult(
+                normalizedCapabilityId,
+                capabilityId,
+                action,
+                requestedVersion,
+                $"Setup catalog does not define capability '{capabilityId}'.");
+        }
+
+        var actionDefinition = capability.Actions.FirstOrDefault(candidate =>
+            string.Equals(candidate.Action, action, StringComparison.OrdinalIgnoreCase));
+        if (actionDefinition is null)
+        {
+            return CreateFailureResult(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                requestedVersion,
+                $"Setup catalog does not define an '{action}' action for '{capability.DisplayName}'.");
+        }
+
+        var platform = GetCurrentPlatform();
+        var normalizedRequestedVersion = NormalizeValue(requestedVersion);
+        var recipe = actionDefinition.Recipes.FirstOrDefault(candidate => RecipeMatches(candidate, platform, normalizedRequestedVersion));
+        if (recipe is null)
+        {
+            return CreateFailureResult(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                normalizedRequestedVersion,
+                $"Setup catalog does not define a matching {platform} recipe for '{capability.DisplayName}' {action}.");
+        }
+
+        var effectiveVersion = normalizedRequestedVersion ?? NormalizeValue(recipe.DefaultVersion);
+        var missingCommand = recipe.RequiredCommands
+            .Select(RenderTemplate)
+            .FirstOrDefault(command => !string.IsNullOrWhiteSpace(command) && !CommandExists(command));
+        if (missingCommand is not null)
+        {
+            return CreateFailureResult(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                effectiveVersion,
+                BuildMissingCommandMessage(recipe, missingCommand, action));
+        }
+
+        return recipe.ExecutionKind switch
+        {
+            RunnerSetupRecipeExecutionKind.PlatformShell => await ExecutePlatformShellRecipeAsync(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                recipe,
+                effectiveVersion,
+                cancellationToken),
+            RunnerSetupRecipeExecutionKind.DirectCommand => await ExecuteDirectRecipeAsync(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                recipe,
+                effectiveVersion,
+                cancellationToken),
+            _ => CreateFailureResult(
+                normalizedCapabilityId,
+                capability.DisplayName,
+                action,
+                effectiveVersion,
+                $"Unsupported setup recipe execution kind '{recipe.ExecutionKind}'.")
+        };
+
+        string RenderTemplate(string value) => ApplyTemplate(value, effectiveVersion);
+    }
+
+    private async Task<MachineCapabilityInstallResult> ExecutePlatformShellRecipeAsync(
+        string capabilityId,
+        string capabilityName,
+        string action,
+        RunnerSetupRecipe recipe,
+        string? effectiveVersion,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(recipe.CommandText))
+        {
+            return CreateFailureResult(capabilityId, capabilityName, action, effectiveVersion, "Setup recipe requires command text.");
+        }
+
+        var commandText = ApplyTemplate(recipe.CommandText, effectiveVersion);
+        return GetCurrentPlatform() switch
+        {
+            RunnerHostPlatform.Windows => await RunWindowsShellCommandAsync(capabilityId, capabilityName, commandText, cancellationToken, action, effectiveVersion),
+            RunnerHostPlatform.Linux => await RunLinuxShellCommandAsync(capabilityId, capabilityName, commandText, cancellationToken, action, effectiveVersion),
+            _ => CreateFailureResult(capabilityId, capabilityName, action, effectiveVersion, "Platform shell setup recipes are not supported on this runner platform.")
         };
     }
 
-    public Task<MachineCapabilityInstallResult> UpdateCapabilityAsync(string capabilityId, CancellationToken cancellationToken = default)
+    private async Task<MachineCapabilityInstallResult> ExecuteDirectRecipeAsync(
+        string capabilityId,
+        string capabilityName,
+        string action,
+        RunnerSetupRecipe recipe,
+        string? effectiveVersion,
+        CancellationToken cancellationToken)
     {
-        var request = capabilityId.Trim().ToLowerInvariant();
-
-        return request switch
+        var fileName = NormalizeValue(recipe.FileName);
+        if (fileName is null)
         {
-            "gh" => UpdateGitHubCliAsync(cancellationToken),
-            "copilot" => UpdateCopilotCliAsync(cancellationToken),
-            _ => Task.FromResult(CreateFailureResult(request, capabilityId, "update", null, $"Updating '{capabilityId}' is not supported."))
-        };
-    }
-
-    private Task<MachineCapabilityInstallResult> InstallGitHubCliAsync(CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return RunWindowsCommandAsync(
-                "gh",
-                "GitHub CLI",
-                "winget install --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
-                cancellationToken,
-                action: "install");
+            return CreateFailureResult(capabilityId, capabilityName, action, effectiveVersion, "Direct-command setup recipe requires a file name.");
         }
 
-        return RunLinuxCommandAsync(
-            "gh",
-            "GitHub CLI",
-            "apt-get update && apt-get install -y gh",
+        var arguments = recipe.Arguments
+            .Select(argument => ApplyTemplate(argument, effectiveVersion))
+            .ToArray();
+        return await RunDirectCommandAsync(
+            capabilityId,
+            capabilityName,
+            fileName,
+            arguments,
             cancellationToken,
-            action: "install");
+            action,
+            null,
+            effectiveVersion);
     }
 
-    private Task<MachineCapabilityInstallResult> InstallCopilotCliAsync(CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            if (!CommandExists("npm"))
-            {
-                return Task.FromResult(CreateFailureResult(
-                    "copilot",
-                    "GitHub Copilot CLI",
-                    "install",
-                    null,
-                    "npm is required to install GitHub Copilot CLI. Install Node.js first."));
-            }
-
-            return RunDirectCommandAsync(
-                "copilot",
-                "GitHub Copilot CLI",
-                "npm",
-                ["install", "-g", "@github/copilot"],
-                cancellationToken,
-                action: "install");
-        }
-
-        return RunLinuxCommandAsync(
-            "copilot",
-            "GitHub Copilot CLI",
-            "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
-            cancellationToken,
-            action: "install");
-    }
-
-    private Task<MachineCapabilityInstallResult> InstallNodeAsync(string? requestedVersion, CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return RunWindowsCommandAsync(
-                "node",
-                "Node.js",
-                BuildWindowsNodeInstallCommand(requestedVersion),
-                cancellationToken,
-                action: "install",
-                requestedVersion);
-        }
-
-        return RunLinuxCommandAsync(
-            "node",
-            "Node.js",
-            BuildLinuxNodeInstallCommand(requestedVersion),
-            cancellationToken,
-            action: "install",
-            requestedVersion);
-    }
-
-    private Task<MachineCapabilityInstallResult> InstallPythonAsync(string? requestedVersion, CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            var version = requestedVersion ?? "3.12";
-            return RunWindowsCommandAsync(
-                "python",
-                "Python",
-                $"winget install --id Python.Python.{version} -e --accept-package-agreements --accept-source-agreements",
-                cancellationToken,
-                action: "install",
-                version);
-        }
-
-        var commandText = requestedVersion is null
-            ? "apt-get update && apt-get install -y python3 python3-pip python3-venv pipx"
-            : $"apt-get update && apt-get install -y python{requestedVersion} python{requestedVersion}-venv python3-pip";
-
-        return RunLinuxCommandAsync(
-            "python",
-            "Python",
-            commandText,
-            cancellationToken,
-            action: "install",
-            requestedVersion);
-    }
-
-    private Task<MachineCapabilityInstallResult> InstallDotNetAsync(string? requestedVersion, CancellationToken cancellationToken)
-    {
-        var version = requestedVersion ?? "10.0";
-        if (OperatingSystem.IsWindows())
-        {
-            var major = version.Split('.', 2)[0];
-            var commandText = $"winget install --id Microsoft.DotNet.SDK.{major} -e --accept-package-agreements --accept-source-agreements";
-            if (version.Count(ch => ch == '.') >= 2)
-            {
-                commandText += $" --version {QuoteWindowsArgument(version)}";
-            }
-
-            return RunWindowsCommandAsync(
-                "dotnet",
-                ".NET SDK",
-                commandText,
-                cancellationToken,
-                action: "install",
-                version);
-        }
-
-        return RunLinuxCommandAsync(
-            "dotnet",
-            ".NET SDK",
-            $"wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-{version}",
-            cancellationToken,
-            action: "install",
-            version);
-    }
-
-    private Task<MachineCapabilityInstallResult> UpdateGitHubCliAsync(CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return RunWindowsCommandAsync(
-                "gh",
-                "GitHub CLI",
-                "winget upgrade --id GitHub.cli -e --accept-package-agreements --accept-source-agreements",
-                cancellationToken,
-                action: "update");
-        }
-
-        return RunLinuxCommandAsync(
-            "gh",
-            "GitHub CLI",
-            "apt-get update && apt-get install -y --only-upgrade gh",
-            cancellationToken,
-            action: "update");
-    }
-
-    private Task<MachineCapabilityInstallResult> UpdateCopilotCliAsync(CancellationToken cancellationToken)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            if (!CommandExists("npm"))
-            {
-                return Task.FromResult(CreateFailureResult(
-                    "copilot",
-                    "GitHub Copilot CLI",
-                    "update",
-                    null,
-                    "npm is required to update GitHub Copilot CLI. Install Node.js first."));
-            }
-
-            return RunDirectCommandAsync(
-                "copilot",
-                "GitHub Copilot CLI",
-                "npm",
-                ["update", "-g", "@github/copilot"],
-                cancellationToken,
-                action: "update");
-        }
-
-        return RunLinuxCommandAsync(
-            "copilot",
-            "GitHub Copilot CLI",
-            "if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl; fi && curl -fsSL https://gh.io/copilot-install | bash",
-            cancellationToken,
-            action: "update");
-    }
-
-    private Task<MachineCapabilityInstallResult> RunWindowsCommandAsync(
+    private Task<MachineCapabilityInstallResult> RunWindowsShellCommandAsync(
         string capabilityId,
         string capabilityName,
         string commandText,
         CancellationToken cancellationToken,
         string action,
-        string? requestedVersion = null)
-    {
-        if (!CommandExists("winget"))
-        {
-            return Task.FromResult(CreateFailureResult(
-                capabilityId,
-                capabilityName,
-                action,
-                requestedVersion,
-                "winget is required for this installation flow but is not available on the machine."));
-        }
-
-        return RunDirectCommandAsync(
+        string? requestedVersion = null) =>
+        RunDirectCommandAsync(
             capabilityId,
             capabilityName,
             "powershell.exe",
@@ -249,9 +192,8 @@ public sealed class MachineSetupService : IMachineSetupService
             action,
             commandText,
             requestedVersion);
-    }
 
-    private Task<MachineCapabilityInstallResult> RunLinuxCommandAsync(
+    private Task<MachineCapabilityInstallResult> RunLinuxShellCommandAsync(
         string capabilityId,
         string capabilityName,
         string commandText,
@@ -259,16 +201,6 @@ public sealed class MachineSetupService : IMachineSetupService
         string action,
         string? requestedVersion = null)
     {
-        if (!CommandExists("apt-get"))
-        {
-            return Task.FromResult(CreateFailureResult(
-                capabilityId,
-                capabilityName,
-                action,
-                requestedVersion,
-                "apt-get is required for this installation flow but is not available on the machine."));
-        }
-
         var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
         var nonInteractiveCommand = $"export DEBIAN_FRONTEND=noninteractive && {commandText}";
         var finalCommand =
@@ -371,38 +303,58 @@ public sealed class MachineSetupService : IMachineSetupService
         };
     }
 
-    private static string BuildWindowsNodeInstallCommand(string? requestedVersion)
+    private static bool RecipeMatches(RunnerSetupRecipe recipe, RunnerHostPlatform platform, string? requestedVersion)
     {
-        var baseCommand = requestedVersion switch
+        if (recipe.Platform != platform)
         {
-            null => "winget install --id OpenJS.NodeJS.LTS -e --accept-package-agreements --accept-source-agreements",
-            var version when !version.Contains('.') && version.StartsWith("20", StringComparison.OrdinalIgnoreCase)
-                => "winget install --id OpenJS.NodeJS.LTS -e --accept-package-agreements --accept-source-agreements",
-            var version when !version.Contains('.')
-                => "winget install --id OpenJS.NodeJS -e --accept-package-agreements --accept-source-agreements",
-            _ => "winget install --id OpenJS.NodeJS -e --accept-package-agreements --accept-source-agreements"
-        };
-
-        return requestedVersion is not null && requestedVersion.Contains('.')
-            ? $"{baseCommand} --version {QuoteWindowsArgument(requestedVersion)}"
-            : baseCommand;
-    }
-
-    private static string BuildLinuxNodeInstallCommand(string? requestedVersion)
-    {
-        var major = ExtractLeadingMajor(requestedVersion) ?? "22";
-        return $"if ! command -v curl >/dev/null 2>&1; then apt-get update && apt-get install -y curl ca-certificates; fi && curl -fsSL https://deb.nodesource.com/setup_{major}.x | bash - && apt-get install -y nodejs";
-    }
-
-    private static string? ExtractLeadingMajor(string? version)
-    {
-        if (string.IsNullOrWhiteSpace(version))
-        {
-            return null;
+            return false;
         }
 
-        var digits = new string(version.Trim().TakeWhile(char.IsDigit).ToArray());
-        return digits.Length > 0 ? digits : null;
+        if (string.IsNullOrWhiteSpace(requestedVersion))
+        {
+            return recipe.MatchWhenVersionMissing || string.IsNullOrWhiteSpace(recipe.MatchVersionPattern);
+        }
+
+        if (string.IsNullOrWhiteSpace(recipe.MatchVersionPattern))
+        {
+            return !recipe.MatchWhenVersionMissing;
+        }
+
+        return Regex.IsMatch(requestedVersion, recipe.MatchVersionPattern, RegexOptions.IgnoreCase);
+    }
+
+    private static string ApplyTemplate(string value, string? requestedVersion)
+    {
+        var normalizedVersion = NormalizeValue(requestedVersion);
+        var major = ExtractLeadingMajor(normalizedVersion) ?? string.Empty;
+        return value
+            .Replace("{requestedVersion}", normalizedVersion ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("{major}", major, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildMissingCommandMessage(RunnerSetupRecipe recipe, string missingCommand, string action) =>
+        NormalizeValue(recipe.RequiredCommandsMessage) is { } configured
+            ? configured.Replace("{command}", missingCommand, StringComparison.OrdinalIgnoreCase)
+            : $"{missingCommand} is required for this {action} flow but is not available on the machine.";
+
+    private static RunnerHostPlatform GetCurrentPlatform()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return RunnerHostPlatform.Windows;
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return RunnerHostPlatform.Linux;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return RunnerHostPlatform.MacOS;
+        }
+
+        return RunnerHostPlatform.Unknown;
     }
 
     private static MachineCapabilityInstallResult CreateFailureResult(
@@ -451,14 +403,25 @@ public sealed class MachineSetupService : IMachineSetupService
         return false;
     }
 
-    private static string? NormalizeVersion(string? version)
+    private static string? ExtractLeadingMajor(string? version)
     {
         if (string.IsNullOrWhiteSpace(version))
         {
             return null;
         }
 
-        return version.Trim();
+        var digits = new string(version.Trim().TakeWhile(char.IsDigit).ToArray());
+        return digits.Length > 0 ? digits : null;
+    }
+
+    private static string? NormalizeValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
     }
 
     private static string? FirstMeaningfulLine(params string[] values)
@@ -483,5 +446,4 @@ public sealed class MachineSetupService : IMachineSetupService
     }
 
     private static string QuotePosix(string value) => $"'{value.Replace("'", "'\"'\"'")}'";
-    private static string QuoteWindowsArgument(string value) => $"\"{value.Replace("\"", "\\\"")}\"";
 }

--- a/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
@@ -1,0 +1,278 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AgentDeck.Runner.Configuration;
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class RunnerSetupCatalogService : IRunnerSetupCatalogService, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    private readonly WorkerCoordinatorOptions _options;
+    private readonly SemaphoreSlim _reconcileGate = new(1, 1);
+    private readonly ILogger<RunnerSetupCatalogService> _logger;
+    private RunnerSetupCatalog? _currentCatalog;
+    private RunnerSetupCatalogStatus _currentStatus;
+
+    public RunnerSetupCatalogService(
+        IOptions<WorkerCoordinatorOptions> options,
+        ILogger<RunnerSetupCatalogService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _currentCatalog = LoadPersistedCatalog();
+        _currentStatus = NormalizePersistedState(_currentCatalog, LoadPersistedStatus());
+    }
+
+    public async Task<RunnerSetupCatalog?> GetCurrentCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            return _currentCatalog;
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public async Task<RunnerSetupCatalogStatus?> GetCurrentStatusAsync(CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            return _currentStatus;
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public async Task<RunnerSetupCatalogStatus> ReconcileDesiredSetupCatalogAsync(
+        HttpClient coordinatorClient,
+        RunnerDesiredState desiredState,
+        CancellationToken cancellationToken = default)
+    {
+        await _reconcileGate.WaitAsync(cancellationToken);
+        try
+        {
+            var localCatalogVersion = _currentCatalog?.Version;
+            if (desiredState.DesiredSetupCatalog is null)
+            {
+                _currentStatus = await PersistStatusAsync(new RunnerSetupCatalogStatus
+                {
+                    State = RunnerSetupCatalogState.Unknown,
+                    CatalogId = _currentCatalog?.CatalogId,
+                    LocalCatalogVersion = localCatalogVersion,
+                    StatusMessage = "Coordinator did not provide a desired setup catalog."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+
+            var desiredCatalogId = desiredState.DesiredSetupCatalog.DefinitionId;
+            var desiredCatalogVersion = desiredState.DesiredSetupCatalog.Version;
+            if (_currentCatalog is not null &&
+                string.Equals(_currentCatalog.CatalogId, desiredCatalogId, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_currentCatalog.Version, desiredCatalogVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                _currentStatus = await PersistStatusAsync(new RunnerSetupCatalogStatus
+                {
+                    State = RunnerSetupCatalogState.Matched,
+                    CatalogId = _currentCatalog.CatalogId,
+                    LocalCatalogVersion = _currentCatalog.Version,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = $"Runner setup catalog {_currentCatalog.Version} matches the coordinator."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+
+            try
+            {
+                var catalog = await coordinatorClient.GetFromJsonAsync<RunnerSetupCatalog>(
+                    $"api/runner-definitions/setup-catalogs/{Uri.EscapeDataString(desiredCatalogId)}",
+                    cancellationToken);
+
+                if (catalog is null)
+                {
+                    throw new InvalidOperationException("Coordinator returned an empty setup catalog response.");
+                }
+
+                if (!string.Equals(catalog.CatalogId, desiredCatalogId, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Coordinator setup catalog id '{catalog.CatalogId}' did not match desired catalog '{desiredCatalogId}'.");
+                }
+
+                if (!string.Equals(catalog.Version, desiredCatalogVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Coordinator setup catalog version '{catalog.Version}' did not match desired version '{desiredCatalogVersion}'.");
+                }
+
+                Directory.CreateDirectory(GetSetupCatalogRoot());
+                await WriteTextAtomicallyAsync(GetCatalogPath(), JsonSerializer.Serialize(catalog, JsonOptions), cancellationToken);
+                _currentCatalog = catalog;
+                _currentStatus = await PersistStatusAsync(new RunnerSetupCatalogStatus
+                {
+                    State = RunnerSetupCatalogState.Matched,
+                    CatalogId = catalog.CatalogId,
+                    LocalCatalogVersion = catalog.Version,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = $"Runner setup catalog {catalog.Version} matches the coordinator."
+                }, cancellationToken);
+                return _currentStatus;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to reconcile desired setup catalog {CatalogId}@{CatalogVersion}", desiredCatalogId, desiredCatalogVersion);
+                _currentStatus = await PersistStatusAsync(new RunnerSetupCatalogStatus
+                {
+                    State = RunnerSetupCatalogState.Failed,
+                    CatalogId = desiredCatalogId,
+                    LocalCatalogVersion = localCatalogVersion,
+                    DesiredCatalogVersion = desiredCatalogVersion,
+                    StatusMessage = ex.Message
+                }, cancellationToken);
+                return _currentStatus;
+            }
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    public void Dispose() => _reconcileGate.Dispose();
+
+    private async Task<RunnerSetupCatalogStatus> PersistStatusAsync(RunnerSetupCatalogStatus status, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(GetSetupCatalogRoot());
+        await WriteTextAtomicallyAsync(GetStatusPath(), JsonSerializer.Serialize(status, JsonOptions), cancellationToken);
+        return status;
+    }
+
+    private RunnerSetupCatalog? LoadPersistedCatalog()
+    {
+        var path = GetCatalogPath();
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<RunnerSetupCatalog>(File.ReadAllText(path), JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load persisted setup catalog from {CatalogPath}", path);
+            return null;
+        }
+    }
+
+    private RunnerSetupCatalogStatus? LoadPersistedStatus()
+    {
+        var path = GetStatusPath();
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<RunnerSetupCatalogStatus>(File.ReadAllText(path), JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load persisted setup catalog status from {StatusPath}", path);
+            return null;
+        }
+    }
+
+    private RunnerSetupCatalogStatus NormalizePersistedState(
+        RunnerSetupCatalog? catalog,
+        RunnerSetupCatalogStatus? status)
+    {
+        if (catalog is null)
+        {
+            if (status is not null)
+            {
+                _logger.LogWarning("Discarding persisted setup catalog status because no persisted catalog was available.");
+            }
+
+            return new RunnerSetupCatalogStatus
+            {
+                State = RunnerSetupCatalogState.Unknown,
+                StatusMessage = "Runner has not reconciled a coordinator setup catalog yet."
+            };
+        }
+
+        if (status is null)
+        {
+            return new RunnerSetupCatalogStatus
+            {
+                State = RunnerSetupCatalogState.Unknown,
+                CatalogId = catalog.CatalogId,
+                LocalCatalogVersion = catalog.Version,
+                StatusMessage = $"Loaded persisted setup catalog {catalog.CatalogId}@{catalog.Version}."
+            };
+        }
+
+        var catalogMatchesStatus =
+            string.Equals(status.CatalogId, catalog.CatalogId, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(status.LocalCatalogVersion, catalog.Version, StringComparison.OrdinalIgnoreCase);
+
+        if (catalogMatchesStatus)
+        {
+            return status;
+        }
+
+        _logger.LogWarning(
+            "Discarding inconsistent persisted setup catalog status for {CatalogId}@{CatalogVersion}; status referenced {StatusCatalogId}@{StatusCatalogVersion}.",
+            catalog.CatalogId,
+            catalog.Version,
+            status.CatalogId,
+            status.LocalCatalogVersion);
+
+        return new RunnerSetupCatalogStatus
+        {
+            State = RunnerSetupCatalogState.Unknown,
+            CatalogId = catalog.CatalogId,
+            LocalCatalogVersion = catalog.Version,
+            DesiredCatalogVersion = status.DesiredCatalogVersion,
+            StatusMessage = $"Loaded persisted setup catalog {catalog.CatalogId}@{catalog.Version}; coordinator reconciliation will refresh status."
+        };
+    }
+
+    private string GetSetupCatalogRoot()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.SetupCatalogRoot))
+        {
+            return Path.GetFullPath(_options.SetupCatalogRoot);
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "AgentDeck",
+            "worker",
+            "setup-catalog");
+    }
+
+    private string GetCatalogPath() => Path.Combine(GetSetupCatalogRoot(), "current-setup-catalog.json");
+
+    private string GetStatusPath() => Path.Combine(GetSetupCatalogRoot(), "current-setup-catalog-status.json");
+
+    private static async Task WriteTextAtomicallyAsync(string path, string content, CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(path) ?? throw new InvalidOperationException($"Path '{path}' has no parent directory.");
+        Directory.CreateDirectory(directory);
+        var tempPath = Path.Combine(directory, $"{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/AgentDeck.Runner/Services/WorkerCoordinatorRegistrationService.cs
+++ b/AgentDeck.Runner/Services/WorkerCoordinatorRegistrationService.cs
@@ -14,6 +14,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
     private readonly IRunnerUpdateStagingService _updateStaging;
     private readonly IRunnerWorkflowCatalogService _workflowCatalog;
     private readonly IRunnerCapabilityCatalogService _capabilityCatalog;
+    private readonly IRunnerSetupCatalogService _setupCatalog;
     private readonly IRunnerWorkflowPackService _workflowPacks;
     private readonly ILogger<WorkerCoordinatorRegistrationService> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -24,6 +25,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
         IRunnerUpdateStagingService updateStaging,
         IRunnerWorkflowCatalogService workflowCatalog,
         IRunnerCapabilityCatalogService capabilityCatalog,
+        IRunnerSetupCatalogService setupCatalog,
         IRunnerWorkflowPackService workflowPacks,
         IHttpClientFactory httpClientFactory,
         ILogger<WorkerCoordinatorRegistrationService> logger)
@@ -33,6 +35,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
         _updateStaging = updateStaging;
         _workflowCatalog = workflowCatalog;
         _capabilityCatalog = capabilityCatalog;
+        _setupCatalog = setupCatalog;
         _workflowPacks = workflowPacks;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
@@ -77,6 +80,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                 var snapshot = await _capabilities.GetSnapshotAsync(stoppingToken);
                 var workflowCatalogStatus = await _workflowCatalog.GetCurrentStatusAsync(stoppingToken);
                 var capabilityCatalogStatus = await _capabilityCatalog.GetCurrentStatusAsync(stoppingToken);
+                var setupCatalogStatus = await _setupCatalog.GetCurrentStatusAsync(stoppingToken);
                 var updateStatus = await _updateStaging.GetCurrentStatusAsync(stoppingToken);
                 var workflowPackStatus = await _workflowPacks.GetCurrentStatusAsync(stoppingToken);
                 var request = new RegisterRunnerMachineRequest
@@ -92,6 +96,8 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                     WorkflowCatalogStatus = workflowCatalogStatus,
                     CapabilityCatalogVersion = capabilityCatalogStatus?.LocalCatalogVersion,
                     CapabilityCatalogStatus = capabilityCatalogStatus,
+                    SetupCatalogVersion = setupCatalogStatus?.LocalCatalogVersion,
+                    SetupCatalogStatus = setupCatalogStatus,
                     UpdateStatus = updateStatus,
                     WorkflowPackStatus = workflowPackStatus,
                     RunnerUrl = string.IsNullOrWhiteSpace(_coordinatorOptions.AdvertisedRunnerUrl)
@@ -113,6 +119,7 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                 {
                     var catalogStatus = await _workflowCatalog.ReconcileDesiredWorkflowCatalogAsync(desiredState, stoppingToken);
                     var capabilityCatalogStatusAfterReconcile = await _capabilityCatalog.ReconcileDesiredCapabilityCatalogAsync(httpClient, desiredState, stoppingToken);
+                    var setupCatalogStatusAfterReconcile = await _setupCatalog.ReconcileDesiredSetupCatalogAsync(httpClient, desiredState, stoppingToken);
                     if (!desiredState.ProtocolCompatible)
                     {
                         _logger.LogWarning(
@@ -141,6 +148,15 @@ public sealed class WorkerCoordinatorRegistrationService : BackgroundService
                             coordinatorUrl,
                             request.MachineName,
                             capabilityCatalogStatusAfterReconcile.StatusMessage);
+                    }
+
+                    if (setupCatalogStatusAfterReconcile.State == RunnerSetupCatalogState.Failed)
+                    {
+                        _logger.LogWarning(
+                            "Coordinator {CoordinatorUrl} setup catalog reconcile failed for runner {MachineName}: {StatusMessage}",
+                            coordinatorUrl,
+                            request.MachineName,
+                            setupCatalogStatusAfterReconcile.StatusMessage);
                     }
 
                     if (desiredState.UpdateAvailable)

--- a/AgentDeck.Shared/Enums/RunnerSetupCatalogState.cs
+++ b/AgentDeck.Shared/Enums/RunnerSetupCatalogState.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Enums;
+
+public enum RunnerSetupCatalogState
+{
+    Unknown,
+    Matched,
+    Failed
+}

--- a/AgentDeck.Shared/Enums/RunnerSetupRecipeExecutionKind.cs
+++ b/AgentDeck.Shared/Enums/RunnerSetupRecipeExecutionKind.cs
@@ -1,0 +1,7 @@
+namespace AgentDeck.Shared.Enums;
+
+public enum RunnerSetupRecipeExecutionKind
+{
+    PlatformShell,
+    DirectCommand
+}

--- a/AgentDeck.Shared/Models/RegisterRunnerMachineRequest.cs
+++ b/AgentDeck.Shared/Models/RegisterRunnerMachineRequest.cs
@@ -14,6 +14,8 @@ public sealed class RegisterRunnerMachineRequest
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
     public string? CapabilityCatalogVersion { get; init; }
     public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
+    public string? SetupCatalogVersion { get; init; }
+    public RunnerSetupCatalogStatus? SetupCatalogStatus { get; init; }
     public RunnerUpdateStatus? UpdateStatus { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }
     public string? RunnerUrl { get; init; }

--- a/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
+++ b/AgentDeck.Shared/Models/RegisteredRunnerMachine.cs
@@ -14,10 +14,13 @@ public sealed class RegisteredRunnerMachine
     public RunnerWorkflowCatalogStatus? WorkflowCatalogStatus { get; init; }
     public string? CapabilityCatalogVersion { get; init; }
     public RunnerCapabilityCatalogStatus? CapabilityCatalogStatus { get; init; }
+    public string? SetupCatalogVersion { get; init; }
+    public RunnerSetupCatalogStatus? SetupCatalogStatus { get; init; }
     public string? SecurityPolicyVersion { get; init; }
     public string? DesiredUpdateManifestId { get; init; }
     public string? DesiredWorkflowPackId { get; init; }
     public string? DesiredCapabilityCatalogId { get; init; }
+    public string? DesiredSetupCatalogId { get; init; }
     public RunnerUpdateStatus? UpdateStatus { get; init; }
     public RunnerUpdateRolloutStatus? UpdateRollout { get; init; }
     public RunnerWorkflowPackStatus? WorkflowPackStatus { get; init; }

--- a/AgentDeck.Shared/Models/RunnerDesiredState.cs
+++ b/AgentDeck.Shared/Models/RunnerDesiredState.cs
@@ -10,8 +10,10 @@ public sealed class RunnerDesiredState
     public RunnerDefinitionReference? DesiredUpdateManifest { get; init; }
     public RunnerDefinitionReference? DesiredWorkflowPack { get; init; }
     public RunnerDefinitionReference? DesiredCapabilityCatalog { get; init; }
+    public RunnerDefinitionReference? DesiredSetupCatalog { get; init; }
     public string? WorkflowCatalogVersion { get; init; }
     public string? CapabilityCatalogVersion { get; init; }
+    public string? SetupCatalogVersion { get; init; }
     public bool UpdateAvailable { get; init; }
     public bool ApplyUpdate { get; init; }
     public bool ProtocolCompatible { get; init; } = true;

--- a/AgentDeck.Shared/Models/RunnerSetupCatalog.cs
+++ b/AgentDeck.Shared/Models/RunnerSetupCatalog.cs
@@ -1,0 +1,39 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerSetupCatalog
+{
+    public required string CatalogId { get; init; }
+    public required string Version { get; init; }
+    public required string DisplayName { get; init; }
+    public string? Description { get; init; }
+    public IReadOnlyList<RunnerSetupCapabilityDefinition> Capabilities { get; init; } = [];
+}
+
+public sealed class RunnerSetupCapabilityDefinition
+{
+    public required string CapabilityId { get; init; }
+    public required string DisplayName { get; init; }
+    public IReadOnlyList<RunnerSetupActionDefinition> Actions { get; init; } = [];
+}
+
+public sealed class RunnerSetupActionDefinition
+{
+    public required string Action { get; init; }
+    public IReadOnlyList<RunnerSetupRecipe> Recipes { get; init; } = [];
+}
+
+public sealed class RunnerSetupRecipe
+{
+    public RunnerHostPlatform Platform { get; init; } = RunnerHostPlatform.Unknown;
+    public RunnerSetupRecipeExecutionKind ExecutionKind { get; init; } = RunnerSetupRecipeExecutionKind.PlatformShell;
+    public string? MatchVersionPattern { get; init; }
+    public bool MatchWhenVersionMissing { get; init; }
+    public string? DefaultVersion { get; init; }
+    public string? CommandText { get; init; }
+    public string? FileName { get; init; }
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+    public IReadOnlyList<string> RequiredCommands { get; init; } = [];
+    public string? RequiredCommandsMessage { get; init; }
+}

--- a/AgentDeck.Shared/Models/RunnerSetupCatalogStatus.cs
+++ b/AgentDeck.Shared/Models/RunnerSetupCatalogStatus.cs
@@ -1,0 +1,12 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerSetupCatalogStatus
+{
+    public RunnerSetupCatalogState State { get; init; } = RunnerSetupCatalogState.Unknown;
+    public string? CatalogId { get; init; }
+    public string? LocalCatalogVersion { get; init; }
+    public string? DesiredCatalogVersion { get; init; }
+    public string? StatusMessage { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Workflow catalog versioning now also has explicit compatibility signaling: worke
 
 Capability detection is now also moving under the coordinator-owned control plane: the coordinator can publish a versioned capability catalog that defines the ordered capability probe list and probe commands for built-in tool/SDK checks, runners persist and reconcile that catalog locally, and machine capability snapshots now execute from the reconciled catalog instead of hardcoding the top-level probe list inside `MachineCapabilityService`. The companion Settings page surfaces the runner's capability-catalog version/status alongside the existing workflow-catalog and workflow-pack control-plane state.
 
+Machine setup behavior is now moving through the same coordinator-owned path: the coordinator can publish a versioned setup catalog that defines install/update recipes per capability and platform, runners persist and reconcile that catalog locally, and `MachineSetupService` now selects catalog-authored recipes instead of hardcoding the built-in `gh`, `copilot`, `node`, `python`, and `dotnet` install/update branches directly in the runner. Both direct machine-setup API calls and workflow-pack `ManageCapability` steps flow through that reconciled setup catalog.
+
 ### Control-plane security model
 
 - Runners only accept a non-HTTPS coordinator URL by default when it targets loopback and `Coordinator:AllowInsecureHttpCoordinatorForLoopback` is enabled for local development.


### PR DESCRIPTION
## Summary
- add a coordinator-published setup catalog definition and runner reconcile flow
- drive MachineSetupService install/update behavior from reconciled setup recipes instead of hardcoded capability branches
- surface setup-catalog version and status through the machine directory and Settings UI

Closes #224