### PR TITLE
Harden project editor save guard against duplicate clicks

### DIFF
--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -373,10 +373,10 @@
             return;
         }
 
+        _saving = true;
         try
         {
             var project = BuildProjectDefinition();
-            _saving = true;
             var saved = await CoordinatorClient.UpsertProjectAsync(_coordinatorUrl, project);
             Toasts.Show($"Saved {saved.Name}.", ToastKind.Success);
             Nav.NavigateTo($"/projects/{Uri.EscapeDataString(saved.Id)}");


### PR DESCRIPTION
## Summary\n- move the project editor saving guard ahead of payload construction\n- prevent rapid duplicate save clicks from queuing multiple coordinator upserts\n\n## Validation\n- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj