### PR TITLE
Retry terminal creation safely on reconnect

### DIFF
--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -167,8 +167,25 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
     public async Task<TerminalSession> CreateSessionAsync(string machineId, CreateTerminalRequest request, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
-        _logger.LogInformation("Brokering terminal session creation '{SessionName}' on machine {MachineName} ({MachineId})", request.Name, entry.Machine?.MachineName ?? machineId, machineId);
-        var session = await InvokeRunnerAsync(entry, "create terminal session", client => client.CreateSessionAsync(request), retryOnReconnect: false, cancellationToken);
+        var requestWithSessionId = string.IsNullOrWhiteSpace(request.RequestedSessionId)
+            ? new CreateTerminalRequest
+            {
+                RequestedSessionId = Guid.NewGuid().ToString("N"),
+                Name = request.Name,
+                WorkingDirectory = request.WorkingDirectory,
+                Command = request.Command,
+                Arguments = request.Arguments,
+                Cols = request.Cols,
+                Rows = request.Rows
+            }
+            : request;
+        _logger.LogInformation(
+            "Brokering terminal session creation '{SessionName}' on machine {MachineName} ({MachineId}) with requested session id {RequestedSessionId}",
+            request.Name,
+            entry.Machine?.MachineName ?? machineId,
+            machineId,
+            requestWithSessionId.RequestedSessionId ?? "<none>");
+        var session = await InvokeRunnerAsync(entry, "create terminal session", client => client.CreateSessionAsync(requestWithSessionId), retryOnReconnect: true, cancellationToken);
         var annotated = AnnotateSession(session, entry.Machine!);
         await _agentHubContext.Clients.All.SessionCreatedAsync(annotated);
         return annotated;

--- a/AgentDeck.Runner/Services/TerminalSessionService.cs
+++ b/AgentDeck.Runner/Services/TerminalSessionService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
@@ -12,6 +13,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
     private readonly IWorkspaceService _workspaceService;
     private readonly RunnerOptions _options;
     private readonly ILogger<TerminalSessionService> _logger;
+    private readonly ConcurrentDictionary<string, Task<TerminalSession>> _pendingCreates = new(StringComparer.OrdinalIgnoreCase);
 
     public TerminalSessionService(
         IPtyProcessManager ptyManager,
@@ -29,7 +31,39 @@ public sealed class TerminalSessionService : ITerminalSessionService
 
     public async Task<TerminalSession> CreateSessionAsync(CreateTerminalRequest request, CancellationToken cancellationToken = default)
     {
-        var sessionId = Guid.NewGuid().ToString("N");
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!string.IsNullOrWhiteSpace(request.RequestedSessionId))
+        {
+            var requestedSessionId = request.RequestedSessionId.Trim();
+            if (_sessionStore.Get(requestedSessionId) is { } existingSession &&
+                _ptyManager.IsActive(requestedSessionId))
+            {
+                _logger.LogInformation(
+                    "Reusing existing terminal session {SessionId} ({Name}) for idempotent create request.",
+                    existingSession.Id,
+                    existingSession.Name);
+                return existingSession;
+            }
+
+            var createTask = _pendingCreates.GetOrAdd(
+                requestedSessionId,
+                _ => CreateSessionCoreAsync(request, requestedSessionId, cancellationToken));
+            try
+            {
+                return await createTask;
+            }
+            finally
+            {
+                _pendingCreates.TryRemove(requestedSessionId, out _);
+            }
+        }
+
+        return await CreateSessionCoreAsync(request, Guid.NewGuid().ToString("N"), cancellationToken);
+    }
+
+    private async Task<TerminalSession> CreateSessionCoreAsync(CreateTerminalRequest request, string sessionId, CancellationToken cancellationToken)
+    {
         var workingDir = ResolveWorkingDirectory(request.WorkingDirectory);
         var command = ResolveCommand(request.Command);
         var arguments = request.Arguments;
@@ -78,6 +112,7 @@ public sealed class TerminalSessionService : ITerminalSessionService
                 FormatArguments(launchArguments));
             session.Status = TerminalStatus.Error;
             _sessionStore.Update(session);
+            _sessionStore.Remove(sessionId);
             throw new TerminalSessionStartException(session, ex);
         }
 

--- a/AgentDeck.Shared/Models/CreateTerminalRequest.cs
+++ b/AgentDeck.Shared/Models/CreateTerminalRequest.cs
@@ -3,6 +3,9 @@ namespace AgentDeck.Shared.Models;
 /// <summary>Request payload for creating a new terminal session.</summary>
 public sealed class CreateTerminalRequest
 {
+    /// <summary>Optional stable identifier for idempotent terminal creation across reconnect retries.</summary>
+    public string? RequestedSessionId { get; init; }
+
     /// <summary>Human-readable display name for the session.</summary>
     public required string Name { get; init; }
 


### PR DESCRIPTION
## Summary
- add a stable requested session id to terminal creation requests
- make runner terminal creation idempotent and single-flight per requested session id
- let brokered terminal creation retry across runner reconnects without duplicating sessions

## Testing
- dotnet build AgentDeck.Runner\\AgentDeck.Runner.csproj -c Release
- dotnet build AgentDeck.Coordinator\\AgentDeck.Coordinator.csproj -c Release
- dotnet build AgentDeck.slnx -c Release