### PR TITLE
Allow project-open workspace fallback

### DIFF
--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -231,11 +231,6 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
             result?.BootstrapPending,
             result?.WorkspaceCreated,
             result?.RepositoryCloned);
-        if (result is not null && string.IsNullOrWhiteSpace(result.ProjectPath))
-        {
-            throw new InvalidOperationException($"Runner machine '{entry.Machine?.MachineName ?? entry.MachineId}' returned an empty workspace path while opening project '{request.ProjectId}'.");
-        }
-
         return result;
     }
 


### PR DESCRIPTION
## Summary
- stop throwing in the runner broker when a non-null project-open result omits the workspace path
- let the project-open route apply its default workspace-path fallback and terminal bootstrap flow

## Testing
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release