### PR TITLE
Add end-to-end viewer input logging

### DIFF
--- a/AgentDeck.Coordinator/Hubs/CoordinatorViewerHub.cs
+++ b/AgentDeck.Coordinator/Hubs/CoordinatorViewerHub.cs
@@ -11,15 +11,18 @@ public sealed class CoordinatorViewerHub : Hub<IViewerHubClient>, ICoordinatorVi
     private readonly ICompanionRegistryService _companions;
     private readonly IMachineRemoteControlRegistryService _remoteControl;
     private readonly RunnerBrokerService _runners;
+    private readonly ILogger<CoordinatorViewerHub> _logger;
 
     public CoordinatorViewerHub(
         ICompanionRegistryService companions,
         IMachineRemoteControlRegistryService remoteControl,
-        RunnerBrokerService runners)
+        RunnerBrokerService runners,
+        ILogger<CoordinatorViewerHub> logger)
     {
         _companions = companions;
         _remoteControl = remoteControl;
         _runners = runners;
+        _logger = logger;
     }
 
     public override Task OnConnectedAsync()
@@ -67,6 +70,18 @@ public sealed class CoordinatorViewerHub : Hub<IViewerHubClient>, ICoordinatorVi
     {
         var companionId = RequireCompanionId();
         EnsureControlAllowed(machineId, viewerSessionId, companionId);
+        _logger.LogInformation(
+            "Coordinator received viewer pointer input from companion {CompanionId} for machine {MachineId} viewer {ViewerSessionId}: {EventType} x={X:F3} y={Y:F3} button={Button} clicks={ClickCount} wheel=({WheelDeltaX},{WheelDeltaY})",
+            companionId,
+            machineId,
+            viewerSessionId,
+            input.EventType,
+            input.X,
+            input.Y,
+            input.Button ?? "<none>",
+            input.ClickCount,
+            input.WheelDeltaX,
+            input.WheelDeltaY);
         return _runners.SendViewerPointerInputAsync(machineId, viewerSessionId, companionId, input, Context.ConnectionAborted);
     }
 
@@ -74,6 +89,16 @@ public sealed class CoordinatorViewerHub : Hub<IViewerHubClient>, ICoordinatorVi
     {
         var companionId = RequireCompanionId();
         EnsureControlAllowed(machineId, viewerSessionId, companionId);
+        _logger.LogInformation(
+            "Coordinator received viewer keyboard input from companion {CompanionId} for machine {MachineId} viewer {ViewerSessionId}: {EventType} {Code} alt={Alt} ctrl={Control} shift={Shift}",
+            companionId,
+            machineId,
+            viewerSessionId,
+            input.EventType,
+            input.Code,
+            input.Alt,
+            input.Control,
+            input.Shift);
         return _runners.SendViewerKeyboardInputAsync(machineId, viewerSessionId, companionId, input, Context.ConnectionAborted);
     }
 

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -384,12 +384,34 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
     public async Task SendViewerPointerInputAsync(string machineId, string viewerSessionId, string actorId, RemoteViewerPointerInputEvent input, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Coordinator forwarding viewer pointer input for machine {MachineId} viewer {ViewerSessionId} from actor {ActorId}: {EventType} x={X:F3} y={Y:F3} button={Button} clicks={ClickCount} wheel=({WheelDeltaX},{WheelDeltaY})",
+            machineId,
+            viewerSessionId,
+            actorId,
+            input.EventType,
+            input.X,
+            input.Y,
+            input.Button ?? "<none>",
+            input.ClickCount,
+            input.WheelDeltaX,
+            input.WheelDeltaY);
         await InvokeRunnerAsync(entry, "send viewer pointer input", client => client.SendViewerPointerInputAsync(viewerSessionId, NormalizeActorId(actorId), input), retryOnReconnect: false, cancellationToken);
     }
 
     public async Task SendViewerKeyboardInputAsync(string machineId, string viewerSessionId, string actorId, RemoteViewerKeyboardInputEvent input, CancellationToken cancellationToken = default)
     {
         var entry = await EnsureEntryAsync(machineId, cancellationToken);
+        _logger.LogInformation(
+            "Coordinator forwarding viewer keyboard input for machine {MachineId} viewer {ViewerSessionId} from actor {ActorId}: {EventType} {Code} alt={Alt} ctrl={Control} shift={Shift}",
+            machineId,
+            viewerSessionId,
+            actorId,
+            input.EventType,
+            input.Code,
+            input.Alt,
+            input.Control,
+            input.Shift);
         await InvokeRunnerAsync(entry, "send viewer keyboard input", client => client.SendViewerKeyboardInputAsync(viewerSessionId, NormalizeActorId(actorId), input), retryOnReconnect: false, cancellationToken);
     }
 

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -129,6 +129,10 @@
                         <dt>Input</dt>
                         <dd>@(ViewerClient.CanSendInput ? "Interactive" : "View-only")</dd>
                     </div>
