### PR TITLE
Fix viewer targeting and interaction UX

### DIFF
--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -496,7 +496,8 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
                 SessionId = request.Target.SessionId,
                 WindowTitle = request.Target.WindowTitle,
                 VirtualDeviceId = request.Target.VirtualDeviceId,
-                VirtualDeviceProfileId = request.Target.VirtualDeviceProfileId
+                VirtualDeviceProfileId = request.Target.VirtualDeviceProfileId,
+                KnownWindowTargetIds = request.Target.KnownWindowTargetIds.ToArray()
             }
         };
     }

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -44,6 +44,7 @@
             <div class="project-page__actions">
                 <button class="btn btn-accent" @onclick="NavigateBack">Back</button>
                 <button class="btn btn-accent" @onclick="RefreshAsync" disabled="@_busy">Refresh</button>
+                <button class="btn btn-accent" @onclick="ToggleFullscreenAsync" disabled="@_busy">Toggle fullscreen</button>
                 @if (CanOpenControlActions())
                 {
                     @if (IsCurrentViewerControlledByCurrentCompanion())
@@ -189,6 +190,7 @@
 
         _dotNetReference = DotNetObjectReference.Create(this);
         await ViewerInterop.AttachAsync(_viewerSurfaceId, _dotNetReference);
+        await ViewerInterop.FocusAsync(_viewerSurfaceId);
     }
 
     private async Task RefreshAsync()
@@ -282,6 +284,12 @@
     private void NavigateBack()
     {
         Nav.NavigateTo(string.IsNullOrWhiteSpace(ReturnUrl) ? "/" : ReturnUrl);
+    }
+
+    private async Task ToggleFullscreenAsync()
+    {
+        await RunBusyAsync(() => ViewerInterop.ToggleFullscreenAsync(_viewerSurfaceId));
+        await ViewerInterop.FocusAsync(_viewerSurfaceId);
     }
 
     private bool CanOpenControlActions() =>

--- a/AgentDeck.Core/Services/RemoteViewerInterop.cs
+++ b/AgentDeck.Core/Services/RemoteViewerInterop.cs
@@ -33,6 +33,12 @@ public sealed class RemoteViewerInterop : IAsyncDisposable
         await module.InvokeVoidAsync("focus", elementId);
     }
 
+    public async Task ToggleFullscreenAsync(string elementId)
+    {
+        var module = await _moduleTask.Value;
+        await module.InvokeVoidAsync("toggleFullscreen", elementId);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_moduleTask.IsValueCreated)

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -773,16 +773,24 @@ main {
     gap: 1rem;
 }
 
+.remote-viewer-page__surface-card {
+    max-width: 72rem;
+    width: 100%;
+    margin: 0 auto;
+}
+
 .remote-viewer-surface {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 24rem;
+    min-height: 18rem;
+    max-height: 60vh;
     border: 1px solid rgba(255,255,255,0.08);
     border-radius: 16px;
     background: #0e1320;
     overflow: hidden;
     outline: none;
+    touch-action: none;
 }
 
 .remote-viewer-surface--interactive {
@@ -799,6 +807,7 @@ main {
     height: auto;
     object-fit: contain;
     user-select: none;
+    pointer-events: none;
 }
 
 .viewer-placeholder {

--- a/AgentDeck.Core/wwwroot/js/viewerInterop.js
+++ b/AgentDeck.Core/wwwroot/js/viewerInterop.js
@@ -161,12 +161,13 @@ export function attach(elementId, dotNetReference) {
         moveTimer: null,
         pointerSendChain: Promise.resolve(),
         pressedButtons: [],
+        capturedPointerIds: [],
         wheelRemainderX: 0,
         wheelRemainderY: 0,
-        onMouseMove: null,
-        onDragMouseMove: null,
-        onMouseDown: null,
-        onMouseUp: null,
+        onPointerMove: null,
+        onDragPointerMove: null,
+        onPointerDown: null,
+        onPointerUp: null,
         onWheel: null,
         onContextMenu: null,
         onAuxClick: null,
@@ -187,9 +188,9 @@ export function attach(elementId, dotNetReference) {
         schedulePointerMove(elementId);
     };
 
-    const onMouseMove = event => queueMove(event);
+    const onPointerMove = event => queueMove(event);
 
-    const onDragMouseMove = event => {
+    const onDragPointerMove = event => {
         if (registration.pressedButtons.length === 0) {
             return;
         }
@@ -197,9 +198,19 @@ export function attach(elementId, dotNetReference) {
         queueMove(event);
     };
 
-    const onMouseDown = event => {
+    const onPointerDown = event => {
         element.focus();
         event.preventDefault();
+        if (typeof element.setPointerCapture === "function") {
+            try {
+                element.setPointerCapture(event.pointerId);
+                if (!registration.capturedPointerIds.includes(event.pointerId)) {
+                    registration.capturedPointerIds.push(event.pointerId);
+                }
+            } catch {
+            }
+        }
+
         const point = normalize(element, event);
         if (!point) {
             return;
@@ -211,8 +222,16 @@ export function attach(elementId, dotNetReference) {
         enqueuePointerEvent(registration, "down", point, button, getClickCount(event));
     };
 
-    const onMouseUp = event => {
+    const onPointerUp = event => {
         event.preventDefault();
+        if (typeof element.releasePointerCapture === "function") {
+            try {
+                element.releasePointerCapture(event.pointerId);
+                registration.capturedPointerIds = registration.capturedPointerIds.filter(pointerId => pointerId !== event.pointerId);
+            } catch {
+            }
+        }
+
         const point = normalize(element, event);
         if (!point) {
             return;
@@ -263,10 +282,10 @@ export function attach(elementId, dotNetReference) {
         event.preventDefault();
     };
 
-    registration.onMouseMove = onMouseMove;
-    registration.onDragMouseMove = onDragMouseMove;
-    registration.onMouseDown = onMouseDown;
-    registration.onMouseUp = onMouseUp;
+    registration.onPointerMove = onPointerMove;
+    registration.onDragPointerMove = onDragPointerMove;
+    registration.onPointerDown = onPointerDown;
+    registration.onPointerUp = onPointerUp;
     registration.onWheel = onWheel;
     registration.onContextMenu = preventDefault;
     registration.onAuxClick = preventDefault;
@@ -275,10 +294,10 @@ export function attach(elementId, dotNetReference) {
     registration.onKeyDown = onKeyDown;
     registration.onKeyUp = onKeyUp;
 
-    element.addEventListener("mousemove", onMouseMove);
-    element.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("mousemove", onDragMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
+    element.addEventListener("pointermove", onPointerMove);
+    element.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointermove", onDragPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
     element.addEventListener("wheel", onWheel, { passive: false });
     element.addEventListener("contextmenu", preventDefault);
     element.addEventListener("auxclick", preventDefault);
@@ -300,10 +319,22 @@ export function detach(elementId) {
         window.clearTimeout(existing.moveTimer);
     }
 
-    existing.element.removeEventListener("mousemove", existing.onMouseMove);
-    window.removeEventListener("mousemove", existing.onDragMouseMove);
-    existing.element.removeEventListener("mousedown", existing.onMouseDown);
-    window.removeEventListener("mouseup", existing.onMouseUp);
+    if (typeof existing.element.releasePointerCapture === "function") {
+        for (const pointerId of existing.capturedPointerIds) {
+            try {
+                existing.element.releasePointerCapture(pointerId);
+            } catch {
+            }
+        }
+    }
+
+    existing.capturedPointerIds = [];
+    existing.pressedButtons = [];
+
+    existing.element.removeEventListener("pointermove", existing.onPointerMove);
+    window.removeEventListener("pointermove", existing.onDragPointerMove);
+    existing.element.removeEventListener("pointerdown", existing.onPointerDown);
+    window.removeEventListener("pointerup", existing.onPointerUp);
     existing.element.removeEventListener("wheel", existing.onWheel);
     existing.element.removeEventListener("contextmenu", existing.onContextMenu);
     existing.element.removeEventListener("auxclick", existing.onAuxClick);
@@ -318,5 +349,26 @@ export function focus(elementId) {
     const element = document.getElementById(elementId);
     if (element) {
         element.focus();
+    }
+}
+
+export async function toggleFullscreen(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+        return;
+    }
+
+    if (document.fullscreenElement === element) {
+        await document.exitFullscreen();
+        return;
+    }
+
+    if (document.fullscreenElement && document.fullscreenElement !== element) {
+        await document.exitFullscreen();
+        return;
+    }
+
+    if (typeof element.requestFullscreen === "function") {
+        await element.requestFullscreen();
     }
 }

--- a/AgentDeck.Runner/Services/IManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/IManagedViewerRelayService.cs
@@ -5,6 +5,8 @@ namespace AgentDeck.Runner.Services;
 
 public interface IManagedViewerRelayService
 {
+    IReadOnlyList<CaptureTargetDescriptor> GetCaptureTargets();
+
     Task<ManagedViewerRelayBootstrapResult> StartAsync(
         RemoteViewerSession session,
         string connectionBaseUri,

--- a/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
@@ -110,6 +110,14 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
             $"{target.DisplayName} is ready via AgentDeck-managed relay transport.");
     }
 
+    public IReadOnlyList<CaptureTargetDescriptor> GetCaptureTargets()
+    {
+        lock (_captureSync)
+        {
+            return _capturePlatform.GetTargets();
+        }
+    }
+
     public async Task StopAsync(string sessionId, CancellationToken cancellationToken = default)
     {
         if (!_activeSessions.TryRemove(sessionId, out var activeSession))
@@ -318,10 +326,44 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
             return null;
         }
 
+        var baselineTargetIds = session.Target.KnownWindowTargetIds
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (baselineTargetIds.Count > 0)
+        {
+            var launchedCandidates = candidates
+                .Where(candidate => !baselineTargetIds.Contains(candidate.Id))
+                .ToArray();
+            var launchedMatch = TryMatchWindowTarget(launchedCandidates, session.Target);
+            if (launchedMatch is not null)
+            {
+                return launchedMatch;
+            }
+
+            if (launchedCandidates.Length == 1)
+            {
+                return launchedCandidates[0];
+            }
+
+            return null;
+        }
+
+        return TryMatchWindowTarget(candidates, session.Target);
+    }
+
+    private static CaptureTargetDescriptor? TryMatchWindowTarget(
+        IReadOnlyList<CaptureTargetDescriptor> candidates,
+        RemoteViewerTarget target)
+    {
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
         var exactKeys = new[]
         {
-            session.Target.WindowTitle,
-            session.Target.DisplayName
+            target.WindowTitle,
+            target.DisplayName
         }
         .Where(value => !string.IsNullOrWhiteSpace(value))
         .Select(value => value!.Trim())

--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
+using RdpPoc.Contracts;
 
 namespace AgentDeck.Runner.Services;
 
@@ -28,6 +29,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     private readonly IPtyProcessManager _ptyManager;
     private readonly IAgentSessionStore _sessionStore;
     private readonly IRemoteViewerSessionService _viewers;
+    private readonly IManagedViewerRelayService _managedViewerRelay;
     private readonly IDesktopViewerBootstrapService _viewerBootstrap;
     private readonly IVsCodeDebugSessionService _vsCodeDebug;
     private readonly IWorkspaceService _workspace;
@@ -41,6 +43,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         IPtyProcessManager ptyManager,
         IAgentSessionStore sessionStore,
         IRemoteViewerSessionService viewers,
+        IManagedViewerRelayService managedViewerRelay,
         IDesktopViewerBootstrapService viewerBootstrap,
         IVsCodeDebugSessionService vsCodeDebug,
         IWorkspaceService workspace,
@@ -50,6 +53,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         _ptyManager = ptyManager;
         _sessionStore = sessionStore;
         _viewers = viewers;
+        _managedViewerRelay = managedViewerRelay;
         _viewerBootstrap = viewerBootstrap;
         _vsCodeDebug = vsCodeDebug;
         _workspace = workspace;
@@ -422,12 +426,16 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             MachineId = job.TargetMachineId
         });
 
+        var knownWindowTargetIds = attachRuntimeViewer
+            ? CaptureKnownWindowTargetIds()
+            : [];
+
         try
         {
             await _ptyManager.WriteAsync(sessionId, BuildTerminalPhaseInput(command, completionMarker, processIdMarker));
             if (attachRuntimeViewer)
             {
-                await TryAttachRuntimeViewerAsync(job, sessionId);
+                await TryAttachRuntimeViewerAsync(job, sessionId, knownWindowTargetIds);
             }
 
             if (onBeforeWaitAsync is not null)
@@ -668,9 +676,9 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         return false;
     }
 
-    private async Task TryAttachRuntimeViewerAsync(OrchestrationJob job, string sessionId)
+    private async Task TryAttachRuntimeViewerAsync(OrchestrationJob job, string sessionId, IReadOnlyList<string> knownWindowTargetIds)
     {
-        if (!TryBuildRuntimeViewerRequest(job, sessionId, out var request, out var targetKind))
+        if (!TryBuildRuntimeViewerRequest(job, sessionId, knownWindowTargetIds, out var request, out var targetKind))
         {
             return;
         }
@@ -723,6 +731,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     private bool TryBuildRuntimeViewerRequest(
         OrchestrationJob job,
         string sessionId,
+        IReadOnlyList<string> knownWindowTargetIds,
         out CreateRemoteViewerSessionRequest request,
         out RemoteViewerTargetKind targetKind)
     {
@@ -746,7 +755,8 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
                     JobId = job.Id,
                     SessionId = sessionId,
                     VirtualDeviceId = job.DeviceSelection.DeviceId,
-                    VirtualDeviceProfileId = job.DeviceSelection.ProfileId
+                    VirtualDeviceProfileId = job.DeviceSelection.ProfileId,
+                    KnownWindowTargetIds = knownWindowTargetIds.ToArray()
                 }
             };
 
@@ -770,7 +780,8 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
                 DisplayName = $"{job.ProjectName} {job.LaunchProfileName}",
                 JobId = job.Id,
                 SessionId = sessionId,
-                WindowTitle = job.ProjectName
+                WindowTitle = job.ProjectName,
+                KnownWindowTargetIds = knownWindowTargetIds.ToArray()
             }
         };
 
@@ -816,6 +827,21 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             default:
                 targetKind = default;
                 return false;
+        }
+    }
+
+    private IReadOnlyList<string> CaptureKnownWindowTargetIds()
+    {
+        try
+        {
+            return _managedViewerRelay.GetCaptureTargets()
+                .Where(target => target.Kind == CaptureTargetKind.Window)
+                .Select(target => target.Id)
+                .ToArray();
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return [];
         }
     }
 

--- a/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
@@ -276,7 +276,8 @@ public sealed class RemoteViewerSessionService : IRemoteViewerSessionService
             SessionId = target.SessionId,
             WindowTitle = target.WindowTitle,
             VirtualDeviceId = target.VirtualDeviceId,
-            VirtualDeviceProfileId = target.VirtualDeviceProfileId
+            VirtualDeviceProfileId = target.VirtualDeviceProfileId,
+            KnownWindowTargetIds = target.KnownWindowTargetIds.ToArray()
         };
     }
 

--- a/AgentDeck.Shared/Models/RemoteViewerSession.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerSession.cs
@@ -26,7 +26,8 @@ public sealed class RemoteViewerSession
             SessionId = other.Target.SessionId,
             WindowTitle = other.Target.WindowTitle,
             VirtualDeviceId = other.Target.VirtualDeviceId,
-            VirtualDeviceProfileId = other.Target.VirtualDeviceProfileId
+            VirtualDeviceProfileId = other.Target.VirtualDeviceProfileId,
+            KnownWindowTargetIds = other.Target.KnownWindowTargetIds.ToArray()
         };
         Provider = other.Provider;
         Status = other.Status;

--- a/AgentDeck.Shared/Models/RemoteViewerTarget.cs
+++ b/AgentDeck.Shared/Models/RemoteViewerTarget.cs
@@ -12,4 +12,5 @@ public sealed class RemoteViewerTarget
     public string? WindowTitle { get; init; }
     public string? VirtualDeviceId { get; init; }
     public string? VirtualDeviceProfileId { get; init; }
+    public IReadOnlyList<string> KnownWindowTargetIds { get; init; } = [];
 }


### PR DESCRIPTION
## Summary
- carry launch-time window baselines into runtime viewer requests so managed viewers prefer newly launched surfaces over title-only guesses
- improve the in-app viewer with a smaller default presentation, fullscreen toggle, and automatic focus
- switch the in-app input layer to pointer events and clean up pointer capture correctly on detach

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #284