### PR TITLE
Align viewer input gating with relay control

### DIFF
--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -55,7 +55,7 @@
                     {
                         <button class="btn btn-danger" @onclick="ForceTakeoverAsync" disabled="@_busy">Force take over</button>
                     }
-                    else if (!ViewerClient.CanSendInput)
+                    else if (ViewerClient.CanTakeControlCurrentViewer)
                     {
                         <button class="btn btn-accent" @onclick="TakeControlAsync" disabled="@_busy">Take control</button>
                     }
@@ -356,7 +356,7 @@
 
         var activeTarget = state.TargetDisplayName ?? state.TargetKind.ToString();
         return IsCurrentRemoteController(state)
-            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote target."
+            ? $"You currently control {activeTarget} on this machine. Input here is allowed, and Take control will switch the active remote target."
             : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this viewer requires force takeover.";
     }
 

--- a/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
+++ b/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
@@ -62,7 +62,20 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
             var remoteControlState = RemoteControlState;
             return currentSession?.Status == RemoteViewerSessionStatus.Ready &&
                    currentSession.Provider == RemoteViewerProviderKind.Managed &&
-                   (remoteControlState is null || IsCurrentCompanionController(remoteControlState, currentSession.Id));
+                   (remoteControlState is null || IsCurrentCompanionMachineController(remoteControlState));
+        }
+    }
+
+    public bool CanTakeControlCurrentViewer
+    {
+        get
+        {
+            var currentSession = CurrentSession;
+            var remoteControlState = RemoteControlState;
+            return currentSession is not null &&
+                   remoteControlState is not null &&
+                   IsCurrentCompanionMachineController(remoteControlState) &&
+                   !string.Equals(remoteControlState.ViewerSessionId, currentSession.Id, StringComparison.OrdinalIgnoreCase);
         }
     }
 
@@ -483,10 +496,9 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
         await sourceConnection.InvokeAsync(nameof(ICoordinatorViewerHub.JoinViewerSessionAsync), machineId, viewerSessionId);
     }
 
-    private bool IsCurrentCompanionController(MachineRemoteControlState remoteControlState, string viewerSessionId) =>
+    private bool IsCurrentCompanionMachineController(MachineRemoteControlState remoteControlState) =>
         !string.IsNullOrWhiteSpace(_agentClient.CompanionId) &&
-        string.Equals(remoteControlState.ControllerCompanionId, _agentClient.CompanionId, StringComparison.OrdinalIgnoreCase) &&
-        string.Equals(remoteControlState.ViewerSessionId, viewerSessionId, StringComparison.OrdinalIgnoreCase);
+        string.Equals(remoteControlState.ControllerCompanionId, _agentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
 
     private void NotifyChanged() => Changed?.Invoke();
 }


### PR DESCRIPTION
## Summary
- align the in-app viewer client's input gating with the effective coordinator and RdpPoc relay policy
- stop silently dropping pointer and keyboard input when the same companion already controls another viewer session on the same machine
- keep explicit Take control UI only for switching the active remote target

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #294