### PR TITLE
Keep runtime viewers reconnectable through coordinator

### DIFF
--- a/AgentDeck.Coordinator/Hubs/CoordinatorRunnerHub.cs
+++ b/AgentDeck.Coordinator/Hubs/CoordinatorRunnerHub.cs
@@ -42,6 +42,9 @@ public sealed class CoordinatorRunnerHub : Hub<IRunnerControlClient>, ICoordinat
     public Task PublishTerminalSessionClosedAsync(string sessionId) =>
         _runners.PublishTerminalSessionClosedAsync(RequireMachineId(), sessionId, Context.ConnectionAborted);
 
+    public Task PublishOrchestrationJobUpdatedAsync(OrchestrationJob job) =>
+        _runners.PublishOrchestrationJobUpdatedAsync(RequireMachineId(), job, Context.ConnectionAborted);
+
     public Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session) =>
         _runners.PublishViewerSessionUpdatedAsync(RequireMachineId(), session, Context.ConnectionAborted);
 

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -20,6 +20,8 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
 
     private readonly ConcurrentDictionary<string, RunnerEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> _sessionMachineMap = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> _jobMachineMap = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, OrchestrationJob> _orchestrationJobs = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> _viewerMachineMap = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> _connectionMachineMap = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, RemoteViewerSession> _viewerSessions = new(StringComparer.OrdinalIgnoreCase);
@@ -109,6 +111,14 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
         _companions.RemoveSessionFromAll(sessionId);
         _logger.LogInformation("Runner {MachineId} published terminal session close for {SessionId}", machineId, sessionId);
         await _agentHubContext.Clients.All.SessionClosedAsync(sessionId.Trim());
+    }
+
+    public Task PublishOrchestrationJobUpdatedAsync(string machineId, OrchestrationJob job, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        CacheOrchestrationJob(machineId, job);
+        _logger.LogDebug("Runner {MachineId} published orchestration job update for {JobId}", machineId, job.Id);
+        return Task.CompletedTask;
     }
 
     public Task PublishViewerSessionUpdatedAsync(string machineId, RemoteViewerSession session, CancellationToken cancellationToken = default)
@@ -233,43 +243,62 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
 
     public async Task<IReadOnlyList<OrchestrationJob>> GetOrchestrationJobsAsync(string machineId, CancellationToken cancellationToken = default)
     {
-        var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        return await InvokeRunnerAsync(entry, "list orchestration jobs", client => client.GetOrchestrationJobsAsync(), retryOnReconnect: true, cancellationToken);
+        var entry = await TryEnsureEntryAsync(machineId, cancellationToken);
+        if (entry is null)
+        {
+            return GetCachedOrchestrationJobs(machineId);
+        }
+
+        var jobs = await InvokeRunnerAsync(entry, "list orchestration jobs", client => client.GetOrchestrationJobsAsync(), retryOnReconnect: true, cancellationToken);
+        ReplaceOrchestrationJobs(entry.MachineId, jobs);
+        return jobs;
     }
 
     public async Task<OrchestrationJob?> QueueOrchestrationJobAsync(string machineId, CreateOrchestrationJobRequest request, string actorId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        return await InvokeRunnerAsync(entry, "queue orchestration job", client => client.QueueOrchestrationJobAsync(request, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        var job = await InvokeRunnerAsync(entry, "queue orchestration job", client => client.QueueOrchestrationJobAsync(request, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        if (job is not null)
+        {
+            CacheOrchestrationJob(entry.MachineId, job);
+        }
+
+        return job;
     }
 
     public async Task<OrchestrationJob?> CancelOrchestrationJobAsync(string machineId, string jobId, string actorId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        return await InvokeRunnerAsync(entry, "cancel orchestration job", client => client.CancelOrchestrationJobAsync(jobId, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        var job = await InvokeRunnerAsync(entry, "cancel orchestration job", client => client.CancelOrchestrationJobAsync(jobId, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        if (job is not null)
+        {
+            CacheOrchestrationJob(entry.MachineId, job);
+        }
+
+        return job;
     }
 
     public async Task<IReadOnlyList<RemoteViewerSession>> GetViewerSessionsAsync(string machineId, CancellationToken cancellationToken = default)
     {
-        var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        var sessions = await InvokeRunnerAsync(entry, "list viewer sessions", client => client.GetViewerSessionsAsync(), retryOnReconnect: true, cancellationToken);
-        var annotated = sessions.Select(session => AnnotateViewerSession(entry.MachineId, session)).ToArray();
-        foreach (var session in annotated)
+        var entry = await TryEnsureEntryAsync(machineId, cancellationToken);
+        if (entry is null)
         {
-            _viewerMachineMap[session.Id] = entry.MachineId;
-            _viewerSessions[session.Id] = session;
+            return GetCachedViewerSessions(machineId);
         }
 
+        var sessions = await InvokeRunnerAsync(entry, "list viewer sessions", client => client.GetViewerSessionsAsync(), retryOnReconnect: true, cancellationToken);
+        var annotated = sessions.Select(session => AnnotateViewerSession(entry.MachineId, session)).ToArray();
+        ReplaceViewerSessions(entry.MachineId, annotated);
         return annotated;
     }
 
     public async Task<RemoteViewerSession> CreateViewerSessionAsync(string machineId, CreateRemoteViewerSessionRequest request, string actorId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        var session = await InvokeRunnerAsync(entry, "create viewer session", client => client.CreateViewerSessionAsync(request, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        var brokeredRequest = EnsureManagedViewerRequest(request);
+        var session = await InvokeRunnerAsync(entry, "create viewer session", client => client.CreateViewerSessionAsync(brokeredRequest, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
         var annotated = AnnotateViewerSession(entry.MachineId, session);
-        _viewerMachineMap[annotated.Id] = entry.MachineId;
-        _viewerSessions[annotated.Id] = annotated;
+        CacheViewerSession(entry.MachineId, annotated);
         return annotated;
     }
 
@@ -324,7 +353,7 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
         return await InvokeRunnerAsync(entry, "resolve virtual device", client => client.ResolveVirtualDeviceAsync(selection), retryOnReconnect: true, cancellationToken);
     }
 
-    private async Task<RunnerEntry> EnsureEntryAsync(string machineId, CancellationToken cancellationToken)
+    private async Task<RunnerEntry?> TryEnsureEntryAsync(string machineId, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(machineId);
 
@@ -341,17 +370,25 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
         try
         {
             entry.Machine = machine;
-            if (!string.IsNullOrWhiteSpace(entry.ConnectionId))
-            {
-                return entry;
-            }
-
-            throw new InvalidOperationException($"Runner machine '{machine.MachineName}' does not currently have an active coordinator control connection.");
+            return string.IsNullOrWhiteSpace(entry.ConnectionId) ? null : entry;
         }
         finally
         {
             entry.Gate.Release();
         }
+    }
+
+    private async Task<RunnerEntry> EnsureEntryAsync(string machineId, CancellationToken cancellationToken)
+    {
+        var entry = await TryEnsureEntryAsync(machineId, cancellationToken);
+        if (entry is not null)
+        {
+            return entry;
+        }
+
+        var machine = await _registry.GetMachineAsync(machineId, cancellationToken)
+            ?? throw new InvalidOperationException($"Coordinator does not know runner machine '{machineId}'.");
+        throw new InvalidOperationException($"Runner machine '{machine.MachineName}' does not currently have an active coordinator control connection.");
     }
 
     private IRunnerControlClient GetRunnerClient(RunnerEntry entry) =>
@@ -386,6 +423,110 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
             ConnectionUri = null
         };
     }
+
+    private static CreateRemoteViewerSessionRequest EnsureManagedViewerRequest(CreateRemoteViewerSessionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new CreateRemoteViewerSessionRequest
+        {
+            MachineId = request.MachineId,
+            MachineName = request.MachineName,
+            JobId = request.JobId,
+            Provider = request.Provider == RemoteViewerProviderKind.Auto &&
+                       request.Target.Kind is not RemoteViewerTargetKind.Desktop
+                ? RemoteViewerProviderKind.Managed
+                : request.Provider,
+            Target = new RemoteViewerTarget
+            {
+                Kind = request.Target.Kind,
+                DisplayName = request.Target.DisplayName,
+                JobId = request.Target.JobId,
+                SessionId = request.Target.SessionId,
+                WindowTitle = request.Target.WindowTitle,
+                VirtualDeviceId = request.Target.VirtualDeviceId,
+                VirtualDeviceProfileId = request.Target.VirtualDeviceProfileId
+            }
+        };
+    }
+
+    private void ReplaceOrchestrationJobs(string machineId, IReadOnlyList<OrchestrationJob> jobs)
+    {
+        var normalizedMachineId = machineId.Trim();
+        var incoming = jobs.Select(job => job.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var existing in _jobMachineMap.Where(pair => string.Equals(pair.Value, normalizedMachineId, StringComparison.OrdinalIgnoreCase)).ToArray())
+        {
+            if (!incoming.Contains(existing.Key))
+            {
+                _jobMachineMap.TryRemove(existing.Key, out _);
+                _orchestrationJobs.TryRemove(existing.Key, out _);
+            }
+        }
+
+        foreach (var job in jobs)
+        {
+            CacheOrchestrationJob(normalizedMachineId, job);
+        }
+    }
+
+    private void CacheOrchestrationJob(string machineId, OrchestrationJob job)
+    {
+        var normalizedMachineId = machineId.Trim();
+        if (_orchestrationJobs.TryGetValue(job.Id, out var existingJob) &&
+            existingJob.UpdatedAt > job.UpdatedAt)
+        {
+            return;
+        }
+
+        _jobMachineMap[job.Id] = normalizedMachineId;
+        _orchestrationJobs[job.Id] = CloneOrchestrationJob(job);
+    }
+
+    private IReadOnlyList<OrchestrationJob> GetCachedOrchestrationJobs(string machineId) =>
+        _jobMachineMap
+            .Where(pair => string.Equals(pair.Value, machineId.Trim(), StringComparison.OrdinalIgnoreCase))
+            .Select(pair => _orchestrationJobs.TryGetValue(pair.Key, out var job) ? CloneOrchestrationJob(job) : null)
+            .Where(job => job is not null)
+            .Cast<OrchestrationJob>()
+            .OrderByDescending(job => job.UpdatedAt)
+            .ThenByDescending(job => job.CreatedAt)
+            .ToArray();
+
+    private void ReplaceViewerSessions(string machineId, IReadOnlyList<RemoteViewerSession> sessions)
+    {
+        var normalizedMachineId = machineId.Trim();
+        var incoming = sessions.Select(session => session.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var existing in _viewerMachineMap.Where(pair => string.Equals(pair.Value, normalizedMachineId, StringComparison.OrdinalIgnoreCase)).ToArray())
+        {
+            if (!incoming.Contains(existing.Key))
+            {
+                _viewerMachineMap.TryRemove(existing.Key, out _);
+                _viewerSessions.TryRemove(existing.Key, out _);
+                _viewerFrames.TryRemove(existing.Key, out _);
+            }
+        }
+
+        foreach (var session in sessions)
+        {
+            CacheViewerSession(normalizedMachineId, session);
+        }
+    }
+
+    private void CacheViewerSession(string machineId, RemoteViewerSession session)
+    {
+        var normalizedMachineId = machineId.Trim();
+        _viewerMachineMap[session.Id] = normalizedMachineId;
+        _viewerSessions[session.Id] = new RemoteViewerSession(session);
+    }
+
+    private IReadOnlyList<RemoteViewerSession> GetCachedViewerSessions(string machineId) =>
+        _viewerMachineMap
+            .Where(pair => string.Equals(pair.Value, machineId.Trim(), StringComparison.OrdinalIgnoreCase))
+            .Select(pair => _viewerSessions.TryGetValue(pair.Key, out var session) ? new RemoteViewerSession(session) : null)
+            .Where(session => session is not null)
+            .Cast<RemoteViewerSession>()
+            .OrderByDescending(session => session.UpdatedAt)
+            .ThenByDescending(session => session.CreatedAt)
+            .ToArray();
 
     private async Task<RunnerEntry> ResolveEntryBySessionAsync(string sessionId, CancellationToken cancellationToken)
     {
@@ -555,4 +696,65 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
 
     private static string NormalizeActorId(string actorId) =>
         string.IsNullOrWhiteSpace(actorId) ? "coordinator" : actorId.Trim();
+
+    private static OrchestrationJob CloneOrchestrationJob(OrchestrationJob job) =>
+        new()
+        {
+            Id = job.Id,
+            ProjectId = job.ProjectId,
+            ProjectName = job.ProjectName,
+            LaunchProfileId = job.LaunchProfileId,
+            LaunchProfileName = job.LaunchProfileName,
+            Platform = job.Platform,
+            Mode = job.Mode,
+            LaunchDriver = job.LaunchDriver,
+            TargetMachineRole = job.TargetMachineRole,
+            TargetMachineId = job.TargetMachineId,
+            TargetMachineName = job.TargetMachineName,
+            WorkingDirectory = job.WorkingDirectory,
+            BuildCommand = job.BuildCommand,
+            LaunchCommand = job.LaunchCommand,
+            BootstrapCommand = job.BootstrapCommand,
+            DebugConfigurationName = job.DebugConfigurationName,
+            DeviceSelection = job.DeviceSelection is null
+                ? null
+                : new VirtualDeviceLaunchSelection
+                {
+                    CatalogKind = job.DeviceSelection.CatalogKind,
+                    TargetPlatform = job.DeviceSelection.TargetPlatform,
+                    DeviceId = job.DeviceSelection.DeviceId,
+                    ProfileId = job.DeviceSelection.ProfileId,
+                    DisplayName = job.DeviceSelection.DisplayName,
+                    StartBeforeLaunch = job.DeviceSelection.StartBeforeLaunch,
+                    ReuseRunningDevice = job.DeviceSelection.ReuseRunningDevice
+                },
+            Status = job.Status,
+            SessionId = job.SessionId,
+            ViewerSessionId = job.ViewerSessionId,
+            ExitCode = job.ExitCode,
+            StatusMessage = job.StatusMessage,
+            CreatedAt = job.CreatedAt,
+            UpdatedAt = job.UpdatedAt,
+            Steps =
+            [
+                ..job.Steps.Select(step => new OrchestrationJobStep
+                {
+                    Name = step.Name,
+                    Status = step.Status,
+                    Message = step.Message,
+                    StartedAt = step.StartedAt,
+                    CompletedAt = step.CompletedAt
+                })
+            ],
+            Logs =
+            [
+                ..job.Logs.Select(log => new OrchestrationJobLogEntry
+                {
+                    Timestamp = log.Timestamp,
+                    Level = log.Level,
+                    Message = log.Message,
+                    MachineId = log.MachineId
+                })
+            ]
+        };
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -28,6 +28,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
     private readonly IVirtualDeviceCatalogService _devices;
     private readonly IRunnerTrustPolicy _trustPolicy;
     private readonly IRunnerAuditService _audit;
+    private readonly ICoordinatorRunnerPublisher _publisher;
     private readonly ILogger<CoordinatorRunnerConnectionService> _logger;
     private readonly CoordinatorRunnerConnectionState _connectionState;
 
@@ -49,6 +50,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         IVirtualDeviceCatalogService devices,
         IRunnerTrustPolicy trustPolicy,
         IRunnerAuditService audit,
+        ICoordinatorRunnerPublisher publisher,
         CoordinatorRunnerConnectionState connectionState,
         ILogger<CoordinatorRunnerConnectionService> logger)
     {
@@ -69,8 +71,10 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         _devices = devices;
         _trustPolicy = trustPolicy;
         _audit = audit;
+        _publisher = publisher;
         _connectionState = connectionState;
         _logger = logger;
+        _jobs.Changed += OnJobChanged;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -107,6 +111,8 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             return;
         }
 
+        _jobs.Changed -= OnJobChanged;
+
         await _connectionState.Gate.WaitAsync();
         try
         {
@@ -126,6 +132,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
     private async Task EnsureConnectedAsync(string coordinatorUrl, CancellationToken cancellationToken)
     {
+        var shouldRepublishState = false;
         try
         {
             await _connectionState.Gate.WaitAsync(cancellationToken);
@@ -166,16 +173,28 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             RegisterHandlers(connection);
             await connection.StartAsync(cancellationToken);
             _connectionState.Connection = connection;
-            _logger.LogInformation("Connected runner control channel to coordinator at {CoordinatorUrl} for machine {MachineId}", coordinatorUrl, _options.MachineId);
+            shouldRepublishState = true;
         }
         finally
         {
             _connectionState.Gate.Release();
         }
+
+        if (shouldRepublishState)
+        {
+            await RepublishCoordinatorStateAsync(cancellationToken);
+            _logger.LogInformation("Connected runner control channel to coordinator at {CoordinatorUrl} for machine {MachineId}", coordinatorUrl, _options.MachineId);
+        }
     }
 
     private void RegisterHandlers(HubConnection connection)
     {
+        connection.Reconnected += async _ =>
+        {
+            await RepublishCoordinatorStateAsync(CancellationToken.None);
+            _logger.LogInformation("Replayed runner state after reconnecting coordinator control channel for machine {MachineId}", _options.MachineId);
+        };
+
         connection.On<CreateTerminalRequest, Task<TerminalSession>>(nameof(IRunnerControlClient.CreateSessionAsync),
             request => _terminalSessions.CreateSessionAsync(request));
 
@@ -432,5 +451,53 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         }
 
         return await _devices.ResolveSelectionAsync(selection);
+    }
+
+    private void OnJobChanged(OrchestrationJob job) =>
+        _ = PublishJobChangedAsync(job);
+
+    private async Task PublishJobChangedAsync(OrchestrationJob job)
+    {
+        try
+        {
+            await _publisher.PublishOrchestrationJobUpdatedAsync(job);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to publish orchestration job update for {JobId}", job.Id);
+        }
+    }
+
+    private async Task RepublishCoordinatorStateAsync(CancellationToken cancellationToken)
+    {
+        foreach (var session in _sessionStore.GetAll())
+        {
+            await _publisher.PublishTerminalSessionUpdatedAsync(session, cancellationToken);
+        }
+
+        foreach (var job in _jobs.GetAll())
+        {
+            await _publisher.PublishOrchestrationJobUpdatedAsync(job, cancellationToken);
+        }
+
+        foreach (var viewer in _viewers.GetAll())
+        {
+            await _publisher.PublishViewerSessionUpdatedAsync(viewer, cancellationToken);
+            if (viewer.Provider == RemoteViewerProviderKind.Managed &&
+                viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed &&
+                _managedViewerRelay.GetLatestFrame(viewer.Id) is { } frame)
+            {
+                await _publisher.PublishViewerFrameAsync(
+                    new RemoteViewerRelayFrame(
+                        viewer.Id,
+                        frame.SequenceId,
+                        frame.CapturedAt,
+                        frame.ContentType,
+                        frame.Width,
+                        frame.Height,
+                        frame.Payload),
+                    cancellationToken);
+            }
+        }
     }
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerPublisher.cs
@@ -22,6 +22,9 @@ public sealed class CoordinatorRunnerPublisher : ICoordinatorRunnerPublisher
     public Task PublishTerminalSessionClosedAsync(string sessionId, CancellationToken cancellationToken = default) =>
         SendAsync(nameof(ICoordinatorRunnerHub.PublishTerminalSessionClosedAsync), [sessionId], cancellationToken);
 
+    public Task PublishOrchestrationJobUpdatedAsync(OrchestrationJob job, CancellationToken cancellationToken = default) =>
+        SendAsync(nameof(ICoordinatorRunnerHub.PublishOrchestrationJobUpdatedAsync), [job], cancellationToken);
+
     public Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session, CancellationToken cancellationToken = default) =>
         SendAsync(nameof(ICoordinatorRunnerHub.PublishViewerSessionUpdatedAsync), [session], cancellationToken);
 

--- a/AgentDeck.Runner/Services/ICoordinatorRunnerPublisher.cs
+++ b/AgentDeck.Runner/Services/ICoordinatorRunnerPublisher.cs
@@ -7,6 +7,7 @@ public interface ICoordinatorRunnerPublisher
     Task PublishTerminalOutputAsync(TerminalOutput output, CancellationToken cancellationToken = default);
     Task PublishTerminalSessionUpdatedAsync(TerminalSession session, CancellationToken cancellationToken = default);
     Task PublishTerminalSessionClosedAsync(string sessionId, CancellationToken cancellationToken = default);
+    Task PublishOrchestrationJobUpdatedAsync(OrchestrationJob job, CancellationToken cancellationToken = default);
     Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session, CancellationToken cancellationToken = default);
     Task PublishViewerFrameAsync(RemoteViewerRelayFrame frame, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Runner/Services/IOrchestrationJobService.cs
+++ b/AgentDeck.Runner/Services/IOrchestrationJobService.cs
@@ -5,6 +5,7 @@ namespace AgentDeck.Runner.Services;
 /// <summary>Tracks coordinator-managed run/debug jobs independently from terminal sessions.</summary>
 public interface IOrchestrationJobService
 {
+    event Action<OrchestrationJob>? Changed;
     OrchestrationJob Queue(CreateOrchestrationJobRequest request);
     OrchestrationJob? Get(string jobId);
     IReadOnlyList<OrchestrationJob> GetAll();

--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -496,6 +496,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
                 MachineId = job.TargetMachineId,
                 MachineName = job.TargetMachineName,
                 JobId = job.Id,
+                Provider = RemoteViewerProviderKind.Managed,
                 Target = new RemoteViewerTarget
                 {
                     Kind = targetKind,
@@ -520,6 +521,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             MachineId = job.TargetMachineId,
             MachineName = job.TargetMachineName,
             JobId = job.Id,
+            Provider = RemoteViewerProviderKind.Managed,
             Target = new RemoteViewerTarget
             {
                 Kind = targetKind,

--- a/AgentDeck.Runner/Services/OrchestrationJobService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationJobService.cs
@@ -9,6 +9,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
 {
     private readonly Lock _gate = new();
     private readonly ConcurrentDictionary<string, OrchestrationJob> _jobs = new();
+    public event Action<OrchestrationJob>? Changed;
 
     public OrchestrationJob Queue(CreateOrchestrationJobRequest request)
     {
@@ -54,6 +55,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             _jobs[job.Id] = job;
         }
 
+        NotifyChanged(job);
         return CloneJob(job);
     }
 
@@ -92,6 +94,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             updatedJob.Steps = UpdateSteps(updatedJob.Steps, updatedJob.Status, updatedJob.StatusMessage);
 
             _jobs[jobId] = updatedJob;
+            NotifyChanged(updatedJob);
             return CloneJob(updatedJob);
         }
     }
@@ -120,6 +123,7 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             ];
 
             _jobs[jobId] = updatedJob;
+            NotifyChanged(updatedJob);
             return CloneJob(updatedJob);
         }
     }
@@ -132,6 +136,9 @@ public sealed class OrchestrationJobService : IOrchestrationJobService
             Message = message ?? "Cancellation requested."
         });
     }
+
+    private void NotifyChanged(OrchestrationJob job) =>
+        Changed?.Invoke(CloneJob(job));
 
     private static IReadOnlyList<OrchestrationJobStep> CreateSteps(CreateOrchestrationJobRequest request)
     {

--- a/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
+++ b/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
@@ -68,6 +68,7 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
             MachineId = job.TargetMachineId,
             MachineName = job.TargetMachineName,
             JobId = job.Id,
+            Provider = RemoteViewerProviderKind.Managed,
             Target = new RemoteViewerTarget
             {
                 Kind = RemoteViewerTargetKind.VsCode,
@@ -816,6 +817,7 @@ error "Could not focus the VS Code window to start debugging."
             MachineId = job.TargetMachineId,
             MachineName = job.TargetMachineName,
             JobId = job.Id,
+            Provider = RemoteViewerProviderKind.Managed,
             Target = new RemoteViewerTarget
             {
                 Kind = targetKind,

--- a/AgentDeck.Shared/Hubs/ICoordinatorRunnerHub.cs
+++ b/AgentDeck.Shared/Hubs/ICoordinatorRunnerHub.cs
@@ -7,6 +7,7 @@ public interface ICoordinatorRunnerHub
     Task PublishTerminalOutputAsync(TerminalOutput output);
     Task PublishTerminalSessionUpdatedAsync(TerminalSession session);
     Task PublishTerminalSessionClosedAsync(string sessionId);
+    Task PublishOrchestrationJobUpdatedAsync(OrchestrationJob job);
     Task PublishViewerSessionUpdatedAsync(RemoteViewerSession session);
     Task PublishViewerFrameAsync(RemoteViewerRelayFrame frame);
 }


### PR DESCRIPTION
## Summary
- cache orchestration jobs and viewer sessions at the coordinator so reconnects do not depend on a fresh live runner RPC
- replay runner runtime state after control-channel reconnects and publish orchestration job changes over the coordinator hub
- force runtime run/debug viewer sessions onto the managed relay path so the companion can reconnect through the coordinator

## Testing
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -c Release
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release

Closes #247
Closes #246