### PR TITLE
Break runner coordinator DI cycle

### DIFF
--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -49,10 +49,12 @@ builder.Services.AddSignalR(opts =>
 
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<IAgentSessionStore, AgentSessionStore>();
+builder.Services.AddSingleton<CoordinatorRunnerConnectionState>();
 builder.Services.AddSingleton<IOrchestrationJobService, OrchestrationJobService>();
 builder.Services.AddSingleton<IOrchestrationExecutionService, OrchestrationExecutionService>();
 builder.Services.AddSingleton<IRemoteViewerSessionService, RemoteViewerSessionService>();
 builder.Services.AddSingleton<IRunnerConnectionUrlResolver, RunnerConnectionUrlResolver>();
+builder.Services.AddSingleton<ICoordinatorRunnerPublisher, CoordinatorRunnerPublisher>();
 builder.Services.AddSingleton<CoordinatorRunnerConnectionService>();
 builder.Services.AddSingleton<IManagedViewerRelayService, ManagedViewerRelayService>();
 builder.Services.AddSingleton<IDesktopViewerBootstrapService, DesktopViewerBootstrapService>();

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -102,20 +102,46 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
     public async ValueTask DisposeAsync()
     {
-        if (_connectionState.Connection is not null)
+        if (_connectionState.IsDisposed)
         {
-            await _connectionState.Connection.DisposeAsync();
-            _connectionState.Connection = null;
+            return;
         }
 
-        _connectionState.Gate.Dispose();
+        await _connectionState.Gate.WaitAsync();
+        try
+        {
+            _connectionState.IsDisposed = true;
+            if (_connectionState.Connection is not null)
+            {
+                await _connectionState.Connection.DisposeAsync();
+                _connectionState.Connection = null;
+            }
+        }
+        finally
+        {
+            _connectionState.Gate.Release();
+            _connectionState.Gate.Dispose();
+        }
     }
 
     private async Task EnsureConnectedAsync(string coordinatorUrl, CancellationToken cancellationToken)
     {
-        await _connectionState.Gate.WaitAsync(cancellationToken);
         try
         {
+            await _connectionState.Gate.WaitAsync(cancellationToken);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_connectionState.IsDisposed)
+            {
+                return;
+            }
+
             if (_connectionState.Connection is not null &&
                 _connectionState.Connection.State is HubConnectionState.Connected or HubConnectionState.Connecting or HubConnectionState.Reconnecting)
             {
@@ -180,7 +206,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         connection.On<OpenProjectOnRunnerRequest, string, Task<OpenProjectOnRunnerResult?>>(nameof(IRunnerControlClient.OpenProjectAsync),
             (request, actorId) => OpenProjectAsync(request, actorId));
 
-        connection.On<Task<MachineCapabilitiesSnapshot?>>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
+        connection.On<Task<MachineCapabilitiesSnapshot>>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
             () => _capabilities.GetSnapshotAsync());
 
         connection.On<string, MachineCapabilityInstallRequest, string, Task<MachineCapabilityInstallResult?>>(nameof(IRunnerControlClient.InstallMachineCapabilityAsync),

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -29,8 +29,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
     private readonly IRunnerTrustPolicy _trustPolicy;
     private readonly IRunnerAuditService _audit;
     private readonly ILogger<CoordinatorRunnerConnectionService> _logger;
-    private readonly SemaphoreSlim _connectionGate = new(1, 1);
-    private HubConnection? _connection;
+    private readonly CoordinatorRunnerConnectionState _connectionState;
 
     public CoordinatorRunnerConnectionService(
         IOptions<WorkerCoordinatorOptions> options,
@@ -50,6 +49,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         IVirtualDeviceCatalogService devices,
         IRunnerTrustPolicy trustPolicy,
         IRunnerAuditService audit,
+        CoordinatorRunnerConnectionState connectionState,
         ILogger<CoordinatorRunnerConnectionService> logger)
     {
         _options = options.Value;
@@ -69,6 +69,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         _devices = devices;
         _trustPolicy = trustPolicy;
         _audit = audit;
+        _connectionState = connectionState;
         _logger = logger;
     }
 
@@ -99,87 +100,32 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         }
     }
 
-    public async Task PublishTerminalOutputAsync(TerminalOutput output, CancellationToken cancellationToken = default)
-    {
-        var connection = _connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
-        {
-            return;
-        }
-
-        await connection.SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalOutputAsync), output, cancellationToken);
-    }
-
-    public async Task PublishTerminalSessionUpdatedAsync(TerminalSession session, CancellationToken cancellationToken = default)
-    {
-        var connection = _connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
-        {
-            return;
-        }
-
-        await connection.SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalSessionUpdatedAsync), session, cancellationToken);
-    }
-
-    public async Task PublishTerminalSessionClosedAsync(string sessionId, CancellationToken cancellationToken = default)
-    {
-        var connection = _connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
-        {
-            return;
-        }
-
-        await connection.SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalSessionClosedAsync), sessionId, cancellationToken);
-    }
-
-    public async Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session, CancellationToken cancellationToken = default)
-    {
-        var connection = _connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
-        {
-            return;
-        }
-
-        await connection.SendAsync(nameof(ICoordinatorRunnerHub.PublishViewerSessionUpdatedAsync), session, cancellationToken);
-    }
-
-    public async Task PublishViewerFrameAsync(RemoteViewerRelayFrame frame, CancellationToken cancellationToken = default)
-    {
-        var connection = _connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
-        {
-            return;
-        }
-
-        await connection.SendAsync(nameof(ICoordinatorRunnerHub.PublishViewerFrameAsync), frame, cancellationToken);
-    }
-
     public async ValueTask DisposeAsync()
     {
-        if (_connection is not null)
+        if (_connectionState.Connection is not null)
         {
-            await _connection.DisposeAsync();
-            _connection = null;
+            await _connectionState.Connection.DisposeAsync();
+            _connectionState.Connection = null;
         }
 
-        _connectionGate.Dispose();
+        _connectionState.Gate.Dispose();
     }
 
     private async Task EnsureConnectedAsync(string coordinatorUrl, CancellationToken cancellationToken)
     {
-        await _connectionGate.WaitAsync(cancellationToken);
+        await _connectionState.Gate.WaitAsync(cancellationToken);
         try
         {
-            if (_connection is not null &&
-                _connection.State is HubConnectionState.Connected or HubConnectionState.Connecting or HubConnectionState.Reconnecting)
+            if (_connectionState.Connection is not null &&
+                _connectionState.Connection.State is HubConnectionState.Connected or HubConnectionState.Connecting or HubConnectionState.Reconnecting)
             {
                 return;
             }
 
-            if (_connection is not null)
+            if (_connectionState.Connection is not null)
             {
-                await _connection.DisposeAsync();
-                _connection = null;
+                await _connectionState.Connection.DisposeAsync();
+                _connectionState.Connection = null;
             }
 
             var hubUrl = $"{coordinatorUrl}/hubs/runners?{AgentDeckQueryNames.Machine}={Uri.EscapeDataString(_options.MachineId)}";
@@ -193,12 +139,12 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
             RegisterHandlers(connection);
             await connection.StartAsync(cancellationToken);
-            _connection = connection;
+            _connectionState.Connection = connection;
             _logger.LogInformation("Connected runner control channel to coordinator at {CoordinatorUrl} for machine {MachineId}", coordinatorUrl, _options.MachineId);
         }
         finally
         {
-            _connectionGate.Release();
+            _connectionState.Gate.Release();
         }
     }
 

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionState.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionState.cs
@@ -6,4 +6,5 @@ public sealed class CoordinatorRunnerConnectionState
 {
     public SemaphoreSlim Gate { get; } = new(1, 1);
     public HubConnection? Connection { get; set; }
+    public bool IsDisposed { get; set; }
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionState.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionState.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class CoordinatorRunnerConnectionState
+{
+    public SemaphoreSlim Gate { get; } = new(1, 1);
+    public HubConnection? Connection { get; set; }
+}

--- a/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
@@ -30,12 +30,41 @@ public sealed class CoordinatorRunnerPublisher : ICoordinatorRunnerPublisher
 
     private async Task SendAsync(string methodName, object?[] args, CancellationToken cancellationToken)
     {
-        var connection = _state.Connection;
-        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
+        if (_state.IsDisposed)
         {
             return;
         }
 
-        await connection.SendCoreAsync(methodName, args, cancellationToken);
+        var gateHeld = false;
+        try
+        {
+            await _state.Gate.WaitAsync(cancellationToken);
+            gateHeld = true;
+            if (_state.IsDisposed)
+            {
+                return;
+            }
+
+            var connection = _state.Connection;
+            if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
+            {
+                return;
+            }
+
+            await connection.SendCoreAsync(methodName, args, cancellationToken);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (InvalidOperationException) when (_state.Connection is null || !_state.Connection.State.Equals(HubConnectionState.Connected))
+        {
+        }
+        finally
+        {
+            if (gateHeld)
+            {
+                _state.Gate.Release();
+            }
+        }
     }
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
@@ -1,0 +1,41 @@
+using AgentDeck.Shared.Hubs;
+using AgentDeck.Shared.Models;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class CoordinatorRunnerPublisher : ICoordinatorRunnerPublisher
+{
+    private readonly CoordinatorRunnerConnectionState _state;
+
+    public CoordinatorRunnerPublisher(CoordinatorRunnerConnectionState state)
+    {
+        _state = state;
+    }
+
+    public Task PublishTerminalOutputAsync(TerminalOutput output, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalOutputAsync), [output], cancellationToken);
+
+    public Task PublishTerminalSessionUpdatedAsync(TerminalSession session, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalSessionUpdatedAsync), [session], cancellationToken);
+
+    public Task PublishTerminalSessionClosedAsync(string sessionId, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalSessionClosedAsync), [sessionId], cancellationToken);
+
+    public Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishViewerSessionUpdatedAsync), [session], cancellationToken);
+
+    public Task PublishViewerFrameAsync(RemoteViewerRelayFrame frame, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishViewerFrameAsync), [frame], cancellationToken);
+
+    private async Task SendAsync(string methodName, object?[] args, CancellationToken cancellationToken)
+    {
+        var connection = _state.Connection;
+        if (connection is null || !connection.State.Equals(HubConnectionState.Connected))
+        {
+            return;
+        }
+
+        await connection.SendCoreAsync(methodName, args, cancellationToken);
+    }
+}

--- a/AgentDeck.Runner/Services/HubOutputForwarder.cs
+++ b/AgentDeck.Runner/Services/HubOutputForwarder.cs
@@ -14,7 +14,7 @@ public sealed class HubOutputForwarder : IHostedService
     private readonly IPtyProcessManager _ptyManager;
     private readonly IAgentSessionStore _sessionStore;
     private readonly IHubContext<AgentHub, IAgentHubClient> _hubContext;
-    private readonly CoordinatorRunnerConnectionService _coordinatorConnection;
+    private readonly ICoordinatorRunnerPublisher _coordinatorPublisher;
     private readonly ILogger<HubOutputForwarder> _logger;
     private readonly ConcurrentDictionary<string, string> _recentOutputBySession = new();
 
@@ -22,13 +22,13 @@ public sealed class HubOutputForwarder : IHostedService
         IPtyProcessManager ptyManager,
         IAgentSessionStore sessionStore,
         IHubContext<AgentHub, IAgentHubClient> hubContext,
-        CoordinatorRunnerConnectionService coordinatorConnection,
+        ICoordinatorRunnerPublisher coordinatorPublisher,
         ILogger<HubOutputForwarder> logger)
     {
         _ptyManager = ptyManager;
         _sessionStore = sessionStore;
         _hubContext = hubContext;
-        _coordinatorConnection = coordinatorConnection;
+        _coordinatorPublisher = coordinatorPublisher;
         _logger = logger;
     }
 
@@ -56,7 +56,7 @@ public sealed class HubOutputForwarder : IHostedService
 
         var output = new TerminalOutput { SessionId = e.SessionId, Data = e.Data };
         _ = _hubContext.Clients.Group(e.SessionId).ReceiveOutputAsync(output);
-        _ = _coordinatorConnection.PublishTerminalOutputAsync(output);
+        _ = _coordinatorPublisher.PublishTerminalOutputAsync(output);
     }
 
     private void OnProcessExited(object? sender, (string SessionId, int ExitCode) e)
@@ -96,7 +96,7 @@ public sealed class HubOutputForwarder : IHostedService
             session.ExitCode = e.ExitCode;
             _sessionStore.Update(session);
             _ = _hubContext.Clients.All.SessionUpdatedAsync(session);
-            _ = _coordinatorConnection.PublishTerminalSessionUpdatedAsync(session);
+            _ = _coordinatorPublisher.PublishTerminalSessionUpdatedAsync(session);
         }
     }
 

--- a/AgentDeck.Runner/Services/ICoordinatorRunnerPublisher.cs
+++ b/AgentDeck.Runner/Services/ICoordinatorRunnerPublisher.cs
@@ -1,0 +1,12 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Runner.Services;
+
+public interface ICoordinatorRunnerPublisher
+{
+    Task PublishTerminalOutputAsync(TerminalOutput output, CancellationToken cancellationToken = default);
+    Task PublishTerminalSessionUpdatedAsync(TerminalSession session, CancellationToken cancellationToken = default);
+    Task PublishTerminalSessionClosedAsync(string sessionId, CancellationToken cancellationToken = default);
+    Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session, CancellationToken cancellationToken = default);
+    Task PublishViewerFrameAsync(RemoteViewerRelayFrame frame, CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
@@ -29,7 +29,7 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     private readonly ConcurrentDictionary<string, ActiveRelaySession> _activeSessions = new(StringComparer.Ordinal);
     private readonly IRemoteViewerSessionService _viewers;
     private readonly IHubContext<ManagedViewerRelayHub> _hubContext;
-    private readonly CoordinatorRunnerConnectionService _coordinatorConnection;
+    private readonly ICoordinatorRunnerPublisher _coordinatorPublisher;
     private readonly ManagedDesktopViewerTransportOptions _options;
     private readonly ILogger<ManagedViewerRelayService> _logger;
     private readonly IHostCapturePlatform _capturePlatform;
@@ -38,13 +38,13 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     public ManagedViewerRelayService(
         IRemoteViewerSessionService viewers,
         IHubContext<ManagedViewerRelayHub> hubContext,
-        CoordinatorRunnerConnectionService coordinatorConnection,
+        ICoordinatorRunnerPublisher coordinatorPublisher,
         IOptions<DesktopViewerTransportOptions> transportOptions,
         ILogger<ManagedViewerRelayService> logger)
     {
         _viewers = viewers;
         _hubContext = hubContext;
-        _coordinatorConnection = coordinatorConnection;
+        _coordinatorPublisher = coordinatorPublisher;
         _options = transportOptions.Value.Managed;
         _logger = logger;
         _capturePlatform = HostCapturePlatformFactory.Create();
@@ -380,14 +380,14 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     {
         await _hubContext.Clients.Group(ManagedViewerRelayHub.GetViewerGroupName(session.Id))
             .SendAsync("SessionUpdated", session, cancellationToken);
-        await _coordinatorConnection.PublishViewerSessionUpdatedAsync(session, cancellationToken);
+        await _coordinatorPublisher.PublishViewerSessionUpdatedAsync(session, cancellationToken);
     }
 
     private async Task PublishFrameAsync(string sessionId, RelayFrame frame, CancellationToken cancellationToken)
     {
         await _hubContext.Clients.Group(ManagedViewerRelayHub.GetViewerGroupName(sessionId))
             .SendAsync("FramePublished", frame, cancellationToken);
-        await _coordinatorConnection.PublishViewerFrameAsync(
+        await _coordinatorPublisher.PublishViewerFrameAsync(
             new RemoteViewerRelayFrame(
                 sessionId,
                 frame.SequenceId,


### PR DESCRIPTION
## Summary\n- split runner outbound coordinator publishing from the coordinator RPC handler service\n- move live hub connection state into a lightweight shared state object\n- update relay and PTY forwarding to publish through the standalone runner publisher so the runner host starts cleanly again\n\n## Testing\n- dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj -c Release\n- dotnet build AgentDeck.slnx -c Release\n- dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj -c Release\n\nCloses #242