### PR TITLE
Fix project navigation and session reuse

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -186,18 +186,74 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
 
         var existingWorkspace = project.Workspaces.FirstOrDefault(workspace =>
             string.Equals(workspace.MachineId, machineId, StringComparison.OrdinalIgnoreCase));
-        var projectSession = projectSessions.CreateSession(
-            project.Id,
-            project.Name,
-            machine.MachineId,
-            machine.MachineName,
-            companionId);
+        var latestProjectSession = GetLatestProjectSession(projectSessions, project.Id, machine.MachineId);
+        if (latestProjectSession is not null &&
+            !string.IsNullOrWhiteSpace(latestProjectSession.CompanionId) &&
+            !string.Equals(latestProjectSession.CompanionId, companionId, StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.Conflict(new
+            {
+                message = $"Project '{project.Id}' on machine '{machine.MachineId}' is currently controlled by companion '{latestProjectSession.CompanionId}'. Take control of session '{latestProjectSession.Id}' before opening another live session on that machine."
+            });
+        }
+
+        var createdProjectSession = false;
+        var projectSession = latestProjectSession is not null
+            ? (!string.IsNullOrWhiteSpace(companionId)
+                ? projectSessions.AttachCompanion(latestProjectSession.Id, companionId, viewerOnly: false)
+                : latestProjectSession)
+            : projectSessions.CreateSession(
+                project.Id,
+                project.Name,
+                machine.MachineId,
+                machine.MachineName,
+                companionId);
+        createdProjectSession = latestProjectSession is null;
         OpenProjectOnRunnerResult? openedWorkspace = null;
         ProjectWorkspaceMapping? workspaceMapping = null;
         TerminalSession? session = null;
         try
         {
             var requestedWorkspacePath = existingWorkspace?.ProjectPath ?? BuildDefaultProjectWorkspacePath(project.Id);
+            var existingTerminalSurface = GetLatestProjectTerminalSurface(projectSession);
+            if (!string.IsNullOrWhiteSpace(existingTerminalSurface?.ReferenceId))
+            {
+                var existingSessions = await runners.GetSessionsAsync(machineId, cancellationToken);
+                session = existingSessions.FirstOrDefault(candidate =>
+                    string.Equals(candidate.Id, existingTerminalSurface.ReferenceId, StringComparison.OrdinalIgnoreCase));
+                if (session is not null)
+                {
+                    workspaceMapping = existingWorkspace ?? BuildWorkspaceMapping(machine, session.WorkingDirectory, isPrimary: false);
+                    var reusedProject = existingWorkspace is null
+                        ? projects.UpsertWorkspace(projectId, workspaceMapping)
+                        : project;
+
+                    if (!string.IsNullOrWhiteSpace(companionId))
+                    {
+                        companions.AttachSession(companionId, session.Id);
+                    }
+
+                    logger.LogInformation(
+                        "Reusing project session {ProjectSessionId} and terminal {TerminalSessionId} for project {ProjectId} on machine {MachineId}",
+                        projectSession.Id,
+                        session.Id,
+                        project.Id,
+                        machine.MachineId);
+
+                    return Results.Ok(new OpenProjectOnMachineResult
+                    {
+                        Project = reusedProject,
+                        ProjectSession = projectSession,
+                        Workspace = workspaceMapping,
+                        Session = session,
+                        BootstrapPending = existingTerminalSurface.Status == ProjectSessionSurfaceStatus.Requested,
+                        BootstrapMessage = existingTerminalSurface.StatusMessage,
+                        WorkspaceCreated = false,
+                        RepositoryCloned = false
+                    });
+                }
+            }
+
             logger.LogInformation(
                 "Opening project {ProjectId} ({ProjectName}) on machine {MachineId} ({MachineName}); existing workspace: {ExistingWorkspacePath}; companion: {CompanionId}; session: {ProjectSessionId}",
                 project.Id,
@@ -226,7 +282,10 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
                     "Runner returned no workspace while opening project {ProjectId} on machine {MachineId}",
                     project.Id,
                     machine.MachineId);
-                projectSessions.RemoveSession(projectSession.Id);
+                if (createdProjectSession)
+                {
+                    projectSessions.RemoveSession(projectSession.Id);
+                }
                 return Results.NotFound();
             }
 
@@ -260,6 +319,7 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
 
             session = await runners.CreateSessionAsync(machineId, new CreateTerminalRequest
             {
+                RequestedSessionId = existingTerminalSurface?.ReferenceId,
                 Name = $"{project.Name} ({machine.MachineName})",
                 WorkingDirectory = string.IsNullOrWhiteSpace(openedWorkspace.TerminalWorkingDirectory)
                     ? openedWorkspace.ProjectPath
@@ -328,7 +388,10 @@ app.MapPost("/api/projects/{projectId}/open/{machineId}", async (string projectI
                 projectSession.Id);
             try
             {
-                projectSessions.RemoveSession(projectSession.Id);
+                if (createdProjectSession)
+                {
+                    projectSessions.RemoveSession(projectSession.Id);
+                }
             }
             catch (Exception cleanupEx)
             {
@@ -925,6 +988,23 @@ static ProjectSessionRecord? GetLatestProjectSession(
         .OrderByDescending(session => session.UpdatedAt)
         .FirstOrDefault();
 }
+
+static ProjectSessionSurface? GetLatestProjectTerminalSurface(ProjectSessionRecord projectSession) =>
+    projectSession.Surfaces
+        .Where(surface =>
+            surface.Kind == ProjectSessionSurfaceKind.Terminal &&
+            !string.IsNullOrWhiteSpace(surface.ReferenceId))
+        .OrderByDescending(surface => surface.UpdatedAt)
+        .FirstOrDefault();
+
+static ProjectWorkspaceMapping BuildWorkspaceMapping(RegisteredRunnerMachine machine, string projectPath, bool isPrimary) =>
+    new()
+    {
+        MachineId = machine.MachineId,
+        MachineName = machine.MachineName,
+        ProjectPath = projectPath,
+        IsPrimary = isPrimary
+    };
 
 static OpenProjectOnRunnerResult BuildFallbackOpenProjectResult(
     RegisteredRunnerMachine machine,

--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -2,6 +2,7 @@
 @inject IRunnerConnectionManager Connections
 @inject ISessionStateService SessionState
 @inject IActiveSessionService ActiveSession
+@inject ICompanionDashboardStateService DashboardState
 @inject IConnectionSettingsService SettingsService
 @inject NavigationManager Nav
 @implements IDisposable
@@ -19,23 +20,36 @@
                 <span class="nav-label">Dashboard</span>
             </a>
 
-            @if (SessionState.Sessions.Count > 0)
+            <div class="nav-section-header">Project Links</div>
+            @foreach (var projectSession in GetProjectSessions())
             {
-                <div class="nav-section-header">Terminals</div>
-                @foreach (var session in SessionState.Sessions)
-                {
-                    <button class="nav-session @(ActiveSession.ActiveSessionId == session.Id ? "nav-session--active" : "")"
-                            @onclick="() => SelectSession(session.Id)">
-                        <span class="nav-session-dot nav-session-dot--@session.Status.ToString().ToLower()"></span>
-                        <span class="nav-session-name">
-                            @session.Name
-                            @if (!string.IsNullOrWhiteSpace(session.MachineName))
-                            {
-                                <span class="nav-session-machine">@session.MachineName</span>
-                            }
-                        </span>
-                    </button>
-                }
+                <button class="nav-session @(IsProjectSessionActive(projectSession.Id) ? "nav-session--active" : "")"
+                        @onclick="() => SelectProjectSession(projectSession.Id)">
+                    <span class="nav-session-dot nav-session-dot--project"></span>
+                    <span class="nav-session-name">
+                        @projectSession.ProjectName
+                        @if (!string.IsNullOrWhiteSpace(projectSession.MachineName))
+                        {
+                            <span class="nav-session-machine">@projectSession.MachineName</span>
+                        }
+                    </span>
+                </button>
+            }
+
+            <div class="nav-section-header">Terminal Links</div>
+            @foreach (var session in GetStandaloneSessions())
+            {
+                <button class="nav-session @(ActiveSession.ActiveSessionId == session.Id ? "nav-session--active" : "")"
+                        @onclick="() => SelectSession(session.Id)">
+                    <span class="nav-session-dot nav-session-dot--@session.Status.ToString().ToLower()"></span>
+                    <span class="nav-session-name">
+                        @session.Name
+                        @if (!string.IsNullOrWhiteSpace(session.MachineName))
+                        {
+                            <span class="nav-session-machine">@session.MachineName</span>
+                        }
+                    </span>
+                </button>
             }
 
             <button class="nav-new-terminal" @onclick="OpenNewTerminal">
@@ -117,10 +131,12 @@
     private bool SidebarOpen { get; set; } = true;
     private ErrorBoundary? _errorBoundary;
     private ConnectionSettings _settings = ConnectionSettings.CreateDefault();
+    private CompanionDashboardState _dashboard = new();
 
     protected override async Task OnInitializedAsync()
     {
         _settings = await SettingsService.LoadAsync();
+        await RefreshDashboardAsync();
         Connections.ConnectionStateChanged += OnConnectionStateChanged;
         SessionState.SessionsChanged += OnSessionsChanged;
         ActiveSession.StateChanged += OnActiveSessionChanged;
@@ -132,6 +148,9 @@
         ActiveSession.SetActiveSession(id);
         Nav.NavigateTo($"/terminals/{Uri.EscapeDataString(id)}");
     }
+
+    private void SelectProjectSession(string id) =>
+        Nav.NavigateTo($"/project-sessions/{Uri.EscapeDataString(id)}");
 
     private void OpenNewTerminal()
     {
@@ -156,18 +175,32 @@
     }
 
     private void OnConnectionStateChanged(object? sender, RunnerMachineConnectionChangedEventArgs e) =>
-        InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(RefreshDashboardAsync);
 
-    private void OnSessionsChanged(object? sender, EventArgs _) =>
-        InvokeAsync(StateHasChanged);
+    private void OnSessionsChanged(object? sender, EventArgs args) =>
+        _ = InvokeAsync(RefreshDashboardAsync);
 
-    private void OnActiveSessionChanged(object? sender, EventArgs _) =>
+    private void OnActiveSessionChanged(object? sender, EventArgs args) =>
         InvokeAsync(StateHasChanged);
 
     private void ToggleSidebar() => SidebarOpen = !SidebarOpen;
 
     private bool IsActive(string href) =>
         href == "/" ? Nav.Uri.EndsWith("/") || Nav.Uri.EndsWith("index") : Nav.Uri.Contains(href);
+
+    private bool IsProjectSessionActive(string projectSessionId)
+    {
+        var relativePath = Nav.ToBaseRelativePath(Nav.Uri);
+        return relativePath.StartsWith($"project-sessions/{projectSessionId}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IReadOnlyList<ProjectSessionRecord> GetProjectSessions() =>
+        _dashboard.ProjectSessions
+            .OrderByDescending(session => session.UpdatedAt)
+            .ToArray();
+
+    private IReadOnlyList<TerminalSession> GetStandaloneSessions() =>
+        SessionNavigation.GetStandaloneTerminalSessions(SessionState.Sessions, _dashboard.ProjectSessions);
 
     private string GetStatusClass() => Connections.ConnectedMachineCount switch
     {
@@ -191,6 +224,12 @@
         _errorBoundary?.Recover();
     }
 
+    private async Task RefreshDashboardAsync()
+    {
+        _dashboard = await DashboardState.BuildAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
     private void ReloadApp()
     {
         Nav.NavigateTo(Nav.Uri, forceLoad: true);
@@ -207,6 +246,6 @@
     private void OnSettingsChanged(object? sender, ConnectionSettings settings)
     {
         _settings = settings;
-        InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(RefreshDashboardAsync);
     }
 }

--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -60,4 +60,5 @@ public sealed class CompanionViewerSurfaceSummary
     public string Title { get; init; } = string.Empty;
     public string Description { get; init; } = string.Empty;
     public string Availability { get; init; } = string.Empty;
+    public string AvailabilityClass { get; init; } = "unsupported";
 }

--- a/AgentDeck.Core/Models/SessionNavigation.cs
+++ b/AgentDeck.Core/Models/SessionNavigation.cs
@@ -1,0 +1,40 @@
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Core.Models;
+
+public static class SessionNavigation
+{
+    public static IReadOnlyList<TerminalSession> GetStandaloneTerminalSessions(
+        IEnumerable<TerminalSession> sessions,
+        IEnumerable<ProjectSessionRecord> projectSessions)
+    {
+        var projectTerminalIds = GetProjectTerminalIds(projectSessions);
+        return sessions
+            .Where(session => !projectTerminalIds.Contains(session.Id))
+            .ToArray();
+    }
+
+    public static ProjectSessionRecord? GetProjectSessionForTerminal(
+        string terminalSessionId,
+        IEnumerable<ProjectSessionRecord> projectSessions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(terminalSessionId);
+
+        var normalizedTerminalSessionId = terminalSessionId.Trim();
+        return projectSessions
+            .OrderByDescending(session => session.UpdatedAt)
+            .FirstOrDefault(session => session.Surfaces.Any(surface =>
+                surface.Kind == ProjectSessionSurfaceKind.Terminal &&
+                string.Equals(surface.ReferenceId, normalizedTerminalSessionId, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static HashSet<string> GetProjectTerminalIds(IEnumerable<ProjectSessionRecord> projectSessions) =>
+        projectSessions
+            .SelectMany(session => session.Surfaces)
+            .Where(surface =>
+                surface.Kind == ProjectSessionSurfaceKind.Terminal &&
+                !string.IsNullOrWhiteSpace(surface.ReferenceId))
+            .Select(surface => surface.ReferenceId!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+}

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -9,7 +9,7 @@
     <div class="page-header workspace-dashboard__header">
         <div>
             <h1>Projects</h1>
-            <p>Track runner readiness, open projects on workers, and jump into live project sessions without mixing the dashboard with terminal-only views.</p>
+            <p>Track runner readiness, open projects on workers, and reopen live project sessions through Project Links without mixing them into standalone terminals.</p>
         </div>
     </div>
 
@@ -32,8 +32,8 @@
             </article>
             <article class="dashboard-summary-card">
                 <span class="dashboard-summary-card__label">Active terminals</span>
-                <strong>@SessionState.Sessions.Count</strong>
-                <span class="dashboard-summary-card__subtext">Visible through dedicated terminal pages</span>
+                <strong>@GetStandaloneTerminalCount()</strong>
+                <span class="dashboard-summary-card__subtext">Standalone sessions visible through dedicated terminal pages</span>
             </article>
         </section>
 
@@ -53,41 +53,6 @@
         }
         else
         {
-            <section class="dashboard-section-card">
-                <div class="dashboard-section-card__header">
-                    <div>
-                        <h2>Live project sessions</h2>
-                        <p>Project sessions become the shared surface container for terminals, VS Code, simulators, emulators, and future viewer tabs.</p>
-                    </div>
-                </div>
-
-                @if (_dashboard.ProjectSessions.Count == 0)
-                {
-                    <p>No live project sessions are registered yet.</p>
-                }
-                else
-                {
-                    <div class="project-session-grid">
-                        @foreach (var session in _dashboard.ProjectSessions.OrderByDescending(session => session.UpdatedAt))
-                        {
-                            <a class="project-session-card project-session-card--link" href="/project-sessions/@Uri.EscapeDataString(session.Id)">
-                                <div class="project-session-card__header">
-                                    <div>
-                                        <h3>@session.ProjectName</h3>
-                                        <p>@GetProjectSessionControllerLabel(session)</p>
-                                    </div>
-                                    <span class="machine-badge">@session.Surfaces.Count tabs</span>
-                                </div>
-                                <p class="project-session-card__meta">
-                                    @GetProjectSessionLocationLabel(session)
-                                    <span>• updated @session.UpdatedAt.ToLocalTime().ToString("g")</span>
-                                </p>
-                            </a>
-                        }
-                    </div>
-                }
-            </section>
-
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
@@ -216,7 +181,7 @@
                                         <div class="project-template-target">
                                             <div class="project-template-target__header">
                                                 <strong>@target.DisplayName</strong>
-                                                <span class="project-template-target__status">
+                                                <span class="project-template-target__status project-template-target__status--@GetTargetAvailabilityClass(target)">
                                                     @GetTargetAvailabilityLabel(target)
                                                 </span>
                                             </div>
@@ -247,14 +212,14 @@
 
                 <div class="viewer-surface-grid">
                     @foreach (var viewerSurface in _dashboard.ViewerSurfaces)
-                    {
-                        <article class="viewer-surface-card">
-                            <h3>@viewerSurface.Title</h3>
-                            <p>@viewerSurface.Description</p>
-                            <span class="viewer-surface-card__availability">@viewerSurface.Availability</span>
-                        </article>
-                    }
-                </div>
+                        {
+                            <article class="viewer-surface-card">
+                                <h3>@viewerSurface.Title</h3>
+                                <p>@viewerSurface.Description</p>
+                                <span class="viewer-surface-card__availability viewer-surface-card__availability--@viewerSurface.AvailabilityClass">@viewerSurface.Availability</span>
+                            </article>
+                        }
+                    </div>
             </section>
         }
     </div>
@@ -276,6 +241,9 @@
 
     private int GetProjectSessionCount(string projectId) =>
         _dashboard.ProjectSessions.Count(session => string.Equals(session.ProjectId, projectId, StringComparison.OrdinalIgnoreCase));
+
+    private int GetStandaloneTerminalCount() =>
+        SessionNavigation.GetStandaloneTerminalSessions(SessionState.Sessions, _dashboard.ProjectSessions).Count;
 
     private string GetProjectSessionControllerLabel(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.CompanionId)
@@ -425,6 +393,16 @@
         }
 
         return target.SetupRequiredMachineNames.Count > 0 ? "Needs setup" : "Unavailable";
+    }
+
+    private static string GetTargetAvailabilityClass(CompanionProjectTargetSummary target)
+    {
+        if (target.ReadyMachineNames.Count > 0)
+        {
+            return "supported";
+        }
+
+        return target.SetupRequiredMachineNames.Count > 0 ? "setup" : "unsupported";
     }
 
     private async Task RefreshDashboardAsync()

--- a/AgentDeck.Core/Pages/TerminalView.razor
+++ b/AgentDeck.Core/Pages/TerminalView.razor
@@ -1,4 +1,5 @@
 @page "/terminals/{SessionId}"
+@inject ICompanionDashboardStateService DashboardState
 @inject ISessionStateService SessionState
 @inject IActiveSessionService ActiveSession
 @inject IRunnerConnectionManager Connections
@@ -56,15 +57,30 @@
     [Parameter] public string SessionId { get; set; } = string.Empty;
 
     private TerminalSession? _session;
+    private IReadOnlyList<ProjectSessionRecord> _projectSessions = [];
     private string _quickCommand = string.Empty;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         SessionState.SessionsChanged += OnSessionsChanged;
+        await RefreshAsync();
     }
 
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
+        await RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        _projectSessions = (await DashboardState.BuildAsync()).ProjectSessions;
+        var projectSession = SessionNavigation.GetProjectSessionForTerminal(SessionId, _projectSessions);
+        if (projectSession is not null)
+        {
+            Nav.NavigateTo($"/project-sessions/{Uri.EscapeDataString(projectSession.Id)}");
+            return;
+        }
+
         _session = SessionState.Sessions.FirstOrDefault(session =>
             string.Equals(session.Id, SessionId, StringComparison.OrdinalIgnoreCase));
         if (_session is not null)
@@ -114,12 +130,8 @@
         await Connections.SendInputAsync(_session.Id, command + "\n");
     }
 
-    private void OnSessionsChanged(object? sender, EventArgs e)
-    {
-        _session = SessionState.Sessions.FirstOrDefault(session =>
-            string.Equals(session.Id, SessionId, StringComparison.OrdinalIgnoreCase));
-        InvokeAsync(StateHasChanged);
-    }
+    private void OnSessionsChanged(object? sender, EventArgs e) =>
+        _ = InvokeAsync(RefreshAsync);
 
     public void Dispose()
     {

--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -1,8 +1,10 @@
 @page "/terminals"
+@inject ICompanionDashboardStateService DashboardState
 @inject ISessionStateService SessionState
 @inject IActiveSessionService ActiveSession
 @inject IRunnerConnectionManager Connections
 @inject NavigationManager Nav
+@implements IDisposable
 
 <div class="mobile-terminals-page">
     <div class="mobile-terminals-page__header">
@@ -13,14 +15,18 @@
         <button class="btn btn-primary" @onclick="OpenNewTerminal">New</button>
     </div>
 
-    @if (SessionState.Sessions.Count == 0)
+    @if (GetStandaloneSessions().Count == 0)
     {
         <div class="mobile-page-placeholder">
             <div class="empty-state">
                 <div class="empty-icon">▣</div>
-                <h2>No active terminals</h2>
+                <h2>No standalone terminals</h2>
                 <p>
-                    @if (Connections.ConnectedMachineCount == 0)
+                    @if (SessionState.Sessions.Count > 0)
+                    {
+                        <span>Project-owned terminals stay inside their project pages. Use Project Links to reopen them.</span>
+                    }
+                    else if (Connections.ConnectedMachineCount == 0)
                     {
                         <span>Connect to a runner in <a href="/settings">Settings</a> to create a terminal.</span>
                     }
@@ -35,7 +41,7 @@
     else
     {
         <div class="mobile-session-list">
-            @foreach (var session in SessionState.Sessions)
+            @foreach (var session in GetStandaloneSessions())
             {
                 <button class="mobile-session-card @(IsActive(session.Id) ? "mobile-session-card--active" : "")"
                         @onclick="() => SelectSession(session.Id)">
@@ -63,6 +69,14 @@
 </div>
 
 @code {
+    private IReadOnlyList<ProjectSessionRecord> _projectSessions = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        SessionState.SessionsChanged += OnSessionsChanged;
+        await RefreshProjectSessionsAsync();
+    }
+
     private void OpenNewTerminal() => ActiveSession.OpenDialog();
 
     private void SelectSession(string sessionId)
@@ -73,14 +87,33 @@
 
     private bool IsActive(string sessionId) => string.Equals(ActiveSession.ActiveSessionId, sessionId, StringComparison.Ordinal);
 
+    private IReadOnlyList<TerminalSession> GetStandaloneSessions() =>
+        SessionNavigation.GetStandaloneTerminalSessions(SessionState.Sessions, _projectSessions);
+
     private string GetHeaderSubtitle()
     {
-        var count = SessionState.Sessions.Count;
+        var count = GetStandaloneSessions().Count;
         if (count == 0)
         {
-            return "Create and switch between active sessions.";
+            return SessionState.Sessions.Count > 0
+                ? "Project-owned terminals are available through Project Links."
+                : "Create and switch between active sessions.";
         }
 
         return count == 1 ? "1 active session" : $"{count} active sessions";
+    }
+
+    private void OnSessionsChanged(object? sender, EventArgs e) =>
+        _ = InvokeAsync(RefreshProjectSessionsAsync);
+
+    private async Task RefreshProjectSessionsAsync()
+    {
+        _projectSessions = (await DashboardState.BuildAsync()).ProjectSessions;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        SessionState.SessionsChanged -= OnSessionsChanged;
     }
 }

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -187,7 +187,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                             Description = $"{project.Definition.Name} can expose an Android emulator surface once orchestration is launched.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Ready on {string.Join(", ", target.ReadyMachineNames)}"
-                                : "No Android-ready machine discovered yet"
+                                : "No Android-ready machine discovered yet",
+                            AvailabilityClass = target.ReadyMachineNames.Count > 0 ? "supported" : "unsupported"
                         });
                 }
 
@@ -202,7 +203,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                             Description = $"{project.Definition.Name} can expose an Apple simulator surface once orchestration is launched.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Ready on {string.Join(", ", target.ReadyMachineNames)}"
-                                : "No Apple simulator-ready machine discovered yet"
+                                : "No Apple simulator-ready machine discovered yet",
+                            AvailabilityClass = target.ReadyMachineNames.Count > 0 ? "supported" : "unsupported"
                         });
                 }
 
@@ -217,7 +219,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                             Description = $"{project.Definition.Name} debug sessions are expected to expose a VS Code-backed viewer surface.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Debug-capable target ready on {string.Join(", ", target.ReadyMachineNames)}"
-                                : "No debug-capable machine discovered yet"
+                                : "No debug-capable machine discovered yet",
+                            AvailabilityClass = target.ReadyMachineNames.Count > 0 ? "supported" : "unsupported"
                         });
                 }
 
@@ -232,7 +235,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                             Description = $"Desktop/window viewer support for {project.Definition.Name} on {target.DisplayName} is modeled separately from terminals.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Potentially hostable on {string.Join(", ", target.ReadyMachineNames)}"
-                                : "No ready machine discovered yet"
+                                : "No ready machine discovered yet",
+                            AvailabilityClass = target.ReadyMachineNames.Count > 0 ? "setup" : "unsupported"
                         });
                 }
             }

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -159,6 +159,7 @@ main {
 .nav-session-dot--running  { background: var(--color-green); }
 .nav-session-dot--stopped  { background: var(--color-subtext); opacity: 0.5; }
 .nav-session-dot--error    { background: var(--color-red); }
+.nav-session-dot--project  { background: var(--color-accent); }
 
 .nav-session-name {
     display: flex;
@@ -564,20 +565,24 @@ main {
 }
 
 .project-target-chip--supported,
-.project-template-target__status {
+.project-template-target__status--supported,
+.viewer-surface-card__availability--supported {
     background: rgba(166,227,161,0.15);
     color: var(--color-green);
 }
 
-.project-target-chip--setup {
+.project-target-chip--setup,
+.project-template-target__status--setup,
+.viewer-surface-card__availability--setup {
     background: rgba(249,226,175,0.15);
     color: var(--color-yellow);
 }
 
 .project-target-chip--unsupported,
-.viewer-surface-card__availability {
-    background: rgba(166,173,200,0.15);
-    color: var(--color-subtext);
+.project-template-target__status--unsupported,
+.viewer-surface-card__availability--unsupported {
+    background: rgba(243,139,168,0.15);
+    color: var(--color-red);
 }
 
 .project-template-profile {


### PR DESCRIPTION
## Summary
- split the companion nav into project links and standalone terminal links
- reuse the latest project session and owned terminal when reopening the same project on the same machine
- remove the redundant dashboard live project sessions section and apply red/yellow availability styling

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #283