### PR TITLE
Keep runtime viewers open after successful GUI launches

### DIFF
--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -403,12 +403,14 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
         if (phaseName == "Launch")
         {
-            await CloseJobViewerIfPresentAsync(jobId, "Viewer session closed because the launch completed.");
+            var launchCompletedMessage = string.IsNullOrWhiteSpace(job.ViewerSessionId)
+                ? "Launch completed successfully."
+                : "Launch completed successfully. Runtime viewer remains available.";
             _jobs.UpdateStatus(jobId, new UpdateOrchestrationJobStatusRequest
             {
                 Status = OrchestrationJobStatus.Completed,
                 ExitCode = exitCode,
-                Message = "Launch completed successfully."
+                Message = launchCompletedMessage
             });
             return true;
         }


### PR DESCRIPTION
## Summary\n- stop closing linked runtime viewer sessions when a run launch exits successfully\n- keep the viewer entry point available after launch completion so GUI app flows remain usable\n- preserve the existing failure and cancellation cleanup behavior\n\n## Validation\n- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj