### PR TITLE
Restore viewer mouse event bridge

### DIFF
--- a/AgentDeck.Core/wwwroot/js/viewerInterop.js
+++ b/AgentDeck.Core/wwwroot/js/viewerInterop.js
@@ -181,13 +181,12 @@ export function attach(elementId, dotNetReference) {
         moveTimer: null,
         pointerSendChain: Promise.resolve(),
         pressedButtons: [],
-        capturedPointerIds: [],
         wheelRemainderX: 0,
         wheelRemainderY: 0,
-        onPointerMove: null,
-        onDragPointerMove: null,
-        onPointerDown: null,
-        onPointerUp: null,
+        onMouseMove: null,
+        onDragMouseMove: null,
+        onMouseDown: null,
+        onMouseUp: null,
         onWheel: null,
         onContextMenu: null,
         onAuxClick: null,
@@ -208,9 +207,9 @@ export function attach(elementId, dotNetReference) {
         schedulePointerMove(elementId);
     };
 
-    const onPointerMove = event => queueMove(event);
+    const onMouseMove = event => queueMove(event);
 
-    const onDragPointerMove = event => {
+    const onDragMouseMove = event => {
         if (registration.pressedButtons.length === 0) {
             return;
         }
@@ -218,19 +217,9 @@ export function attach(elementId, dotNetReference) {
         queueMove(event);
     };
 
-    const onPointerDown = event => {
+    const onMouseDown = event => {
         element.focus();
         event.preventDefault();
-        if (typeof element.setPointerCapture === "function") {
-            try {
-                element.setPointerCapture(event.pointerId);
-                if (!registration.capturedPointerIds.includes(event.pointerId)) {
-                    registration.capturedPointerIds.push(event.pointerId);
-                }
-            } catch {
-            }
-        }
-
         const point = normalize(element, event);
         if (!point) {
             return;
@@ -242,16 +231,8 @@ export function attach(elementId, dotNetReference) {
         enqueuePointerEvent(registration, "down", point, button, getClickCount(event));
     };
 
-    const onPointerUp = event => {
+    const onMouseUp = event => {
         event.preventDefault();
-        if (typeof element.releasePointerCapture === "function") {
-            try {
-                element.releasePointerCapture(event.pointerId);
-                registration.capturedPointerIds = registration.capturedPointerIds.filter(pointerId => pointerId !== event.pointerId);
-            } catch {
-            }
-        }
-
         const point = normalize(element, event);
         if (!point) {
             return;
@@ -302,10 +283,10 @@ export function attach(elementId, dotNetReference) {
         event.preventDefault();
     };
 
-    registration.onPointerMove = onPointerMove;
-    registration.onDragPointerMove = onDragPointerMove;
-    registration.onPointerDown = onPointerDown;
-    registration.onPointerUp = onPointerUp;
+    registration.onMouseMove = onMouseMove;
+    registration.onDragMouseMove = onDragMouseMove;
+    registration.onMouseDown = onMouseDown;
+    registration.onMouseUp = onMouseUp;
     registration.onWheel = onWheel;
     registration.onContextMenu = preventDefault;
     registration.onAuxClick = preventDefault;
@@ -314,10 +295,10 @@ export function attach(elementId, dotNetReference) {
     registration.onKeyDown = onKeyDown;
     registration.onKeyUp = onKeyUp;
 
-    element.addEventListener("pointermove", onPointerMove);
-    element.addEventListener("pointerdown", onPointerDown);
-    window.addEventListener("pointermove", onDragPointerMove);
-    window.addEventListener("pointerup", onPointerUp);
+    element.addEventListener("mousemove", onMouseMove);
+    element.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mousemove", onDragMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
     element.addEventListener("wheel", onWheel, { passive: false });
     element.addEventListener("contextmenu", preventDefault);
     element.addEventListener("auxclick", preventDefault);
@@ -339,22 +320,12 @@ export function detach(elementId) {
         window.clearTimeout(existing.moveTimer);
     }
 
-    if (typeof existing.element.releasePointerCapture === "function") {
-        for (const pointerId of existing.capturedPointerIds) {
-            try {
-                existing.element.releasePointerCapture(pointerId);
-            } catch {
-            }
-        }
-    }
-
-    existing.capturedPointerIds = [];
     existing.pressedButtons = [];
 
-    existing.element.removeEventListener("pointermove", existing.onPointerMove);
-    window.removeEventListener("pointermove", existing.onDragPointerMove);
-    existing.element.removeEventListener("pointerdown", existing.onPointerDown);
-    window.removeEventListener("pointerup", existing.onPointerUp);
+    existing.element.removeEventListener("mousemove", existing.onMouseMove);
+    window.removeEventListener("mousemove", existing.onDragMouseMove);
+    existing.element.removeEventListener("mousedown", existing.onMouseDown);
+    window.removeEventListener("mouseup", existing.onMouseUp);
     existing.element.removeEventListener("wheel", existing.onWheel);
     existing.element.removeEventListener("contextmenu", existing.onContextMenu);
     existing.element.removeEventListener("auxclick", existing.onAuxClick);


### PR DESCRIPTION
## Summary
- switch the in-app viewer interop back from pointer events to the proven mouse-event path used by RdpPoc
- keep the frame-based coordinate normalization so clicks still land on the rendered frame instead of the padded container
- preserve the existing logging so companion/coordinator/runner traces show whether input now flows end-to-end

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #298