### PR TITLE
Add viewer JS hook diagnostics

### DIFF
--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -133,6 +133,10 @@
                         <dt>Last input</dt>
                         <dd>@(ViewerClient.LastInputActivity ?? "No input dispatched yet.")</dd>
                     </div>
+                    <div>
+                        <dt>Viewer hooks</dt>
+                        <dd>@(_lastInteropStatus ?? "No JS hook status reported yet.")</dd>
+                    </div>
                 </dl>
                 @if (!ViewerClient.SupportsInAppViewer)
                 {
@@ -153,6 +157,8 @@
     private bool _loading = true;
     private bool _busy;
     private string? _coordinatorUrl;
+    private string? _lastInteropStatus;
+    private bool _hooksRefreshedAfterFirstFrame;
 
     protected override Task OnInitializedAsync()
     {
@@ -166,6 +172,8 @@
         try
         {
             _coordinatorUrl = (await SettingsService.LoadAsync()).CoordinatorUrl;
+            _hooksRefreshedAfterFirstFrame = false;
+            _lastInteropStatus = null;
             if (string.IsNullOrWhiteSpace(_coordinatorUrl))
             {
                 Toasts.Show("Connect to a coordinator before opening viewers.", ToastKind.Warning);
@@ -189,6 +197,15 @@
     {
         if (!firstRender)
         {
+            if (!_hooksRefreshedAfterFirstFrame &&
+                _dotNetReference is not null &&
+                !string.IsNullOrWhiteSpace(ViewerClient.CurrentFrameDataUrl))
+            {
+                _hooksRefreshedAfterFirstFrame = true;
+                await ViewerInterop.AttachAsync(_viewerSurfaceId, _dotNetReference);
+                await ViewerInterop.FocusAsync(_viewerSurfaceId);
+            }
+
             return;
         }
 
@@ -284,6 +301,13 @@
     [JSInvokable]
     public Task HandleKeyboard(string eventType, string code, bool alt, bool control, bool shift) =>
         ViewerClient.SendKeyboardAsync(eventType, code, alt, control, shift);
+
+    [JSInvokable]
+    public Task HandleInteropStatus(string message)
+    {
+        _lastInteropStatus = $"[{DateTimeOffset.Now:HH:mm:ss.fff}] {message}";
+        return InvokeAsync(StateHasChanged);
+    }
 
     private void NavigateBack()
     {

--- a/AgentDeck.Core/wwwroot/js/viewerInterop.js
+++ b/AgentDeck.Core/wwwroot/js/viewerInterop.js
@@ -2,6 +2,24 @@ const registrations = new Map();
 const pointerMoveIntervalMs = 16;
 const wheelPixelStep = 100;
 const wheelPageStep = 3;
+const moveLogIntervalMs = 500;
+
+function log(message, level = "info") {
+    const prefixed = `[AgentDeck.ViewerInterop] ${message}`;
+    if (level === "warn") {
+        console.warn(prefixed);
+        return;
+    }
+
+    console.info(prefixed);
+}
+
+function reportStatus(registration, message, level = "info") {
+    log(message, level);
+    registration.dotNetReference
+        .invokeMethodAsync("HandleInteropStatus", message)
+        .catch(() => {});
+}
 
 function clamp(value) {
     return Math.min(Math.max(value, 0), 1);
@@ -193,8 +211,44 @@ export function attach(elementId, dotNetReference) {
         onDoubleClick: null,
         onDragStart: null,
         onKeyDown: null,
-        onKeyUp: null
+        onKeyUp: null,
+        onFrameLoad: null,
+        frameElement: null,
+        lastMoveLogAt: 0
     };
+
+    reportStatus(registration, `Attaching viewer hooks for #${elementId}. framePresent=${getInteractiveFrameElement(element) !== null}`);
+
+    const bindFrameLoad = () => {
+        const frame = getInteractiveFrameElement(element);
+        if (registration.frameElement === frame) {
+            return;
+        }
+
+        if (registration.frameElement && registration.onFrameLoad) {
+            registration.frameElement.removeEventListener("load", registration.onFrameLoad);
+        }
+
+        registration.frameElement = frame;
+        if (!frame) {
+            reportStatus(registration, `No frame element found for #${elementId} at attach time.`, "warn");
+            return;
+        }
+
+        const onFrameLoad = () => {
+            reportStatus(registration, `Frame load observed for #${elementId} (${frame.clientWidth}x${frame.clientHeight}).`);
+            element.focus();
+        };
+
+        registration.onFrameLoad = onFrameLoad;
+        frame.addEventListener("load", onFrameLoad);
+        reportStatus(registration, `Frame element detected for #${elementId}. complete=${frame.complete}`);
+        if (frame.complete) {
+            onFrameLoad();
+        }
+    };
+
+    bindFrameLoad();
 
     const queueMove = event => {
         const point = normalize(element, event);
@@ -204,6 +258,11 @@ export function attach(elementId, dotNetReference) {
 
         point.button = getActiveDragButton(registration);
         registration.pendingMove = point;
+        const now = Date.now();
+        if (now - registration.lastMoveLogAt >= moveLogIntervalMs) {
+            registration.lastMoveLogAt = now;
+            reportStatus(registration, `mousemove x=${point.x.toFixed(3)} y=${point.y.toFixed(3)} button=${point.button ?? "<none>"}`);
+        }
         schedulePointerMove(elementId);
     };
 
@@ -222,10 +281,12 @@ export function attach(elementId, dotNetReference) {
         event.preventDefault();
         const point = normalize(element, event);
         if (!point) {
+            reportStatus(registration, `mousedown ignored because no normalized point was available for #${elementId}.`, "warn");
             return;
         }
 
         const button = buttonName(event.button);
+        reportStatus(registration, `mousedown x=${point.x.toFixed(3)} y=${point.y.toFixed(3)} button=${button}`);
         addPressedButton(registration, button);
         flushPendingMoveBeforeImmediatePointer(elementId);
         enqueuePointerEvent(registration, "down", point, button, getClickCount(event));
@@ -235,10 +296,12 @@ export function attach(elementId, dotNetReference) {
         event.preventDefault();
         const point = normalize(element, event);
         if (!point) {
+            reportStatus(registration, `mouseup ignored because no normalized point was available for #${elementId}.`, "warn");
             return;
         }
 
         const button = buttonName(event.button);
+        reportStatus(registration, `mouseup x=${point.x.toFixed(3)} y=${point.y.toFixed(3)} button=${button}`);
         flushPendingMoveBeforeImmediatePointer(elementId);
         enqueuePointerEvent(registration, "up", point, button, getClickCount(event));
         removePressedButton(registration, button);
@@ -248,6 +311,7 @@ export function attach(elementId, dotNetReference) {
         event.preventDefault();
         const point = normalize(element, event);
         if (!point) {
+            reportStatus(registration, `wheel ignored because no normalized point was available for #${elementId}.`, "warn");
             return;
         }
 
@@ -263,6 +327,7 @@ export function attach(elementId, dotNetReference) {
         registration.wheelRemainderX -= wheelDeltaX;
         registration.wheelRemainderY -= wheelDeltaY;
 
+        reportStatus(registration, `wheel x=${point.x.toFixed(3)} y=${point.y.toFixed(3)} dx=${wheelDeltaX} dy=${wheelDeltaY}`);
         flushPendingMoveBeforeImmediatePointer(elementId);
         enqueuePointerEvent(registration, "wheel", point, null, 0, wheelDeltaX, wheelDeltaY);
     };
@@ -270,6 +335,7 @@ export function attach(elementId, dotNetReference) {
     const preventDefault = event => event.preventDefault();
 
     const onKeyDown = event => {
+        reportStatus(registration, `keydown code=${event.code} alt=${event.altKey} ctrl=${event.ctrlKey} shift=${event.shiftKey}`);
         dotNetReference
             .invokeMethodAsync("HandleKeyboard", "keydown", event.code, event.altKey, event.ctrlKey, event.shiftKey)
             .catch(() => {});
@@ -277,6 +343,7 @@ export function attach(elementId, dotNetReference) {
     };
 
     const onKeyUp = event => {
+        reportStatus(registration, `keyup code=${event.code} alt=${event.altKey} ctrl=${event.ctrlKey} shift=${event.shiftKey}`);
         dotNetReference
             .invokeMethodAsync("HandleKeyboard", "keyup", event.code, event.altKey, event.ctrlKey, event.shiftKey)
             .catch(() => {});
@@ -308,6 +375,7 @@ export function attach(elementId, dotNetReference) {
     element.addEventListener("keyup", onKeyUp);
 
     registrations.set(elementId, registration);
+    reportStatus(registration, `Viewer hooks registered for #${elementId}.`);
 }
 
 export function detach(elementId) {
@@ -318,6 +386,10 @@ export function detach(elementId) {
 
     if (existing.moveTimer !== null) {
         window.clearTimeout(existing.moveTimer);
+    }
+
+    if (existing.frameElement && existing.onFrameLoad) {
+        existing.frameElement.removeEventListener("load", existing.onFrameLoad);
     }
 
     existing.pressedButtons = [];
@@ -333,6 +405,7 @@ export function detach(elementId) {
     existing.element.removeEventListener("dragstart", existing.onDragStart);
     existing.element.removeEventListener("keydown", existing.onKeyDown);
     existing.element.removeEventListener("keyup", existing.onKeyUp);
+    reportStatus(existing, `Viewer hooks detached for #${elementId}.`);
     registrations.delete(elementId);
 }
 
@@ -340,26 +413,31 @@ export function focus(elementId) {
     const element = document.getElementById(elementId);
     if (element) {
         element.focus();
+        log(`Focus requested for #${elementId}.`);
     }
 }
 
 export async function toggleFullscreen(elementId) {
     const element = document.getElementById(elementId);
     if (!element) {
+        log(`Toggle fullscreen requested for missing #${elementId}.`, "warn");
         return;
     }
 
     if (document.fullscreenElement === element) {
+        log(`Exiting fullscreen for #${elementId}.`);
         await document.exitFullscreen();
         return;
     }
 
     if (document.fullscreenElement && document.fullscreenElement !== element) {
+        log(`Exiting existing fullscreen element before entering fullscreen for #${elementId}.`);
         await document.exitFullscreen();
         return;
     }
 
     if (typeof element.requestFullscreen === "function") {
+        log(`Entering fullscreen for #${elementId}.`);
         await element.requestFullscreen();
     }
 }


### PR DESCRIPTION
## Summary
- report browser-side viewer hook startup and event activity back into the viewer page
- log JS-side hook lifecycle and input events so we can tell whether the MAUI WebView is firing them at all
- rebind the interop once after the first real frame becomes available to rule out timing issues during page startup

## Testing
- dotnet build AgentDeck.slnx -c Release

Closes #300