### PR TITLE
Fail fast on empty project-open results

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -221,6 +221,11 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
                 return Results.NotFound();
             }
 
+            if (string.IsNullOrWhiteSpace(openedWorkspace.ProjectPath))
+            {
+                throw new InvalidOperationException($"Runner machine '{machine.MachineName}' returned an empty workspace path while opening project '{project.Id}'.");
+            }
+
             logger.LogInformation(
                 "Runner opened project {ProjectId} on machine {MachineId} at {ProjectPath} (created: {WorkspaceCreated}, cloned: {RepositoryCloned})",
                 project.Id,

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -229,6 +229,11 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
             result?.ProjectPath ?? "<none>",
             result?.WorkspaceCreated,
             result?.RepositoryCloned);
+        if (result is not null && string.IsNullOrWhiteSpace(result.ProjectPath))
+        {
+            throw new InvalidOperationException($"Runner machine '{entry.Machine?.MachineName ?? entry.MachineId}' returned an empty workspace path while opening project '{request.ProjectId}'.");
+        }
+
         return result;
     }
 

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -270,7 +270,24 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
     private async Task<OpenProjectOnRunnerResult?> OpenProjectAsync(OpenProjectOnRunnerRequest request, string actorId)
     {
-        return await _projectBootstrap.OpenProjectAsync(request);
+        _logger.LogInformation(
+            "Runner received brokered project open for {ProjectId} ({ProjectName}); existing workspace: {ExistingWorkspacePath}; repository: {RepositoryUrl}; actor: {ActorId}",
+            request.ProjectId,
+            request.ProjectName ?? "<unnamed>",
+            request.ExistingWorkspacePath ?? "<none>",
+            string.IsNullOrWhiteSpace(request.Repository.Url) ? "<none>" : request.Repository.Url,
+            actorId);
+
+        var result = await _projectBootstrap.OpenProjectAsync(request);
+
+        _logger.LogInformation(
+            "Runner completed brokered project open for {ProjectId} with path {ProjectPath} (created: {WorkspaceCreated}, cloned: {RepositoryCloned})",
+            request.ProjectId,
+            result.ProjectPath,
+            result.WorkspaceCreated,
+            result.RepositoryCloned);
+
+        return result;
     }
 
     private async Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string capabilityId, MachineCapabilityInstallRequest request, string actorId)


### PR DESCRIPTION
## Summary
- add direct runner logs around brokered project-open handling
- reject empty brokered project-open workspace paths immediately
- stop open-project requests from degrading into long client-side timeouts

## Testing
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -c Release
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release