### PR TITLE
Implement runner HTTP terminal session creation endpoint

### DIFF
--- a/AgentDeck.Runner/Hubs/AgentHub.cs
+++ b/AgentDeck.Runner/Hubs/AgentHub.cs
@@ -1,10 +1,8 @@
-using AgentDeck.Runner.Configuration;
 using AgentDeck.Runner.Services;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Hubs;
 using AgentDeck.Shared.Models;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Options;
 
 namespace AgentDeck.Runner.Hubs;
 
@@ -13,21 +11,18 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
 {
     private readonly IPtyProcessManager _ptyManager;
     private readonly IAgentSessionStore _sessionStore;
-    private readonly IWorkspaceService _workspaceService;
-    private readonly RunnerOptions _options;
+    private readonly ITerminalSessionService _terminalSessions;
     private readonly ILogger<AgentHub> _logger;
 
     public AgentHub(
         IPtyProcessManager ptyManager,
         IAgentSessionStore sessionStore,
-        IWorkspaceService workspaceService,
-        IOptions<RunnerOptions> options,
+        ITerminalSessionService terminalSessions,
         ILogger<AgentHub> logger)
     {
         _ptyManager = ptyManager;
         _sessionStore = sessionStore;
-        _workspaceService = workspaceService;
-        _options = options.Value;
+        _terminalSessions = terminalSessions;
         _logger = logger;
     }
 
@@ -55,62 +50,33 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
 
     public async Task<TerminalSession> CreateSessionAsync(CreateTerminalRequest request)
     {
-        var sessionId = Guid.NewGuid().ToString("N");
-        var workingDir = ResolveWorkingDirectory(request.WorkingDirectory);
-        var command = ResolveCommand(request.Command);
-        var arguments = request.Arguments;
-        var commandWasSpecified = !string.IsNullOrWhiteSpace(request.Command);
-        var (launchCommand, launchArguments) = ResolveLaunch(command, arguments, workingDir, commandWasSpecified);
-
-        var session = new TerminalSession
-        {
-            Id = sessionId,
-            Name = request.Name,
-            WorkingDirectory = workingDir,
-            Command = command,
-            Arguments = arguments,
-            Status = TerminalStatus.Running
-        };
-
-        _sessionStore.Add(session);
-
         try
         {
-            _logger.LogInformation(
-                "Creating session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}, commandWasSpecified={CommandWasSpecified}",
-                sessionId,
+            var session = await _terminalSessions.CreateSessionAsync(request, Context.ConnectionAborted);
+            await Clients.All.SessionCreatedAsync(session);
+            return session;
+        }
+        catch (TerminalSessionStartException ex)
+        {
+            _logger.LogError(
+                ex.InnerException ?? ex,
+                "Failed to create terminal session ({Name}) via hub: requestedCommand={RequestedCommand}, workingDirectory={WorkingDirectory}",
                 request.Name,
                 request.Command ?? "<default>",
-                command,
-                FormatArguments(arguments),
-                workingDir,
-                launchCommand,
-                FormatArguments(launchArguments),
-                commandWasSpecified);
-            await _ptyManager.StartAsync(sessionId, launchCommand, launchArguments, workingDir, request.Cols, request.Rows);
+                request.WorkingDirectory);
+            await Clients.All.SessionCreatedAsync(ex.Session);
+            throw new HubException($"Failed to start terminal process: {ex.Message}");
         }
         catch (Exception ex)
         {
             _logger.LogError(
                 ex,
-                "Failed to start PTY for session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}",
-                sessionId,
+                "Failed to create terminal session ({Name}) via hub: requestedCommand={RequestedCommand}, workingDirectory={WorkingDirectory}",
                 request.Name,
                 request.Command ?? "<default>",
-                command,
-                FormatArguments(arguments),
-                workingDir,
-                launchCommand,
-                FormatArguments(launchArguments));
-            session.Status = TerminalStatus.Error;
-            _sessionStore.Update(session);
-            await Clients.All.SessionCreatedAsync(session);
-            throw new HubException($"Failed to start terminal process: {ex.Message}");
+                request.WorkingDirectory);
+            throw new HubException(ex.Message);
         }
-
-        _logger.LogInformation("Created session {SessionId} ({Name})", sessionId, request.Name);
-        await Clients.All.SessionCreatedAsync(session);
-        return session;
     }
 
     public async Task CloseSessionAsync(string sessionId)
