### PR TITLE
Fix runner completion protocol

### DIFF
--- a/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/IRunnerBrokerService.cs
@@ -13,7 +13,7 @@ public interface IRunnerBrokerService
     Task SendInputAsync(string sessionId, string data, CancellationToken cancellationToken = default);
     Task<WorkspaceInfo?> GetWorkspaceAsync(string machineId, CancellationToken cancellationToken = default);
     Task<OpenProjectOnRunnerResult?> OpenProjectAsync(string machineId, OpenProjectOnRunnerRequest request, string actorId, CancellationToken cancellationToken = default);
-    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default);
+    Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string machineId, string capabilityId, MachineCapabilityInstallRequest request, string actorId, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(string machineId, string capabilityId, string actorId, CancellationToken cancellationToken = default);
     Task<bool> RetryMachineWorkflowPackAsync(string machineId, string actorId, CancellationToken cancellationToken = default);

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -254,7 +254,7 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
         return result;
     }
 
-    public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default)
+    public async Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(string machineId, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
         return await InvokeRunnerAsync(entry, "read machine capabilities", client => client.GetMachineCapabilitiesAsync(), retryOnReconnect: true, cancellationToken);

--- a/AgentDeck.Core/Services/AgentDeckClient.cs
+++ b/AgentDeck.Core/Services/AgentDeckClient.cs
@@ -181,17 +181,22 @@ public sealed class AgentDeckClient : IAgentDeckClient, IAsyncDisposable
         }
     }
 
-    public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken ct = default)
+    public async Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(string machineId, CancellationToken ct = default)
     {
-        if (_http.BaseAddress is null) return null;
+        if (_http.BaseAddress is null)
+        {
+            throw new InvalidOperationException("Coordinator base address is not configured.");
+        }
+
         try
         {
-            return await _http.GetFromJsonAsync<MachineCapabilitiesSnapshot>($"/api/machines/{Uri.EscapeDataString(machineId)}/capabilities", ct);
+            return await _http.GetFromJsonAsync<MachineCapabilitiesSnapshot>($"/api/machines/{Uri.EscapeDataString(machineId)}/capabilities", ct)
+                ?? throw new InvalidOperationException($"Coordinator returned an empty capabilities snapshot for machine '{machineId}'.");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "GetMachineCapabilitiesAsync failed");
-            return null;
+            throw;
         }
     }
 

--- a/AgentDeck.Core/Services/IAgentDeckClient.cs
+++ b/AgentDeck.Core/Services/IAgentDeckClient.cs
@@ -72,7 +72,7 @@ public interface IAgentDeckClient
     Task<WorkspaceInfo?> GetWorkspaceAsync(string machineId, CancellationToken ct = default);
 
     /// <summary>Get supported CLI/SDK detection results for the selected runner machine via the coordinator.</summary>
-    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(string machineId, CancellationToken ct = default);
+    Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(string machineId, CancellationToken ct = default);
 
     /// <summary>Install a supported CLI or SDK on the selected runner machine via the coordinator.</summary>
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string machineId, string capabilityId, string? version = null, CancellationToken ct = default);

--- a/AgentDeck.Core/Services/IRunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/IRunnerConnectionManager.cs
@@ -25,7 +25,7 @@ public interface IRunnerConnectionManager
     Task CloseSessionAsync(string sessionId);
     Task<IReadOnlyList<TerminalSession>> GetSessionsAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
     Task<WorkspaceInfo?> GetWorkspaceAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
-    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
+    Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(RunnerMachineSettings machine, string capabilityId, string? version = null, CancellationToken cancellationToken = default);
     Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(RunnerMachineSettings machine, string capabilityId, CancellationToken cancellationToken = default);
 }

--- a/AgentDeck.Core/Services/RunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/RunnerConnectionManager.cs
@@ -238,7 +238,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
         return await _client.GetWorkspaceAsync(machine.Id, cancellationToken);
     }
 
-    public async Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default)
+    public async Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync(RunnerMachineSettings machine, CancellationToken cancellationToken = default)
     {
         await EnsureMachineConnectedAsync(machine, cancellationToken);
         return await _client.GetMachineCapabilitiesAsync(machine.Id, cancellationToken);

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -278,7 +278,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         connection.On<OpenProjectOnRunnerRequest, string, OpenProjectOnRunnerResult?>(nameof(IRunnerControlClient.OpenProjectAsync),
             (request, actorId) => OpenProjectAsync(request, actorId));
 
-        connection.On<MachineCapabilitiesSnapshot?>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
+        connection.On<MachineCapabilitiesSnapshot>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
             async () => await _capabilities.GetSnapshotAsync());
 
         connection.On<string, MachineCapabilityInstallRequest, string, MachineCapabilityInstallResult?>(nameof(IRunnerControlClient.InstallMachineCapabilityAsync),

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -248,7 +248,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             return Task.CompletedTask;
         };
 
-        connection.On<CreateTerminalRequest, Task<TerminalSession>>(nameof(IRunnerControlClient.CreateSessionAsync),
+        connection.On<CreateTerminalRequest, TerminalSession>(nameof(IRunnerControlClient.CreateSessionAsync),
             request => CreateSessionWithDiagnosticsAsync(request));
 
         connection.On<string, Task>(nameof(IRunnerControlClient.CloseSessionAsync), async sessionId =>
@@ -263,7 +263,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             _sessionStore.Remove(sessionId);
         });
 
-        connection.On<Task<IReadOnlyList<TerminalSession>>>(nameof(IRunnerControlClient.GetSessionsAsync),
+        connection.On<IReadOnlyList<TerminalSession>>(nameof(IRunnerControlClient.GetSessionsAsync),
             () => GetSessionsWithDiagnosticsAsync());
 
         connection.On<string, string, Task>(nameof(IRunnerControlClient.SendInputAsync),
@@ -272,40 +272,40 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         connection.On<string, int, int, Task>(nameof(IRunnerControlClient.ResizeTerminalAsync),
             (sessionId, cols, rows) => _ptyManager.ResizeAsync(sessionId, cols, rows));
 
-        connection.On<Task<WorkspaceInfo?>>(nameof(IRunnerControlClient.GetWorkspaceAsync),
+        connection.On<WorkspaceInfo?>(nameof(IRunnerControlClient.GetWorkspaceAsync),
             () => Task.FromResult<WorkspaceInfo?>(_workspace.GetWorkspaceInfo()));
 
-        connection.On<OpenProjectOnRunnerRequest, string, Task<OpenProjectOnRunnerResult?>>(nameof(IRunnerControlClient.OpenProjectAsync),
+        connection.On<OpenProjectOnRunnerRequest, string, OpenProjectOnRunnerResult?>(nameof(IRunnerControlClient.OpenProjectAsync),
             (request, actorId) => OpenProjectAsync(request, actorId));
 
-        connection.On<Task<MachineCapabilitiesSnapshot>>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
-            () => _capabilities.GetSnapshotAsync());
+        connection.On<MachineCapabilitiesSnapshot?>(nameof(IRunnerControlClient.GetMachineCapabilitiesAsync),
+            async () => await _capabilities.GetSnapshotAsync());
 
-        connection.On<string, MachineCapabilityInstallRequest, string, Task<MachineCapabilityInstallResult?>>(nameof(IRunnerControlClient.InstallMachineCapabilityAsync),
+        connection.On<string, MachineCapabilityInstallRequest, string, MachineCapabilityInstallResult?>(nameof(IRunnerControlClient.InstallMachineCapabilityAsync),
             (capabilityId, request, actorId) => InstallMachineCapabilityAsync(capabilityId, request, actorId));
 
-        connection.On<string, string, Task<MachineCapabilityInstallResult?>>(nameof(IRunnerControlClient.UpdateMachineCapabilityAsync),
+        connection.On<string, string, MachineCapabilityInstallResult?>(nameof(IRunnerControlClient.UpdateMachineCapabilityAsync),
             (capabilityId, actorId) => UpdateMachineCapabilityAsync(capabilityId, actorId));
 
         connection.On<string, Task>(nameof(IRunnerControlClient.RetryMachineWorkflowPackAsync),
             actorId => RetryWorkflowPackAsync(actorId));
 
-        connection.On<Task<IReadOnlyList<OrchestrationJob>>>(nameof(IRunnerControlClient.GetOrchestrationJobsAsync),
+        connection.On<IReadOnlyList<OrchestrationJob>>(nameof(IRunnerControlClient.GetOrchestrationJobsAsync),
             () => Task.FromResult(_jobs.GetAll()));
 
-        connection.On<CreateOrchestrationJobRequest, string, Task<OrchestrationJob?>>(nameof(IRunnerControlClient.QueueOrchestrationJobAsync),
+        connection.On<CreateOrchestrationJobRequest, string, OrchestrationJob?>(nameof(IRunnerControlClient.QueueOrchestrationJobAsync),
             (request, actorId) => QueueOrchestrationJobAsync(request, actorId));
 
-        connection.On<string, string, Task<OrchestrationJob?>>(nameof(IRunnerControlClient.CancelOrchestrationJobAsync),
+        connection.On<string, string, OrchestrationJob?>(nameof(IRunnerControlClient.CancelOrchestrationJobAsync),
             (jobId, actorId) => CancelOrchestrationJobAsync(jobId, actorId));
 
-        connection.On<Task<IReadOnlyList<RemoteViewerSession>>>(nameof(IRunnerControlClient.GetViewerSessionsAsync),
+        connection.On<IReadOnlyList<RemoteViewerSession>>(nameof(IRunnerControlClient.GetViewerSessionsAsync),
             () => Task.FromResult(_viewers.GetAll()));
 
-        connection.On<CreateRemoteViewerSessionRequest, string, Task<RemoteViewerSession>>(nameof(IRunnerControlClient.CreateViewerSessionAsync),
+        connection.On<CreateRemoteViewerSessionRequest, string, RemoteViewerSession>(nameof(IRunnerControlClient.CreateViewerSessionAsync),
             (request, actorId) => CreateViewerSessionAsync(request, actorId));
 
-        connection.On<string, string, Task<RemoteViewerSession?>>(nameof(IRunnerControlClient.CloseViewerSessionAsync),
+        connection.On<string, string, RemoteViewerSession?>(nameof(IRunnerControlClient.CloseViewerSessionAsync),
             (viewerSessionId, actorId) => CloseViewerSessionAsync(viewerSessionId, actorId));
 
         connection.On<string, string, RemoteViewerPointerInputEvent, Task>(nameof(IRunnerControlClient.SendViewerPointerInputAsync),
@@ -314,10 +314,10 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         connection.On<string, string, RemoteViewerKeyboardInputEvent, Task>(nameof(IRunnerControlClient.SendViewerKeyboardInputAsync),
             (viewerSessionId, actorId, input) => SendViewerKeyboardInputAsync(viewerSessionId, actorId, input));
 
-        connection.On<Task<IReadOnlyList<VirtualDeviceCatalogSnapshot>>>(nameof(IRunnerControlClient.GetVirtualDeviceCatalogsAsync),
+        connection.On<IReadOnlyList<VirtualDeviceCatalogSnapshot>>(nameof(IRunnerControlClient.GetVirtualDeviceCatalogsAsync),
             () => _devices.GetCatalogsAsync());
 
-        connection.On<VirtualDeviceLaunchSelection, Task<VirtualDeviceLaunchResolution?>>(nameof(IRunnerControlClient.ResolveVirtualDeviceAsync),
+        connection.On<VirtualDeviceLaunchSelection, VirtualDeviceLaunchResolution?>(nameof(IRunnerControlClient.ResolveVirtualDeviceAsync),
             selection => ResolveVirtualDeviceAsync(selection));
     }
 

--- a/AgentDeck.Shared/Hubs/IRunnerControlClient.cs
+++ b/AgentDeck.Shared/Hubs/IRunnerControlClient.cs
@@ -12,7 +12,7 @@ public interface IRunnerControlClient
 
     Task<WorkspaceInfo?> GetWorkspaceAsync();
     Task<OpenProjectOnRunnerResult?> OpenProjectAsync(OpenProjectOnRunnerRequest request, string actorId);
-    Task<MachineCapabilitiesSnapshot?> GetMachineCapabilitiesAsync();
+    Task<MachineCapabilitiesSnapshot> GetMachineCapabilitiesAsync();
     Task<MachineCapabilityInstallResult?> InstallMachineCapabilityAsync(string capabilityId, MachineCapabilityInstallRequest request, string actorId);
     Task<MachineCapabilityInstallResult?> UpdateMachineCapabilityAsync(string capabilityId, string actorId);
     Task RetryMachineWorkflowPackAsync(string actorId);


### PR DESCRIPTION
## Summary
- fix runner brokered SignalR result handlers to register the unwrapped result types instead of Task<T>
- align the machine capabilities handler with the nullable hub contract
- preserve the existing diagnostics so reconnects remain visible if anything else fails

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #275