### PR TITLE
Keep runtime list reads alive during runner reconnects

### DIFF
--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -249,9 +249,16 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
             return GetCachedOrchestrationJobs(machineId);
         }
 
-        var jobs = await InvokeRunnerAsync(entry, "list orchestration jobs", client => client.GetOrchestrationJobsAsync(), retryOnReconnect: true, cancellationToken);
-        ReplaceOrchestrationJobs(entry.MachineId, jobs);
-        return jobs;
+        try
+        {
+            var jobs = await InvokeRunnerAsync(entry, "list orchestration jobs", client => client.GetOrchestrationJobsAsync(), retryOnReconnect: true, cancellationToken);
+            ReplaceOrchestrationJobs(entry.MachineId, jobs);
+            return jobs;
+        }
+        catch (InvalidOperationException)
+        {
+            return GetCachedOrchestrationJobs(machineId);
+        }
     }
 
     public async Task<OrchestrationJob?> QueueOrchestrationJobAsync(string machineId, CreateOrchestrationJobRequest request, string actorId, CancellationToken cancellationToken = default)
@@ -286,10 +293,17 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
             return GetCachedViewerSessions(machineId);
         }
 
-        var sessions = await InvokeRunnerAsync(entry, "list viewer sessions", client => client.GetViewerSessionsAsync(), retryOnReconnect: true, cancellationToken);
-        var annotated = sessions.Select(session => AnnotateViewerSession(entry.MachineId, session)).ToArray();
-        ReplaceViewerSessions(entry.MachineId, annotated);
-        return annotated;
+        try
+        {
+            var sessions = await InvokeRunnerAsync(entry, "list viewer sessions", client => client.GetViewerSessionsAsync(), retryOnReconnect: true, cancellationToken);
+            var annotated = sessions.Select(session => AnnotateViewerSession(entry.MachineId, session)).ToArray();
+            ReplaceViewerSessions(entry.MachineId, annotated);
+            return annotated;
+        }
+        catch (InvalidOperationException)
+        {
+            return GetCachedViewerSessions(machineId);
+        }
     }
 
     public async Task<RemoteViewerSession> CreateViewerSessionAsync(string machineId, CreateRemoteViewerSessionRequest request, string actorId, CancellationToken cancellationToken = default)

--- a/AgentDeck.Core/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core/Services/CoordinatorApiClient.cs
@@ -232,9 +232,16 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         using var httpClient = CreateClient(coordinatorUrl);
         try
         {
-            return await httpClient.GetFromJsonAsync<IReadOnlyList<OrchestrationJob>>(
+            using var response = await httpClient.GetAsync(
                 $"api/machines/{Uri.EscapeDataString(machineId)}/orchestration/jobs",
-                cancellationToken) ?? [];
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return [];
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<IReadOnlyList<OrchestrationJob>>(cancellationToken: cancellationToken) ?? [];
         }
         catch (Exception ex)
         {
@@ -312,9 +319,16 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         using var httpClient = CreateClient(coordinatorUrl);
         try
         {
-            return await httpClient.GetFromJsonAsync<IReadOnlyList<RemoteViewerSession>>(
+            using var response = await httpClient.GetAsync(
                 $"api/machines/{Uri.EscapeDataString(machineId)}/viewers/sessions",
-                cancellationToken) ?? [];
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return [];
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<IReadOnlyList<RemoteViewerSession>>(cancellationToken: cancellationToken) ?? [];
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- fall back to cached-or-empty runtime lists when runner reconnect churn interrupts orchestration/viewer list reads
- stop treating list endpoint 404 responses as fatal in the coordinator client
- keep project details loading so the user can open the project terminal immediately after project creation

## Testing
- dotnet build AgentDeck.Core\\AgentDeck.Core.csproj -c Release
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release

Closes #249