### PR TITLE
Fix project terminal persistence after viewer navigation

### DIFF
--- a/AgentDeck.Core/Components/TerminalPanel.razor
+++ b/AgentDeck.Core/Components/TerminalPanel.razor
@@ -1,5 +1,6 @@
 @inject TerminalInterop TerminalJs
 @inject IRunnerConnectionManager Connections
+@inject ISessionStateService SessionState
 @implements IAsyncDisposable
 
 <div class="terminal-panel @(IsActive ? "terminal-panel--active" : "")"
@@ -15,6 +16,10 @@
     private DotNetObjectReference<TerminalPanel>? _dotnetRef;
     private bool _initialised;
     private bool _wasActive;
+    private readonly Lock _outputLock = new();
+    private bool _hydratingOutput;
+    private long _lastOutputSequence;
+    private readonly List<TerminalOutputChunk> _pendingOutput = [];
 
     protected override void OnParametersSet()
     {
@@ -28,8 +33,25 @@
 
         _dotnetRef = DotNetObjectReference.Create(this);
         await TerminalJs.CreateTerminalAsync(_containerId, Session.Id, _dotnetRef);
+        lock (_outputLock)
+        {
+            _hydratingOutput = true;
+        }
+
+        SessionState.OutputAppended += OnOutputAppended;
+        var snapshot = SessionState.GetOutputSnapshot(Session.Id);
+        if (!string.IsNullOrEmpty(snapshot.Content))
+        {
+            await TerminalJs.WriteAsync(Session.Id, snapshot.Content);
+        }
+
+        lock (_outputLock)
+        {
+            _lastOutputSequence = snapshot.Sequence;
+        }
+
+        await FlushPendingOutputAsync();
         await Connections.JoinSessionAsync(Session.Id);
-        Connections.OutputReceived += OnOutputReceived;
 
         // Fit to the actual container dimensions and explicitly resize the PTY.
         // This is critical: the PTY starts at the CreateTerminalRequest default
@@ -71,14 +93,66 @@
         _wasActive = IsActive;
     }
 
-    private void OnOutputReceived(object? sender, TerminalOutput output)
+    private void OnOutputAppended(object? sender, TerminalOutputChunk output)
     {
         if (output.SessionId != Session.Id) return;
+
+        lock (_outputLock)
+        {
+            if (_hydratingOutput)
+            {
+                _pendingOutput.Add(output);
+                return;
+            }
+
+            if (output.Sequence <= _lastOutputSequence)
+            {
+                return;
+            }
+
+            _lastOutputSequence = output.Sequence;
+        }
         _ = InvokeAsync(async () =>
         {
             try { await TerminalJs.WriteAsync(Session.Id, output.Data); }
             catch { /* component disposed or JS interop unavailable */ }
         });
+    }
+
+    private async Task FlushPendingOutputAsync()
+    {
+        while (true)
+        {
+            TerminalOutputChunk? next = null;
+            lock (_outputLock)
+            {
+                if (_pendingOutput.Count == 0)
+                {
+                    _hydratingOutput = false;
+                    return;
+                }
+
+                var nextIndex = 0;
+                for (var index = 1; index < _pendingOutput.Count; index++)
+                {
+                    if (_pendingOutput[index].Sequence < _pendingOutput[nextIndex].Sequence)
+                    {
+                        nextIndex = index;
+                    }
+                }
+
+                next = _pendingOutput[nextIndex];
+                _pendingOutput.RemoveAt(nextIndex);
+                if (next.Sequence <= _lastOutputSequence)
+                {
+                    continue;
+                }
+
+                _lastOutputSequence = next.Sequence;
+            }
+
+            await TerminalJs.WriteAsync(Session.Id, next.Data);
+        }
     }
 
     /// <summary>Called from JS when the user types in the terminal.</summary>
@@ -97,12 +171,11 @@
 
     public async ValueTask DisposeAsync()
     {
-        Connections.OutputReceived -= OnOutputReceived;
+        SessionState.OutputAppended -= OnOutputAppended;
 
         if (_initialised)
         {
             await TerminalJs.UnregisterAutoFitAsync(Session.Id);
-            await Connections.LeaveSessionAsync(Session.Id);
             await TerminalJs.DisposeTerminalAsync(Session.Id);
         }
 

--- a/AgentDeck.Core/Services/AppInitializer.cs
+++ b/AgentDeck.Core/Services/AppInitializer.cs
@@ -35,6 +35,7 @@ public sealed class AppInitializer
             _sessionState.AddOrUpdate(s);
             _toast.Show($"Session '{s.Name}' started on {s.MachineName ?? "runner"}", ToastKind.Success);
         };
+        _connections.OutputReceived += (_, output) => _sessionState.AppendOutput(output);
         _connections.SessionUpdated += (_, s) => _sessionState.AddOrUpdate(s);
         _connections.SessionClosed += (_, id) =>
         {

--- a/AgentDeck.Core/Services/ISessionStateService.cs
+++ b/AgentDeck.Core/Services/ISessionStateService.cs
@@ -7,7 +7,23 @@ public interface ISessionStateService
 {
     IReadOnlyList<TerminalSession> Sessions { get; }
     event EventHandler? SessionsChanged;
+    event EventHandler<TerminalOutputChunk>? OutputAppended;
     void Sync(IReadOnlyList<TerminalSession> sessions);
     void AddOrUpdate(TerminalSession session);
     void Remove(string sessionId);
+    void AppendOutput(TerminalOutput output);
+    TerminalOutputSnapshot GetOutputSnapshot(string sessionId);
+}
+
+public sealed class TerminalOutputSnapshot
+{
+    public string Content { get; init; } = string.Empty;
+    public long Sequence { get; init; }
+}
+
+public sealed class TerminalOutputChunk
+{
+    public required string SessionId { get; init; }
+    public required string Data { get; init; }
+    public required long Sequence { get; init; }
 }

--- a/AgentDeck.Core/Services/RunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/RunnerConnectionManager.cs
@@ -14,6 +14,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
     private readonly Dictionary<string, RunnerMachineSettings> _machines = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _activeMachineIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _sessionMachineMap = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _joinedSessionIds = new(StringComparer.OrdinalIgnoreCase);
 
     public RunnerConnectionManager(
         IAgentDeckClient client,
@@ -39,6 +40,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
             lock (_lock)
             {
                 _sessionMachineMap.Remove(sessionId);
+                _joinedSessionIds.Remove(sessionId);
             }
 
             SessionClosed?.Invoke(this, sessionId);
@@ -50,7 +52,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
             lock (_lock)
             {
                 machineIds = _activeMachineIds.ToArray();
-                sessionIds = _sessionMachineMap.Keys.ToArray();
+                sessionIds = _joinedSessionIds.ToArray();
             }
 
             if (state == HubConnectionState.Connected)
@@ -160,6 +162,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
             foreach (var sessionId in orphanedSessions)
             {
                 _sessionMachineMap.Remove(sessionId);
+                _joinedSessionIds.Remove(sessionId);
             }
 
             shouldDisconnectCoordinator = _activeMachineIds.Count == 0;
@@ -186,13 +189,31 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
     public async Task JoinSessionAsync(string sessionId)
     {
         RequireSessionMachineId(sessionId);
-        await _client.JoinSessionAsync(sessionId);
+        var shouldJoin = false;
+        lock (_lock)
+        {
+            shouldJoin = _joinedSessionIds.Add(sessionId);
+        }
+
+        if (shouldJoin)
+        {
+            await _client.JoinSessionAsync(sessionId);
+        }
     }
 
     public async Task LeaveSessionAsync(string sessionId)
     {
         RequireSessionMachineId(sessionId);
-        await _client.LeaveSessionAsync(sessionId);
+        var shouldLeave = false;
+        lock (_lock)
+        {
+            shouldLeave = _joinedSessionIds.Remove(sessionId);
+        }
+
+        if (shouldLeave)
+        {
+            await _client.LeaveSessionAsync(sessionId);
+        }
     }
 
     public async Task SendInputAsync(string sessionId, string data)
@@ -263,6 +284,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
             _machines.Clear();
             _activeMachineIds.Clear();
             _sessionMachineMap.Clear();
+            _joinedSessionIds.Clear();
         }
 
         if (_client is IAsyncDisposable asyncDisposable)

--- a/AgentDeck.Core/Services/SessionStateService.cs
+++ b/AgentDeck.Core/Services/SessionStateService.cs
@@ -5,13 +5,23 @@ namespace AgentDeck.Core.Services;
 /// <inheritdoc />
 public sealed class SessionStateService : ISessionStateService
 {
+    private const int MaxBufferedCharacters = 262144;
+
+    private sealed class TerminalBufferState
+    {
+        public string Content { get; set; } = string.Empty;
+        public long Sequence { get; set; }
+    }
+
     private readonly Lock _lock = new();
     private readonly List<TerminalSession> _sessions = [];
+    private readonly Dictionary<string, TerminalBufferState> _buffers = new(StringComparer.OrdinalIgnoreCase);
 
     // Snapshot exposed to UI — replaced atomically under lock
     public IReadOnlyList<TerminalSession> Sessions { get; private set; } = [];
 
     public event EventHandler? SessionsChanged;
+    public event EventHandler<TerminalOutputChunk>? OutputAppended;
 
     public void Sync(IReadOnlyList<TerminalSession> sessions)
     {
@@ -20,6 +30,14 @@ public sealed class SessionStateService : ISessionStateService
             _sessions.Clear();
             _sessions.AddRange(sessions);
             Sessions = [.. _sessions];
+
+            var activeSessionIds = sessions
+                .Select(session => session.Id)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var sessionId in _buffers.Keys.Where(sessionId => !activeSessionIds.Contains(sessionId)).ToArray())
+            {
+                _buffers.Remove(sessionId);
+            }
         }
         SessionsChanged?.Invoke(this, EventArgs.Empty);
     }
@@ -42,8 +60,56 @@ public sealed class SessionStateService : ISessionStateService
         lock (_lock)
         {
             removed = _sessions.RemoveAll(s => s.Id == sessionId) > 0;
-            if (removed) Sessions = [.. _sessions];
+            _buffers.Remove(sessionId);
+            if (removed)
+            {
+                Sessions = [.. _sessions];
+            }
         }
         if (removed) SessionsChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    public void AppendOutput(TerminalOutput output)
+    {
+        TerminalOutputChunk? chunk = null;
+
+        lock (_lock)
+        {
+            if (!_buffers.TryGetValue(output.SessionId, out var buffer))
+            {
+                buffer = new TerminalBufferState();
+                _buffers[output.SessionId] = buffer;
+            }
+
+            buffer.Sequence++;
+            buffer.Content = TruncateBuffer(buffer.Content + output.Data);
+            chunk = new TerminalOutputChunk
+            {
+                SessionId = output.SessionId,
+                Data = output.Data,
+                Sequence = buffer.Sequence
+            };
+        }
+
+        OutputAppended?.Invoke(this, chunk);
+    }
+
+    public TerminalOutputSnapshot GetOutputSnapshot(string sessionId)
+    {
+        lock (_lock)
+        {
+            return _buffers.TryGetValue(sessionId, out var buffer)
+                ? new TerminalOutputSnapshot
+                {
+                    Content = buffer.Content,
+                    Sequence = buffer.Sequence
+                }
+                : new TerminalOutputSnapshot();
+        }
+    }
+
+    private static string TruncateBuffer(string content) =>
+        content.Length <= MaxBufferedCharacters
+            ? content
+            : content[^MaxBufferedCharacters..];
 }


### PR DESCRIPTION
## Summary\n- buffer terminal output in companion session state so project terminals rehydrate after navigation\n- keep joined terminal subscriptions alive across viewer/project page switches to avoid blank or dead terminals on return\n- clean up joined-session tracking when sessions close\n\n## Testing\n- dotnet build AgentDeck.slnx -c Release\n\nCloses #288