### PR TITLE
Handle large runner control messages

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -39,4 +39,6 @@ public sealed class CoordinatorOptions
     public TimeSpan RunnerControlClientTimeoutInterval { get; set; } = TimeSpan.FromSeconds(60);
 
     public TimeSpan RunnerControlHandshakeTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    public long RunnerControlMaximumReceiveMessageSize { get; set; } = 1024 * 1024;
 }

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddSignalR(options =>
     options.KeepAliveInterval = coordinatorOptions.RunnerControlKeepAliveInterval;
     options.ClientTimeoutInterval = coordinatorOptions.RunnerControlClientTimeoutInterval;
     options.HandshakeTimeout = coordinatorOptions.RunnerControlHandshakeTimeout;
+    options.MaximumReceiveMessageSize = coordinatorOptions.RunnerControlMaximumReceiveMessageSize;
 });
 builder.Services.AddSingleton<ICoordinatorArtifactService, CoordinatorArtifactService>();
 builder.Services.AddSingleton<IRunnerDefinitionCatalogService, RunnerDefinitionCatalogService>();

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -384,7 +384,8 @@
     "WorkerExpiry": "00:00:45",
     "RunnerControlKeepAliveInterval": "00:00:15",
     "RunnerControlClientTimeoutInterval": "00:01:00",
-    "RunnerControlHandshakeTimeout": "00:00:30"
+    "RunnerControlHandshakeTimeout": "00:00:30",
+    "RunnerControlMaximumReceiveMessageSize": 1048576
   },
   "Logging": {
     "LogLevel": {

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -12,6 +12,9 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsyncDisposable
 {
+    private const int CoordinatorTransportJobLogCountLimit = 1;
+    private const int CoordinatorTransportMessageLengthLimit = 2048;
+
     private readonly WorkerCoordinatorOptions _options;
     private readonly ITerminalSessionService _terminalSessions;
     private readonly IPtyProcessManager _ptyManager;
@@ -291,7 +294,8 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             actorId => RetryWorkflowPackAsync(actorId));
 
         connection.On<IReadOnlyList<OrchestrationJob>>(nameof(IRunnerControlClient.GetOrchestrationJobsAsync),
-            () => Task.FromResult(_jobs.GetAll()));
+            () => Task.FromResult<IReadOnlyList<OrchestrationJob>>(
+                [.. _jobs.GetAll().Select(job => SanitizeOrchestrationJobForCoordinatorTransport(job))]));
 
         connection.On<CreateOrchestrationJobRequest, string, OrchestrationJob?>(nameof(IRunnerControlClient.QueueOrchestrationJobAsync),
             (request, actorId) => QueueOrchestrationJobAsync(request, actorId));
@@ -473,7 +477,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         var job = _jobs.Queue(request);
         _execution.Start(job.Id);
         _audit.Record(decision, RunnerAuditOutcome.Succeeded, $"Queued orchestration job '{job.Id}' for launch profile '{request.LaunchProfileId}'.");
-        return Task.FromResult<OrchestrationJob?>(job);
+        return Task.FromResult<OrchestrationJob?>(SanitizeOrchestrationJobForCoordinatorTransport(job));
     }
 
     private async Task<OrchestrationJob?> CancelOrchestrationJobAsync(string jobId, string actorId)
@@ -493,7 +497,10 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
         await _execution.RequestCancellationAsync(jobId);
         _audit.Record(decision, RunnerAuditOutcome.Succeeded, $"Requested cancellation for orchestration job '{jobId}'.");
-        return _jobs.Get(jobId);
+        var job = _jobs.Get(jobId);
+        return job is null
+            ? null
+            : SanitizeOrchestrationJobForCoordinatorTransport(job);
     }
 
     private async Task<RemoteViewerSession> CreateViewerSessionAsync(CreateRemoteViewerSessionRequest request, string actorId)
@@ -596,7 +603,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
     {
         try
         {
-            await _publisher.PublishOrchestrationJobUpdatedAsync(job);
+            await _publisher.PublishOrchestrationJobUpdatedAsync(SanitizeOrchestrationJobForCoordinatorTransport(job));
         }
         catch (Exception ex)
         {
@@ -613,7 +620,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
 
         foreach (var job in _jobs.GetAll())
         {
-            await _publisher.PublishOrchestrationJobUpdatedAsync(job, cancellationToken);
+            await _publisher.PublishOrchestrationJobUpdatedAsync(SanitizeOrchestrationJobForCoordinatorTransport(job), cancellationToken);
         }
 
         foreach (var viewer in _viewers.GetAll())
@@ -635,5 +642,70 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
                     cancellationToken);
             }
         }
+    }
+
+    private static OrchestrationJob SanitizeOrchestrationJobForCoordinatorTransport(OrchestrationJob job)
+    {
+        return new OrchestrationJob
+        {
+            Id = job.Id,
+            ProjectId = job.ProjectId,
+            ProjectName = job.ProjectName,
+            ProjectSessionId = job.ProjectSessionId,
+            LaunchProfileId = job.LaunchProfileId,
+            LaunchProfileName = job.LaunchProfileName,
+            Platform = job.Platform,
+            Mode = job.Mode,
+            LaunchDriver = job.LaunchDriver,
+            TargetMachineRole = job.TargetMachineRole,
+            TargetMachineId = job.TargetMachineId,
+            TargetMachineName = job.TargetMachineName,
+            WorkingDirectory = job.WorkingDirectory,
+            BuildCommand = job.BuildCommand,
+            LaunchCommand = job.LaunchCommand,
+            BootstrapCommand = job.BootstrapCommand,
+            DebugConfigurationName = job.DebugConfigurationName,
+            DeviceSelection = job.DeviceSelection,
+            Status = job.Status,
+            SessionId = job.SessionId,
+            ViewerSessionId = job.ViewerSessionId,
+            ExitCode = job.ExitCode,
+            StatusMessage = TrimCoordinatorTransportText(job.StatusMessage),
+            CreatedAt = job.CreatedAt,
+            UpdatedAt = job.UpdatedAt,
+            Steps =
+            [
+                .. job.Steps.Select(step => new OrchestrationJobStep
+                {
+                    Name = step.Name,
+                    Status = step.Status,
+                    Message = TrimCoordinatorTransportText(step.Message),
+                    StartedAt = step.StartedAt,
+                    CompletedAt = step.CompletedAt
+                })
+            ],
+            Logs =
+            [
+                .. job.Logs
+                    .TakeLast(CoordinatorTransportJobLogCountLimit)
+                    .Select(log => new OrchestrationJobLogEntry
+                    {
+                        Timestamp = log.Timestamp,
+                        Level = log.Level,
+                        Message = TrimCoordinatorTransportText(log.Message) ?? string.Empty,
+                        MachineId = log.MachineId
+                    })
+            ]
+        };
+    }
+
+    private static string? TrimCoordinatorTransportText(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= CoordinatorTransportMessageLengthLimit)
+        {
+            return value;
+        }
+
+        return $"{value[..CoordinatorTransportMessageLengthLimit]}...";
     }
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -12,7 +12,8 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsyncDisposable
 {
-    private const int CoordinatorTransportJobLogCountLimit = 1;
+    // Keep a bounded recent history so coordinator/app surfaces retain context without replaying full PTY-scale logs.
+    private const int CoordinatorTransportJobLogCountLimit = 10;
     private const int CoordinatorTransportMessageLengthLimit = 2048;
 
     private readonly WorkerCoordinatorOptions _options;

--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ Coordinator configuration (`AgentDeck.Coordinator/appsettings.json`):
       "AllowUpdateApply": false
     },
     "WorkerHeartbeatInterval": "00:00:15",
-    "WorkerExpiry": "00:00:45"
+    "WorkerExpiry": "00:00:45",
+    "RunnerControlKeepAliveInterval": "00:00:15",
+    "RunnerControlClientTimeoutInterval": "00:01:00",
+    "RunnerControlHandshakeTimeout": "00:00:30",
+    "RunnerControlMaximumReceiveMessageSize": 1048576
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add an explicit coordinator runner-control receive size budget instead of relying on the 32 KB default
- sanitize orchestration jobs before sending them over the runner control hub by trimming text and keeping only the latest log entry
- document the new coordinator control-channel size setting

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #277