### PR TITLE
Add project open tracing

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -189,6 +189,16 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
         TerminalSession? session = null;
         try
         {
+            logger.LogInformation(
+                "Opening project {ProjectId} ({ProjectName}) on machine {MachineId} ({MachineName}); existing workspace: {ExistingWorkspacePath}; companion: {CompanionId}; session: {ProjectSessionId}",
+                project.Id,
+                project.Name,
+                machine.MachineId,
+                machine.MachineName,
+                existingWorkspace?.ProjectPath ?? "<none>",
+                companionId ?? "<none>",
+                projectSession.Id);
+
             openedWorkspace = await runners.OpenProjectAsync(
                 machineId,
                 new OpenProjectOnRunnerRequest
@@ -203,9 +213,21 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
 
             if (openedWorkspace is null)
             {
+                logger.LogWarning(
+                    "Runner returned no workspace while opening project {ProjectId} on machine {MachineId}",
+                    project.Id,
+                    machine.MachineId);
                 projectSessions.RemoveSession(projectSession.Id);
                 return Results.NotFound();
             }
+
+            logger.LogInformation(
+                "Runner opened project {ProjectId} on machine {MachineId} at {ProjectPath} (created: {WorkspaceCreated}, cloned: {RepositoryCloned})",
+                project.Id,
+                machine.MachineId,
+                openedWorkspace.ProjectPath,
+                openedWorkspace.WorkspaceCreated,
+                openedWorkspace.RepositoryCloned);
 
             workspaceMapping = new ProjectWorkspaceMapping
             {
@@ -220,6 +242,14 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
                 Name = $"{project.Name} ({machine.MachineName})",
                 WorkingDirectory = openedWorkspace.ProjectPath
             }, cancellationToken);
+
+            logger.LogInformation(
+                "Created project terminal session {TerminalSessionId} for project {ProjectId} on machine {MachineId} in {WorkingDirectory}",
+                session.Id,
+                project.Id,
+                machine.MachineId,
+                openedWorkspace.ProjectPath);
+
             if (!string.IsNullOrWhiteSpace(companionId))
             {
                 companions.AttachSession(companionId, session.Id);
@@ -249,6 +279,14 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
         }
         catch (Exception ex)
         {
+            logger.LogError(
+                ex,
+                "Open-project flow failed for project {ProjectId} on machine {MachineId}; workspacePath: {ProjectPath}; terminalSession: {TerminalSessionId}; projectSession: {ProjectSessionId}",
+                project.Id,
+                machine.MachineId,
+                openedWorkspace?.ProjectPath ?? workspaceMapping?.ProjectPath ?? "<unknown>",
+                session?.Id ?? "<none>",
+                projectSession.Id);
             try
             {
                 projectSessions.RemoveSession(projectSession.Id);

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -213,7 +213,23 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
     public async Task<OpenProjectOnRunnerResult?> OpenProjectAsync(string machineId, OpenProjectOnRunnerRequest request, string actorId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        return await InvokeRunnerAsync(entry, "open project", client => client.OpenProjectAsync(request, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        _logger.LogInformation(
+            "Brokering project open for project {ProjectId} ({ProjectName}) on machine {MachineName} ({MachineId}); existing workspace: {ExistingWorkspacePath}; repository: {RepositoryUrl}",
+            request.ProjectId,
+            request.ProjectName,
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            request.ExistingWorkspacePath ?? "<none>",
+            string.IsNullOrWhiteSpace(request.Repository.Url) ? "<none>" : request.Repository.Url);
+        var result = await InvokeRunnerAsync(entry, "open project", client => client.OpenProjectAsync(request, NormalizeActorId(actorId)), retryOnReconnect: false, cancellationToken);
+        _logger.LogInformation(
+            "Runner responded to project open for {ProjectId} on machine {MachineId} with path {ProjectPath} (created: {WorkspaceCreated}, cloned: {RepositoryCloned})",
+            request.ProjectId,
+            machineId,
+            result?.ProjectPath ?? "<none>",
+            result?.WorkspaceCreated,
+            result?.RepositoryCloned);
+        return result;
     }
 
     public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default)

--- a/AgentDeck.Runner/Services/ProjectWorkspaceBootstrapService.cs
+++ b/AgentDeck.Runner/Services/ProjectWorkspaceBootstrapService.cs
@@ -25,20 +25,46 @@ public sealed class ProjectWorkspaceBootstrapService : IProjectWorkspaceBootstra
         var projectPath = ResolveProjectPath(request);
         var workspaceCreated = false;
         var repositoryCloned = false;
+        var workspaceAlreadyExists = Directory.Exists(projectPath);
 
-        if (!Directory.Exists(projectPath))
+        _logger.LogInformation(
+            "Runner opening project workspace for {ProjectId} ({ProjectName}); resolved path: {ProjectPath}; existing workspace override: {ExistingWorkspacePath}; repository: {RepositoryUrl}; path exists: {PathExists}",
+            request.ProjectId,
+            request.ProjectName ?? "<unnamed>",
+            projectPath,
+            request.ExistingWorkspacePath ?? "<none>",
+            string.IsNullOrWhiteSpace(request.Repository.Url) ? "<none>" : request.Repository.Url,
+            workspaceAlreadyExists);
+
+        if (!workspaceAlreadyExists)
         {
             if (!string.IsNullOrWhiteSpace(request.Repository.Url))
             {
+                _logger.LogInformation(
+                    "Cloning repository {RepositoryUrl} into {ProjectPath} for project {ProjectId}",
+                    request.Repository.Url,
+                    projectPath,
+                    request.ProjectId);
                 await CloneRepositoryAsync(request.Repository, projectPath, cancellationToken);
                 repositoryCloned = true;
                 workspaceCreated = true;
             }
             else
             {
+                _logger.LogInformation(
+                    "Creating empty workspace directory {ProjectPath} for project {ProjectId}",
+                    projectPath,
+                    request.ProjectId);
                 Directory.CreateDirectory(projectPath);
                 workspaceCreated = true;
             }
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Reusing existing workspace directory {ProjectPath} for project {ProjectId}",
+                projectPath,
+                request.ProjectId);
         }
 
         _logger.LogInformation(
@@ -60,12 +86,23 @@ public sealed class ProjectWorkspaceBootstrapService : IProjectWorkspaceBootstra
     {
         if (!string.IsNullOrWhiteSpace(request.ExistingWorkspacePath))
         {
-            return _workspace.ResolvePath(request.ExistingWorkspacePath);
+            var resolvedExistingPath = _workspace.ResolvePath(request.ExistingWorkspacePath);
+            _logger.LogInformation(
+                "Resolved existing workspace path {ExistingWorkspacePath} to {ResolvedProjectPath} for project {ProjectId}",
+                request.ExistingWorkspacePath,
+                resolvedExistingPath,
+                request.ProjectId);
+            return resolvedExistingPath;
         }
 
         var folderName = BuildWorkspaceFolderName(request);
-
-        return _workspace.ResolveDirectory(folderName);
+        var resolvedDirectory = _workspace.ResolveDirectory(folderName);
+        _logger.LogInformation(
+            "Resolved new workspace folder {WorkspaceFolderName} to {ResolvedProjectPath} for project {ProjectId}",
+            folderName,
+            resolvedDirectory,
+            request.ProjectId);
+        return resolvedDirectory;
     }
 
     private static string BuildWorkspaceFolderName(OpenProjectOnRunnerRequest request)
@@ -131,8 +168,22 @@ public sealed class ProjectWorkspaceBootstrapService : IProjectWorkspaceBootstra
             if (process.ExitCode != 0)
             {
                 var failureMessage = FirstMeaningfulLine(standardError, standardOutput) ?? "git clone failed.";
+                _logger.LogWarning(
+                    "git clone failed for {RepositoryUrl} into {ProjectPath} with exit code {ExitCode}. stdout: {StandardOutput}. stderr: {StandardError}",
+                    repository.Url,
+                    projectPath,
+                    process.ExitCode,
+                    string.IsNullOrWhiteSpace(standardOutput) ? "<empty>" : standardOutput.Trim(),
+                    string.IsNullOrWhiteSpace(standardError) ? "<empty>" : standardError.Trim());
                 throw new InvalidOperationException($"Failed to clone repository '{repository.Url}'. {failureMessage}");
             }
+
+            _logger.LogInformation(
+                "git clone succeeded for {RepositoryUrl} into {ProjectPath}. stdout: {StandardOutput}. stderr: {StandardError}",
+                repository.Url,
+                projectPath,
+                string.IsNullOrWhiteSpace(standardOutput) ? "<empty>" : standardOutput.Trim(),
+                string.IsNullOrWhiteSpace(standardError) ? "<empty>" : standardError.Trim());
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
## Summary
- log coordinator project-open flow entry, runner broker handoff, workspace result, terminal creation, and failure cleanup context
- log runner workspace path resolution, reuse/create decisions, and git clone start/result details
- make it possible to pinpoint whether project opening fails before broker dispatch, during workspace bootstrap, or during terminal session creation

## Testing
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -c Release
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release

Closes #251