+                    <div>
+                        <dt>Last input</dt>
+                        <dd>@(ViewerClient.LastInputActivity ?? "No input dispatched yet.")</dd>
+                    </div>
                 </dl>
                 @if (!ViewerClient.SupportsInAppViewer)
                 {

--- a/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
+++ b/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
@@ -2,25 +2,32 @@ using AgentDeck.Shared.Hubs;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
 
 namespace AgentDeck.Core.Services;
 
 public sealed class RemoteViewerRelayClient : IAsyncDisposable
 {
     private readonly SemaphoreSlim _sync = new(1, 1);
+    private readonly Lock _inputActivityLock = new();
     private readonly ICoordinatorApiClient _coordinatorClient;
     private readonly IAgentDeckClient _agentClient;
+    private readonly ILogger<RemoteViewerRelayClient> _logger;
     private HubConnection? _connection;
     private string? _coordinatorUrl;
     private string? _machineId;
     private string? _viewerSessionId;
+    private DateTimeOffset _lastVisibleInputActivityAt;
+    private string? _lastInputActivity;
 
     public RemoteViewerRelayClient(
         ICoordinatorApiClient coordinatorClient,
-        IAgentDeckClient agentClient)
+        IAgentDeckClient agentClient,
+        ILogger<RemoteViewerRelayClient> logger)
     {
         _coordinatorClient = coordinatorClient;
         _agentClient = agentClient;
+        _logger = logger;
     }
 
     public event Action? Changed;
@@ -32,6 +39,17 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
     public string? CurrentFrameDataUrl { get; private set; }
 
     public string StatusMessage { get; private set; } = "Idle";
+
+    public string? LastInputActivity
+    {
+        get
+        {
+            lock (_inputActivityLock)
+            {
+                return _lastInputActivity;
+            }
+        }
+    }
 
     public bool IsWatching
     {
@@ -185,6 +203,12 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
             _sync.Release();
         }
 
+        lock (_inputActivityLock)
+        {
+            _lastInputActivity = null;
+            _lastVisibleInputActivityAt = default;
+        }
+
         NotifyChanged();
     }
 
@@ -220,9 +244,18 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
             string.IsNullOrWhiteSpace(machineId) ||
             string.IsNullOrWhiteSpace(sessionId))
         {
+            RecordInputActivity(
+                $"Blocked pointer {FormatPointerSummary(eventType, x, y, button, clickCount, wheelDeltaX, wheelDeltaY)} "
+                + $"(canSendInput={canSendInput}, connected={connection is not null}, machine={machineId ?? "<none>"}, session={sessionId ?? "<none>"})",
+                LogLevel.Warning,
+                forceVisible: !string.Equals(eventType, "move", StringComparison.OrdinalIgnoreCase));
             return;
         }
 
+        RecordInputActivity(
+            $"Dispatching pointer {FormatPointerSummary(eventType, x, y, button, clickCount, wheelDeltaX, wheelDeltaY)} to {machineId}/{sessionId}",
+            LogLevel.Information,
+            forceVisible: !string.Equals(eventType, "move", StringComparison.OrdinalIgnoreCase));
         await connection.InvokeAsync(
             nameof(ICoordinatorViewerHub.SendViewerPointerInputAsync),
             machineId,
@@ -255,9 +288,18 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
             string.IsNullOrWhiteSpace(machineId) ||
             string.IsNullOrWhiteSpace(sessionId))
         {
+            RecordInputActivity(
+                $"Blocked keyboard {FormatKeyboardSummary(eventType, code, alt, control, shift)} "
+                + $"(canSendInput={canSendInput}, connected={connection is not null}, machine={machineId ?? "<none>"}, session={sessionId ?? "<none>"})",
+                LogLevel.Warning,
+                forceVisible: true);
             return;
         }
 
+        RecordInputActivity(
+            $"Dispatching keyboard {FormatKeyboardSummary(eventType, code, alt, control, shift)} to {machineId}/{sessionId}",
+            LogLevel.Information,
+            forceVisible: true);
         await connection.InvokeAsync(
             nameof(ICoordinatorViewerHub.SendViewerKeyboardInputAsync),
             machineId,
@@ -499,6 +541,46 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
     private bool IsCurrentCompanionMachineController(MachineRemoteControlState remoteControlState) =>
         !string.IsNullOrWhiteSpace(_agentClient.CompanionId) &&
         string.Equals(remoteControlState.ControllerCompanionId, _agentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
+
+    private void RecordInputActivity(string message, LogLevel level, bool forceVisible)
+    {
+        var now = DateTimeOffset.Now;
+        var activity = $"[{now:HH:mm:ss.fff}] {message}";
+        var shouldNotify = false;
+        lock (_inputActivityLock)
+        {
+            _lastInputActivity = activity;
+            if (forceVisible || now - _lastVisibleInputActivityAt >= TimeSpan.FromMilliseconds(250))
+            {
+                _lastVisibleInputActivityAt = now;
+                shouldNotify = true;
+            }
+        }
+
+        switch (level)
+        {
+            case LogLevel.Warning:
+                _logger.LogWarning("{Message}", activity);
+                break;
+            case LogLevel.Error:
+                _logger.LogError("{Message}", activity);
+                break;
+            default:
+                _logger.LogInformation("{Message}", activity);
+                break;
+        }
+
+        if (shouldNotify)
+        {
+            NotifyChanged();
+        }
+    }
+
+    private static string FormatPointerSummary(string eventType, double x, double y, string? button, int clickCount, int wheelDeltaX, int wheelDeltaY) =>
+        $"{eventType} x={x:F3} y={y:F3} button={button ?? "<none>"} clicks={clickCount} wheel=({wheelDeltaX},{wheelDeltaY})";
+
+    private static string FormatKeyboardSummary(string eventType, string code, bool alt, bool control, bool shift) =>
+        $"{eventType} code={code} modifiers=[alt:{alt},ctrl:{control},shift:{shift}]";
 
     private void NotifyChanged() => Changed?.Invoke();
 }

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -595,6 +595,18 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
             throw new InvalidOperationException($"Viewer session '{viewerSessionId}' is not backed by the managed relay.");
         }
 
+        _logger.LogInformation(
+            "Runner received viewer pointer input from coordinator for viewer {ViewerSessionId} actor {ActorId}: {EventType} x={X:F3} y={Y:F3} button={Button} clicks={ClickCount} wheel=({WheelDeltaX},{WheelDeltaY})",
+            viewerSessionId,
+            actorId,
+            input.EventType,
+            input.X,
+            input.Y,
+            input.Button ?? "<none>",
+            input.ClickCount,
+            input.WheelDeltaX,
+            input.WheelDeltaY);
+
         await _managedViewerRelay.SendPointerInputAsync(
             viewerSessionId,
             new PointerInputEvent(viewerSessionId, input.EventType, input.X, input.Y, input.Button, input.ClickCount, input.WheelDeltaX, input.WheelDeltaY));
