### PR TITLE
Fix viewer input targeting and fullscreen layout

### DIFF
--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -78,7 +78,7 @@
                      tabindex="0">
                     @if (!string.IsNullOrWhiteSpace(ViewerClient.CurrentFrameDataUrl))
                     {
-                        <img src="@ViewerClient.CurrentFrameDataUrl" alt="Remote frame" draggable="false" />
+                        <img class="remote-viewer-surface__frame" src="@ViewerClient.CurrentFrameDataUrl" alt="Remote frame" draggable="false" />
                     }
                     else
                     {

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -598,11 +598,6 @@ main {
     border-top: 1px solid rgba(255,255,255,0.06);
 }
 
-.project-template-target:first-child {
-    border-top: none;
-    padding-top: 0;
-}
-
 .project-template-target__note {
     color: var(--color-subtext);
     font-size: 0.8rem;
@@ -785,6 +780,8 @@ main {
     justify-content: center;
     min-height: 18rem;
     max-height: 60vh;
+    width: fit-content;
+    max-width: 100%;
     border: 1px solid rgba(255,255,255,0.08);
     border-radius: 16px;
     background: #0e1320;
@@ -801,13 +798,32 @@ main {
     cursor: default;
 }
 
-.remote-viewer-surface img {
+.remote-viewer-surface__frame {
     display: block;
-    width: 100%;
+    width: auto;
     height: auto;
+    max-width: 100%;
+    max-height: 60vh;
     object-fit: contain;
     user-select: none;
     pointer-events: none;
+}
+
+.remote-viewer-surface:fullscreen {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    margin: 0 auto;
+    border-radius: 0;
+    border: none;
+}
+
+.remote-viewer-surface:fullscreen .remote-viewer-surface__frame {
+    width: auto;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
 }
 
 .viewer-placeholder {

--- a/AgentDeck.Core/wwwroot/js/viewerInterop.js
+++ b/AgentDeck.Core/wwwroot/js/viewerInterop.js
@@ -8,8 +8,17 @@ function clamp(value) {
 }
 
 function normalize(element, event) {
-    const rect = element.getBoundingClientRect();
+    const frame = getInteractiveFrameElement(element);
+    const rect = (frame ?? element).getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) {
+        return null;
+    }
+
+    if (frame
+        && (event.clientX < rect.left
+            || event.clientX > rect.right
+            || event.clientY < rect.top
+            || event.clientY > rect.bottom)) {
         return null;
     }
 
@@ -17,6 +26,17 @@ function normalize(element, event) {
         x: clamp((event.clientX - rect.left) / rect.width),
         y: clamp((event.clientY - rect.top) / rect.height)
     };
+}
+
+function getInteractiveFrameElement(element) {
+    const frame = element.querySelector(".remote-viewer-surface__frame");
+    if (!frame) {
+        return null;
+    }
+
+    return frame.clientWidth > 0 && frame.clientHeight > 0
+        ? frame
+        : null;
 }
 
 function buttonName(button) {


### PR DESCRIPTION
## Summary\n- normalize remote viewer pointer input against the rendered frame instead of the padded surface container\n- update fullscreen layout so the frame stays centered with height-first sizing on desktop\n- remove the obsolete .project-template-target:first-child CSS rule\n\n## Testing\n- dotnet build AgentDeck.slnx -c Release\n\nCloses #289