@@ -131,27 +97,4 @@ public sealed class AgentHub : Hub<IAgentHubClient>, IAgentHub
         return Task.FromResult(_sessionStore.GetAll());
     }
 
-    private string ResolveWorkingDirectory(string workingDirectory)
-    {
-        return _workspaceService.ResolvePath(workingDirectory);
-    }
-
-    private string ResolveCommand(string? command)
-    {
-        return !string.IsNullOrWhiteSpace(command)
-            ? command
-            : ShellLaunchBuilder.ResolveDefaultShell(_options.DefaultShell);
-    }
-
-    private static (string Command, IReadOnlyList<string> Arguments) ResolveLaunch(
-        string command,
-        IReadOnlyList<string> arguments,
-        string workingDirectory,
-        bool commandWasSpecified)
-    {
-        return ShellLaunchBuilder.BuildInteractiveLaunch(command, arguments, workingDirectory, commandWasSpecified);
-    }
-
-    private static string FormatArguments(IReadOnlyList<string> arguments) =>
-        arguments.Count == 0 ? "<none>" : string.Join(" ", arguments);
 }

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddSingleton<IRunnerWorkflowPackService, RunnerWorkflowPackServ
 builder.Services.AddSingleton<IVsCodeDebugSessionService, VsCodeDebugSessionService>();
 builder.Services.AddSingleton<IVirtualDeviceCatalogService, VirtualDeviceCatalogService>();
 builder.Services.AddSingleton<IWorkspaceService, WorkspaceService>();
+builder.Services.AddSingleton<ITerminalSessionService, TerminalSessionService>();
 builder.Services.AddSingleton<IProjectWorkspaceBootstrapService, ProjectWorkspaceBootstrapService>();
 builder.Services.AddSingleton<IMachineCapabilityService, MachineCapabilityService>();
 builder.Services.AddSingleton<IMachineSetupService, MachineSetupService>();
@@ -83,7 +84,32 @@ app.MapGet("/api/audit/events", (IRunnerAuditService audit) =>
 app.MapGet("/api/sessions", (IAgentSessionStore store) =>
     Results.Ok(store.GetAll()));
 
-app.MapPost("/api/sessions", () => Results.StatusCode(501));
+app.MapPost("/api/sessions", async (CreateTerminalRequest request, ITerminalSessionService terminalSessions, Microsoft.AspNetCore.SignalR.IHubContext<AgentDeck.Runner.Hubs.AgentHub, AgentDeck.Shared.Hubs.IAgentHubClient> hubContext, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var session = await terminalSessions.CreateSessionAsync(request, cancellationToken);
+        await hubContext.Clients.All.SessionCreatedAsync(session);
+        return Results.Ok(session);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { message = ex.Message });
+    }
+    catch (TerminalSessionStartException ex)
+    {
+        await hubContext.Clients.All.SessionCreatedAsync(ex.Session);
+        return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+    }
+});
 
 app.MapDelete("/api/sessions/{id}", async (string id, IAgentSessionStore store, IPtyProcessManager ptyManager) =>
 {

--- a/AgentDeck.Runner/Services/ITerminalSessionService.cs
+++ b/AgentDeck.Runner/Services/ITerminalSessionService.cs
@@ -1,0 +1,8 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public interface ITerminalSessionService
+{
+    Task<TerminalSession> CreateSessionAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Runner/Services/TerminalSessionService.cs
+++ b/AgentDeck.Runner/Services/TerminalSessionService.cs
@@ -1,0 +1,104 @@
+using AgentDeck.Runner.Configuration;
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class TerminalSessionService : ITerminalSessionService
+{
+    private readonly IPtyProcessManager _ptyManager;
+    private readonly IAgentSessionStore _sessionStore;
+    private readonly IWorkspaceService _workspaceService;
+    private readonly RunnerOptions _options;
+    private readonly ILogger<TerminalSessionService> _logger;
+
+    public TerminalSessionService(
+        IPtyProcessManager ptyManager,
+        IAgentSessionStore sessionStore,
+        IWorkspaceService workspaceService,
+        IOptions<RunnerOptions> options,
+        ILogger<TerminalSessionService> logger)
+    {
+        _ptyManager = ptyManager;
+        _sessionStore = sessionStore;
+        _workspaceService = workspaceService;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<TerminalSession> CreateSessionAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default)
+    {
+        var sessionId = Guid.NewGuid().ToString("N");
+        var workingDir = ResolveWorkingDirectory(request.WorkingDirectory);
+        var command = ResolveCommand(request.Command);
+        var arguments = request.Arguments;
+        var commandWasSpecified = !string.IsNullOrWhiteSpace(request.Command);
+        var (launchCommand, launchArguments) = ResolveLaunch(command, arguments, workingDir, commandWasSpecified);
+
+        var session = new TerminalSession
+        {
+            Id = sessionId,
+            Name = request.Name,
+            WorkingDirectory = workingDir,
+            Command = command,
+            Arguments = arguments,
+            Status = TerminalStatus.Running
+        };
+
+        _sessionStore.Add(session);
+
+        try
+        {
+            _logger.LogInformation(
+                "Creating session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}, commandWasSpecified={CommandWasSpecified}",
+                sessionId,
+                request.Name,
+                request.Command ?? "<default>",
+                command,
+                FormatArguments(arguments),
+                workingDir,
+                launchCommand,
+                FormatArguments(launchArguments),
+                commandWasSpecified);
+            await _ptyManager.StartAsync(sessionId, launchCommand, launchArguments, workingDir, request.Cols, request.Rows, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to start PTY for session {SessionId} ({Name}): requestedCommand={RequestedCommand}, resolvedCommand={ResolvedCommand}, arguments={Arguments}, workingDirectory={WorkingDirectory}, launchCommand={LaunchCommand}, launchArguments={LaunchArguments}",
+                sessionId,
+                request.Name,
+                request.Command ?? "<default>",
+                command,
+                FormatArguments(arguments),
+                workingDir,
+                launchCommand,
+                FormatArguments(launchArguments));
+            session.Status = TerminalStatus.Error;
+            _sessionStore.Update(session);
+            throw new TerminalSessionStartException(session, ex);
+        }
+
+        _logger.LogInformation("Created session {SessionId} ({Name})", sessionId, request.Name);
+        return session;
+    }
+
+    private string ResolveWorkingDirectory(string workingDirectory) => _workspaceService.ResolvePath(workingDirectory);
+
+    private string ResolveCommand(string? command) =>
+        !string.IsNullOrWhiteSpace(command)
+            ? command
+            : ShellLaunchBuilder.ResolveDefaultShell(_options.DefaultShell);
+
+    private static (string Command, IReadOnlyList<string> Arguments) ResolveLaunch(
+        string command,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        bool commandWasSpecified) =>
+        ShellLaunchBuilder.BuildInteractiveLaunch(command, arguments, workingDirectory, commandWasSpecified);
+
+    private static string FormatArguments(IReadOnlyList<string> arguments) =>
+        arguments.Count == 0 ? "<none>" : string.Join(" ", arguments);
+}

--- a/AgentDeck.Runner/Services/TerminalSessionStartException.cs
+++ b/AgentDeck.Runner/Services/TerminalSessionStartException.cs
@@ -1,0 +1,14 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class TerminalSessionStartException : Exception
+{
+    public TerminalSessionStartException(TerminalSession session, Exception innerException)
+        : base(innerException.Message, innerException)
+    {
+        Session = session;
+    }
+
+    public TerminalSession Session { get; }
+}


### PR DESCRIPTION
## Summary\n- replace the runner POST /api/sessions 501 stub with a real terminal creation endpoint\n- extract terminal session creation into a shared runner service used by both HTTP and SignalR\n- preserve error-session broadcasts on PTY startup failures and return explicit HTTP failures\n\n## Validation\n- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj\n- live smoke test against a temporary runner instance on port 5077 using POST /api/sessions and GET /api/sessions