@@ -608,6 +620,16 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         {
             throw new InvalidOperationException($"Viewer session '{viewerSessionId}' is not backed by the managed relay.");
         }
+
+        _logger.LogInformation(
+            "Runner received viewer keyboard input from coordinator for viewer {ViewerSessionId} actor {ActorId}: {EventType} {Code} alt={Alt} ctrl={Control} shift={Shift}",
+            viewerSessionId,
+            actorId,
+            input.EventType,
+            input.Code,
+            input.Alt,
+            input.Control,
+            input.Shift);
 
         await _managedViewerRelay.SendKeyboardInputAsync(
             viewerSessionId,

--- a/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
@@ -181,16 +181,39 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     {
         var activeSession = GetActiveSession(sessionId);
 
-        await Task.Run(() =>
+        _logger.LogInformation(
+            "Managed relay injecting pointer input for viewer {SessionId} target {TargetKind}:{TargetId} ({TargetDisplayName}): {EventType} x={X:F3} y={Y:F3} button={Button} clicks={ClickCount} wheel=({WheelDeltaX},{WheelDeltaY})",
+            sessionId,
+            activeSession.Assignment.TargetKind,
+            activeSession.Assignment.TargetId,
+            activeSession.Assignment.TargetDisplayName,
+            input.EventType,
+            input.X,
+            input.Y,
+            input.Button ?? "<none>",
+            input.ClickCount,
+            input.WheelDeltaX,
+            input.WheelDeltaY);
+
+        try
         {
-            lock (activeSession.InputSync)
+            await Task.Run(() =>
             {
-                lock (_captureSync)
+                lock (activeSession.InputSync)
                 {
-                    _capturePlatform.HandlePointerInput(activeSession.Assignment, input);
+                    lock (_captureSync)
+                    {
+                        _capturePlatform.HandlePointerInput(activeSession.Assignment, input);
+                    }
                 }
-            }
-        }, cancellationToken);
+            }, cancellationToken);
+            _logger.LogInformation("Managed relay completed pointer input for viewer {SessionId}", sessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Managed relay pointer input failed for viewer {SessionId}", sessionId);
+            throw;
+        }
     }
 
     public async Task SendKeyboardInputAsync(
@@ -200,19 +223,40 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     {
         var activeSession = GetActiveSession(sessionId);
 
-        await Task.Run(() =>
+        _logger.LogInformation(
+            "Managed relay injecting keyboard input for viewer {SessionId} target {TargetKind}:{TargetId} ({TargetDisplayName}): {EventType} {Code} alt={Alt} ctrl={Control} shift={Shift}",
+            sessionId,
+            activeSession.Assignment.TargetKind,
+            activeSession.Assignment.TargetId,
+            activeSession.Assignment.TargetDisplayName,
+            input.EventType,
+            input.Code,
+            input.Alt,
+            input.Control,
+            input.Shift);
+
+        try
         {
-            lock (activeSession.InputSync)
+            await Task.Run(() =>
             {
-                lock (_captureSync)
+                lock (activeSession.InputSync)
                 {
-                    activeSession.ModifierState = _capturePlatform.HandleKeyboardInput(
-                        activeSession.Assignment,
-                        input,
-                        activeSession.ModifierState);
+                    lock (_captureSync)
+                    {
+                        activeSession.ModifierState = _capturePlatform.HandleKeyboardInput(
+                            activeSession.Assignment,
+                            input,
+                            activeSession.ModifierState);
+                    }
                 }
-            }
-        }, cancellationToken);
+            }, cancellationToken);
+            _logger.LogInformation("Managed relay completed keyboard input for viewer {SessionId}", sessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Managed relay keyboard input failed for viewer {SessionId}", sessionId);
+            throw;
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- log viewer pointer and keyboard input from companion dispatch through coordinator receipt/forwarding, runner receipt, and managed relay injection
- surface the last dispatched input in the companion viewer page so silent drops are visible immediately
- keep logging additive so viewer control behavior stays unchanged while tracing the path

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #296