### PR TITLE
Add orchestration execution diagnostics

### DIFF
--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -476,8 +476,35 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         }
 
         var job = _jobs.Queue(request);
-        _execution.Start(job.Id);
-        _audit.Record(decision, RunnerAuditOutcome.Succeeded, $"Queued orchestration job '{job.Id}' for launch profile '{request.LaunchProfileId}'.");
+        var started = _execution.Start(job.Id);
+        if (!started)
+        {
+            const string failureMessage = "Runner rejected orchestration execution because a job with the same identifier was already active.";
+            _logger.LogWarning(
+                "Runner could not start orchestration job {JobId} for project {ProjectId} using launch profile {LaunchProfileId}: {FailureMessage}",
+                job.Id,
+                request.ProjectId,
+                request.LaunchProfileId,
+                failureMessage);
+            _jobs.AppendLog(job.Id, new AppendOrchestrationJobLogRequest
+            {
+                Level = OrchestrationLogLevel.Error,
+                Message = failureMessage,
+                MachineId = request.TargetMachineId
+            });
+            job = _jobs.UpdateStatus(job.Id, new UpdateOrchestrationJobStatusRequest
+            {
+                Status = OrchestrationJobStatus.Failed,
+                Message = failureMessage
+            }) ?? job;
+        }
+
+        _audit.Record(
+            decision,
+            started ? RunnerAuditOutcome.Succeeded : RunnerAuditOutcome.Failed,
+            started
+                ? $"Queued orchestration job '{job.Id}' for launch profile '{request.LaunchProfileId}'."
+                : $"Failed to start orchestration job '{job.Id}' for launch profile '{request.LaunchProfileId}'.");
         return Task.FromResult<OrchestrationJob?>(SanitizeOrchestrationJobForCoordinatorTransport(job));
     }
 

--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -71,9 +71,11 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     {
         if (!_activeJobs.TryAdd(jobId, 0))
         {
+            _logger.LogWarning("Ignored duplicate start request for orchestration job {JobId} because it is already active.", jobId);
             return false;
         }
 
+        _logger.LogInformation("Starting orchestration execution for job {JobId}.", jobId);
         _ = Task.Run(() => ExecuteJobAsync(jobId), CancellationToken.None);
         return true;
     }
@@ -117,8 +119,20 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             var job = _jobs.Get(jobId);
             if (job is null)
             {
+                _logger.LogWarning("Orchestration job {JobId} disappeared before execution started.", jobId);
                 return;
             }
+
+            _logger.LogInformation(
+                "Executing orchestration job {JobId} for project {ProjectId} ({ProjectName}); profile {LaunchProfileId}; mode {Mode}; platform {Platform}; terminal {TerminalSessionId}; working directory {WorkingDirectory}",
+                job.Id,
+                job.ProjectId,
+                job.ProjectName,
+                job.LaunchProfileId,
+                job.Mode,
+                job.Platform,
+                job.SessionId ?? "<none>",
+                job.WorkingDirectory);
 
             if (job.Status is OrchestrationJobStatus.CancelRequested or OrchestrationJobStatus.Cancelled)
             {
@@ -138,6 +152,11 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
             var workingDirectory = ResolveWorkingDirectory(job.WorkingDirectory);
             var terminalSessionId = RequireOwnedTerminalSessionId(job);
+            _logger.LogInformation(
+                "Orchestration job {JobId} resolved owned terminal {TerminalSessionId} at {WorkingDirectory} for build/launch execution.",
+                job.Id,
+                terminalSessionId,
+                workingDirectory);
             _jobs.AppendLog(jobId, new AppendOrchestrationJobLogRequest
             {
                 Level = OrchestrationLogLevel.Information,
@@ -286,6 +305,10 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             SessionId = terminalSessionId,
             Message = "Launching VS Code from the owned terminal."
         });
+        _logger.LogInformation(
+            "Orchestration job {JobId} launching VS Code debug through owned terminal {TerminalSessionId}.",
+            job.Id,
+            terminalSessionId);
 
         var launch = await _vsCodeDebug.LaunchAsync(job.Id, job, workingDirectory);
         _jobs.AppendLog(job.Id, new AppendOrchestrationJobLogRequest
@@ -354,6 +377,13 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             throw new InvalidOperationException($"Owned terminal session '{sessionId}' is not currently active on the runner.");
         }
 
+        _logger.LogInformation(
+            "Orchestration job {JobId} entering phase {Status} on terminal {TerminalSessionId} with command: {Command}",
+            job.Id,
+            status,
+            sessionId,
+            command);
+
         var operationId = Guid.NewGuid().ToString("N");
         var completionMarker = $"__AGENTDECK_EXIT_{operationId}__";
         var processIdMarker = isVsCode ? $"__AGENTDECK_PID_{operationId}__" : null;
@@ -402,7 +432,14 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
                 await onBeforeWaitAsync(activeSession);
             }
 
-            return await completion.Task;
+            var exitCode = await completion.Task;
+            _logger.LogInformation(
+                "Orchestration job {JobId} phase {Status} finished on terminal {TerminalSessionId} with exit code {ExitCode}.",
+                job.Id,
+                status,
+                sessionId,
+                exitCode);
+            return exitCode;
         }
         finally
         {
@@ -775,6 +812,11 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
         if (TryReadMarkedInt(ref markerBuffer, session.CompletionMarker, out var exitCode))
         {
+            _logger.LogInformation(
+                "Detected orchestration completion marker for job {JobId} on terminal {TerminalSessionId} with exit code {ExitCode}.",
+                session.JobId,
+                e.SessionId,
+                exitCode);
             session.Completion.TrySetResult(exitCode);
         }
 
@@ -785,6 +827,11 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     {
         if (_sessions.TryGetValue(e.SessionId, out var session))
         {
+            _logger.LogInformation(
+                "Terminal {TerminalSessionId} exited while orchestration job {JobId} was active; using process exit code {ExitCode}.",
+                e.SessionId,
+                session.JobId,
+                e.ExitCode);
             session.Completion.TrySetResult(e.ExitCode);
         }
     }


### PR DESCRIPTION
## Summary
- fail queued jobs fast when the runner rejects execution start
- add explicit orchestration execution lifecycle logs for job start, terminal targeting, phase dispatch, marker completion, and terminal-exit fallback
- keep audit outcomes aligned with actual start success or failure

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #279