### PR TITLE
Close runner-managed apps with viewer and runner shutdown

### DIFF
--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddSingleton<IRemoteViewerSessionService, RemoteViewerSessionSe
 builder.Services.AddSingleton<IRunnerConnectionUrlResolver, RunnerConnectionUrlResolver>();
 builder.Services.AddSingleton<ICoordinatorRunnerPublisher, CoordinatorRunnerPublisher>();
 builder.Services.AddSingleton<CoordinatorRunnerConnectionService>();
+builder.Services.AddSingleton<IRunnerLaunchedApplicationService, RunnerLaunchedApplicationService>();
 builder.Services.AddSingleton<IManagedViewerRelayService, ManagedViewerRelayService>();
 builder.Services.AddSingleton<IDesktopViewerBootstrapService, DesktopViewerBootstrapService>();
 builder.Services.AddSingleton<IRunnerAuditService, RunnerAuditService>();
@@ -77,6 +78,7 @@ builder.Services.AddHostedService<HubOutputForwarder>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<CoordinatorRunnerConnectionService>());
 builder.Services.AddHostedService(sp => (OrchestrationExecutionService)sp.GetRequiredService<IOrchestrationExecutionService>());
 builder.Services.AddHostedService<WorkerCoordinatorRegistrationService>();
+builder.Services.AddHostedService(sp => (RunnerLaunchedApplicationService)sp.GetRequiredService<IRunnerLaunchedApplicationService>());
 
 var app = builder.Build();
 

--- a/AgentDeck.Runner/Services/DesktopViewerBootstrapService.cs
+++ b/AgentDeck.Runner/Services/DesktopViewerBootstrapService.cs
@@ -154,6 +154,7 @@ public sealed class DesktopViewerBootstrapService : IDesktopViewerBootstrapServi
     private readonly ConcurrentDictionary<string, ActiveDesktopTransport> _activeTransports = new();
     private readonly IRemoteViewerSessionService _viewers;
     private readonly IManagedViewerRelayService _managedRelay;
+    private readonly IRunnerLaunchedApplicationService _launchedApplications;
     private readonly IRunnerConnectionUrlResolver _connectionUrlResolver;
     private readonly DesktopViewerTransportOptions _transportOptions;
     private readonly ILogger<DesktopViewerBootstrapService> _logger;
@@ -161,12 +162,14 @@ public sealed class DesktopViewerBootstrapService : IDesktopViewerBootstrapServi
     public DesktopViewerBootstrapService(
         IRemoteViewerSessionService viewers,
         IManagedViewerRelayService managedRelay,
+        IRunnerLaunchedApplicationService launchedApplications,
         IRunnerConnectionUrlResolver connectionUrlResolver,
         IOptions<DesktopViewerTransportOptions> transportOptions,
         ILogger<DesktopViewerBootstrapService> logger)
     {
         _viewers = viewers;
         _managedRelay = managedRelay;
+        _launchedApplications = launchedApplications;
         _connectionUrlResolver = connectionUrlResolver;
         _transportOptions = transportOptions.Value;
         _logger = logger;
@@ -280,6 +283,11 @@ public sealed class DesktopViewerBootstrapService : IDesktopViewerBootstrapServi
         {
             await activeTransport.StopAsync();
         }
+
+        await _launchedApplications.CloseViewerApplicationAsync(
+            sessionId,
+            message ?? "Viewer session closed.",
+            cancellationToken);
 
         var result = _viewers.Close(sessionId, message ?? "Viewer session closed.");
         if (result.Session is not null && existingSession?.Provider == RemoteViewerProviderKind.Managed)

--- a/AgentDeck.Runner/Services/IRunnerLaunchedApplicationService.cs
+++ b/AgentDeck.Runner/Services/IRunnerLaunchedApplicationService.cs
@@ -1,0 +1,16 @@
+using RdpPoc.Contracts;
+
+namespace AgentDeck.Runner.Services;
+
+public interface IRunnerLaunchedApplicationService
+{
+    void TrackViewerSession(string viewerSessionId, string displayName, string? terminalSessionId = null);
+
+    void UpdateTrackedProcess(string viewerSessionId, int processId, string? targetId = null, string? targetDisplayName = null);
+
+    void UpdateResolvedTarget(string viewerSessionId, CaptureTargetDescriptor target);
+
+    Task CloseViewerApplicationAsync(string viewerSessionId, string reason, CancellationToken cancellationToken = default);
+
+    void UntrackViewerSession(string viewerSessionId);
+}

--- a/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
@@ -33,18 +33,21 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
     private readonly ManagedDesktopViewerTransportOptions _options;
     private readonly ILogger<ManagedViewerRelayService> _logger;
     private readonly IHostCapturePlatform _capturePlatform;
+    private readonly IRunnerLaunchedApplicationService _launchedApplications;
     private readonly object _captureSync = new();
 
     public ManagedViewerRelayService(
         IRemoteViewerSessionService viewers,
         IHubContext<ManagedViewerRelayHub> hubContext,
         ICoordinatorRunnerPublisher coordinatorPublisher,
+        IRunnerLaunchedApplicationService launchedApplications,
         IOptions<DesktopViewerTransportOptions> transportOptions,
         ILogger<ManagedViewerRelayService> logger)
     {
         _viewers = viewers;
         _hubContext = hubContext;
         _coordinatorPublisher = coordinatorPublisher;
+        _launchedApplications = launchedApplications;
         _options = transportOptions.Value.Managed;
         _logger = logger;
         _capturePlatform = HostCapturePlatformFactory.Create();
@@ -64,6 +67,7 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
         }
 
         var target = await ResolveTargetAsync(session, cancellationToken);
+        _launchedApplications.UpdateResolvedTarget(session.Id, target);
         var accessToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(Math.Max(1, _options.AccessTokenBytes)))
             .ToLowerInvariant();
         var assignment = new HostSessionAssignment(
@@ -490,6 +494,7 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
             refreshedTarget.Id,
             refreshedTarget.DisplayName,
             failureReason);
+        _launchedApplications.UpdateResolvedTarget(activeSession.Session.Id, refreshedTarget);
         return true;
     }
 

--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -32,6 +32,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     private readonly IManagedViewerRelayService _managedViewerRelay;
     private readonly IDesktopViewerBootstrapService _viewerBootstrap;
     private readonly IVsCodeDebugSessionService _vsCodeDebug;
+    private readonly IRunnerLaunchedApplicationService _launchedApplications;
     private readonly IWorkspaceService _workspace;
     private readonly ILogger<OrchestrationExecutionService> _logger;
     private readonly ConcurrentDictionary<string, byte> _activeJobs = new();
@@ -46,6 +47,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         IManagedViewerRelayService managedViewerRelay,
         IDesktopViewerBootstrapService viewerBootstrap,
         IVsCodeDebugSessionService vsCodeDebug,
+        IRunnerLaunchedApplicationService launchedApplications,
         IWorkspaceService workspace,
         ILogger<OrchestrationExecutionService> logger)
     {
@@ -56,6 +58,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         _managedViewerRelay = managedViewerRelay;
         _viewerBootstrap = viewerBootstrap;
         _vsCodeDebug = vsCodeDebug;
+        _launchedApplications = launchedApplications;
         _workspace = workspace;
         _logger = logger;
     }
@@ -687,6 +690,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         try
         {
             viewer = _viewers.Create(request);
+            _launchedApplications.TrackViewerSession(viewer.Id, viewer.Target.DisplayName, sessionId);
             _jobs.UpdateStatus(job.Id, new UpdateOrchestrationJobStatusRequest
             {
                 Status = OrchestrationJobStatus.Running,

--- a/AgentDeck.Runner/Services/RunnerLaunchedApplicationService.cs
+++ b/AgentDeck.Runner/Services/RunnerLaunchedApplicationService.cs
@@ -1,0 +1,223 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+using RdpPoc.Contracts;
+
+namespace AgentDeck.Runner.Services;
+
+public sealed class RunnerLaunchedApplicationService : IRunnerLaunchedApplicationService, IHostedService
+{
+    private const string CtrlC = "\u0003";
+
+    private sealed record TrackedApplication(
+        string ViewerSessionId,
+        string DisplayName,
+        string? TerminalSessionId,
+        int? RunnerProcessId,
+        int? ResolvedProcessId,
+        string? TargetId,
+        string? TargetDisplayName,
+        DateTimeOffset UpdatedAt);
+
+    private readonly ConcurrentDictionary<string, TrackedApplication> _trackedApplications = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IPtyProcessManager _ptyManager;
+    private readonly ILogger<RunnerLaunchedApplicationService> _logger;
+
+    public RunnerLaunchedApplicationService(
+        IPtyProcessManager ptyManager,
+        ILogger<RunnerLaunchedApplicationService> logger)
+    {
+        _ptyManager = ptyManager;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        var viewerSessionIds = _trackedApplications.Keys.ToArray();
+        foreach (var viewerSessionId in viewerSessionIds)
+        {
+            await CloseViewerApplicationAsync(
+                viewerSessionId,
+                "Runner shutdown closed a runner-managed application.",
+                cancellationToken);
+        }
+    }
+
+    public void TrackViewerSession(string viewerSessionId, string displayName, string? terminalSessionId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewerSessionId);
+
+        _trackedApplications.AddOrUpdate(
+            viewerSessionId.Trim(),
+            _ => new TrackedApplication(
+                viewerSessionId.Trim(),
+                string.IsNullOrWhiteSpace(displayName) ? viewerSessionId.Trim() : displayName.Trim(),
+                string.IsNullOrWhiteSpace(terminalSessionId) ? null : terminalSessionId.Trim(),
+                null,
+                null,
+                null,
+                null,
+                DateTimeOffset.UtcNow),
+            (_, existing) => existing with
+            {
+                DisplayName = string.IsNullOrWhiteSpace(displayName) ? existing.DisplayName : displayName.Trim(),
+                TerminalSessionId = string.IsNullOrWhiteSpace(terminalSessionId) ? existing.TerminalSessionId : terminalSessionId.Trim(),
+                UpdatedAt = DateTimeOffset.UtcNow
+            });
+    }
+
+    public void UpdateTrackedProcess(string viewerSessionId, int processId, string? targetId = null, string? targetDisplayName = null)
+    {
+        if (string.IsNullOrWhiteSpace(viewerSessionId) || processId <= 0)
+        {
+            return;
+        }
+
+        if (!_trackedApplications.TryGetValue(viewerSessionId.Trim(), out var existing))
+        {
+            return;
+        }
+
+        _trackedApplications[viewerSessionId.Trim()] = existing with
+        {
+            RunnerProcessId = processId,
+            TargetId = string.IsNullOrWhiteSpace(targetId) ? existing.TargetId : targetId.Trim(),
+            TargetDisplayName = string.IsNullOrWhiteSpace(targetDisplayName) ? existing.TargetDisplayName : targetDisplayName.Trim(),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public void UpdateResolvedTarget(string viewerSessionId, CaptureTargetDescriptor target)
+    {
+        if (target.OwnerProcessId is null)
+        {
+            return;
+        }
+
+        if (!_trackedApplications.TryGetValue(viewerSessionId.Trim(), out var existing))
+        {
+            return;
+        }
+
+        _trackedApplications[viewerSessionId.Trim()] = existing with
+        {
+            ResolvedProcessId = target.OwnerProcessId.Value,
+            TargetId = target.Id,
+            TargetDisplayName = target.DisplayName,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public async Task CloseViewerApplicationAsync(string viewerSessionId, string reason, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(viewerSessionId) ||
+            !_trackedApplications.TryRemove(viewerSessionId.Trim(), out var trackedApplication))
+        {
+            return;
+        }
+
+        if (TryCloseTrackedProcess(trackedApplication, reason))
+        {
+            return;
+        }
+
+        if (await TryInterruptTerminalAsync(trackedApplication, reason, cancellationToken))
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "Runner-managed app tracking removed viewer {ViewerSessionId} ({DisplayName}) without an active process or terminal fallback. Reason: {Reason}",
+            trackedApplication.ViewerSessionId,
+            trackedApplication.DisplayName,
+            reason);
+    }
+
+    public void UntrackViewerSession(string viewerSessionId)
+    {
+        if (string.IsNullOrWhiteSpace(viewerSessionId))
+        {
+            return;
+        }
+
+        _trackedApplications.TryRemove(viewerSessionId.Trim(), out _);
+    }
+
+    private bool TryCloseTrackedProcess(TrackedApplication trackedApplication, string reason)
+    {
+        var processId = trackedApplication.RunnerProcessId ?? trackedApplication.ResolvedProcessId;
+        if (processId is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId.Value);
+            if (process.HasExited)
+            {
+                _logger.LogInformation(
+                    "Runner-managed app for viewer {ViewerSessionId} ({DisplayName}) had already exited before cleanup. Reason: {Reason}",
+                    trackedApplication.ViewerSessionId,
+                    trackedApplication.DisplayName,
+                    reason);
+                return true;
+            }
+
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(5000);
+            _logger.LogInformation(
+                "Closed runner-managed process {ProcessId} for viewer {ViewerSessionId} ({DisplayName}) targeting {TargetId} ({TargetDisplayName}). Reason: {Reason}",
+                processId.Value,
+                trackedApplication.ViewerSessionId,
+                trackedApplication.DisplayName,
+                trackedApplication.TargetId ?? "<unknown>",
+                trackedApplication.TargetDisplayName ?? "<unknown>",
+                reason);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            _logger.LogInformation(
+                "Runner-managed process {ProcessId} for viewer {ViewerSessionId} ({DisplayName}) was already gone during cleanup. Reason: {Reason}",
+                processId.Value,
+                trackedApplication.ViewerSessionId,
+                trackedApplication.DisplayName,
+                reason);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to close runner-managed process {ProcessId} for viewer {ViewerSessionId} ({DisplayName}). Trying terminal fallback if available.",
+                processId.Value,
+                trackedApplication.ViewerSessionId,
+                trackedApplication.DisplayName);
+            return false;
+        }
+    }
+
+    private async Task<bool> TryInterruptTerminalAsync(
+        TrackedApplication trackedApplication,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(trackedApplication.TerminalSessionId) ||
+            !_ptyManager.IsActive(trackedApplication.TerminalSessionId))
+        {
+            return false;
+        }
+
+        await _ptyManager.WriteAsync(trackedApplication.TerminalSessionId, CtrlC, cancellationToken);
+        _logger.LogInformation(
+            "Sent Ctrl+C to terminal {TerminalSessionId} while closing runner-managed app for viewer {ViewerSessionId} ({DisplayName}). Reason: {Reason}",
+            trackedApplication.TerminalSessionId,
+            trackedApplication.ViewerSessionId,
+            trackedApplication.DisplayName,
+            reason);
+        return true;
+    }
+}

--- a/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
+++ b/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
+using RdpPoc.Contracts;
 
 namespace AgentDeck.Runner.Services;
 
@@ -32,16 +33,22 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
     private readonly ConcurrentDictionary<string, ActiveDebugSession> _sessions = new();
     private readonly ConcurrentDictionary<string, VsCodeDebugSession> _sessionRecords = new();
     private readonly IRemoteViewerSessionService _viewers;
+    private readonly IManagedViewerRelayService _managedViewerRelay;
     private readonly IDesktopViewerBootstrapService _viewerBootstrap;
+    private readonly IRunnerLaunchedApplicationService _launchedApplications;
     private readonly ILogger<VsCodeDebugSessionService> _logger;
 
     public VsCodeDebugSessionService(
         IRemoteViewerSessionService viewers,
+        IManagedViewerRelayService managedViewerRelay,
         IDesktopViewerBootstrapService viewerBootstrap,
+        IRunnerLaunchedApplicationService launchedApplications,
         ILogger<VsCodeDebugSessionService> logger)
     {
         _viewers = viewers;
+        _managedViewerRelay = managedViewerRelay;
         _viewerBootstrap = viewerBootstrap;
+        _launchedApplications = launchedApplications;
         _logger = logger;
     }
 
@@ -63,6 +70,7 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
         var debugConfigurationName = string.IsNullOrWhiteSpace(job.DebugConfigurationName)
             ? $"{job.ProjectName} Debug"
             : job.DebugConfigurationName;
+        var knownWindowTargetIds = CaptureKnownWindowTargetIds();
 
         var viewer = _viewers.Create(new CreateRemoteViewerSessionRequest
         {
@@ -76,11 +84,20 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
                 DisplayName = $"{job.ProjectName} VS Code",
                 JobId = job.Id,
                 SessionId = orchestrationSessionId,
-                WindowTitle = BuildWindowTitle(job.ProjectName)
+                WindowTitle = BuildWindowTitle(job.ProjectName),
+                KnownWindowTargetIds = knownWindowTargetIds
             }
         });
-
-        viewer = await _viewerBootstrap.BootstrapAsync(viewer.Id, cancellationToken: cancellationToken) ?? viewer;
+        try
+        {
+            _launchedApplications.TrackViewerSession(viewer.Id, viewer.Target.DisplayName);
+            viewer = await _viewerBootstrap.BootstrapAsync(viewer.Id, cancellationToken: cancellationToken) ?? viewer;
+        }
+        catch
+        {
+            await CloseViewerAsync(viewer.Id, "VS Code viewer bootstrap failed.");
+            throw;
+        }
 
         var debugSessionId = Guid.NewGuid().ToString("N");
         var createdAt = DateTimeOffset.UtcNow;
@@ -162,8 +179,8 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
             };
             if (!_sessions.TryAdd(orchestrationSessionId, activeSession))
             {
-                CloseViewer(viewer.Id, "VS Code session closed.");
-                CloseViewer(deviceViewer?.Id, "Device viewer session closed.");
+                await CloseViewerAsync(viewer.Id, "VS Code session closed.");
+                await CloseViewerAsync(deviceViewer?.Id, "Device viewer session closed.");
                 throw new InvalidOperationException($"A VS Code debug session is already active for orchestration session '{orchestrationSessionId}'.");
             }
 
@@ -185,12 +202,8 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to launch VS Code debug session for job {JobId}", job.Id);
-            _viewers.Update(viewer.Id, new UpdateRemoteViewerSessionRequest
-            {
-                Status = RemoteViewerSessionStatus.Failed,
-                Message = ex.Message
-            });
-            CloseViewer(deviceViewer?.Id, "Device viewer session closed because VS Code debugging failed.");
+            await CloseViewerAsync(viewer.Id, "VS Code viewer session closed because debugging failed.");
+            await CloseViewerAsync(deviceViewer?.Id, "Device viewer session closed because VS Code debugging failed.");
             UpdateSession(orchestrationSessionId, session => WithStatus(
                 session,
                 VsCodeDebugSessionStatus.Failed,
@@ -208,6 +221,7 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
         }
 
         session.HostProcessId = processId;
+        _launchedApplications.UpdateTrackedProcess(session.ViewerSessionId, processId);
         return Task.CompletedTask;
     }
 
@@ -244,15 +258,15 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
             VsCodeDebuggerVisibilityState.Visible));
     }
 
-    public Task CompleteAsync(string orchestrationSessionId, int exitCode, CancellationToken cancellationToken = default)
+    public async Task CompleteAsync(string orchestrationSessionId, int exitCode, CancellationToken cancellationToken = default)
     {
         if (_sessions.TryRemove(orchestrationSessionId, out var session))
         {
             var message = exitCode == 0
                 ? "VS Code session closed."
                 : $"VS Code session closed with exit code {exitCode}.";
-            CloseViewer(session.ViewerSessionId, message);
-            CloseViewer(session.DeviceViewerSessionId, "Device viewer session closed.");
+            await CloseViewerAsync(session.ViewerSessionId, message);
+            await CloseViewerAsync(session.DeviceViewerSessionId, "Device viewer session closed.");
             UpdateSession(orchestrationSessionId, existing => WithStatus(
                 existing,
                 exitCode == 0 ? VsCodeDebugSessionStatus.Closed : VsCodeDebugSessionStatus.Failed,
@@ -260,15 +274,14 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
                 VsCodeDebuggerVisibilityState.Closed));
         }
 
-        return Task.CompletedTask;
     }
 
-    public Task StopAsync(string orchestrationSessionId, CancellationToken cancellationToken = default)
+    public async Task StopAsync(string orchestrationSessionId, CancellationToken cancellationToken = default)
     {
         if (_sessions.TryRemove(orchestrationSessionId, out var session))
         {
-            CloseViewer(session.ViewerSessionId, "VS Code session cancelled.");
-            CloseViewer(session.DeviceViewerSessionId, "Device viewer session cancelled.");
+            await CloseViewerAsync(session.ViewerSessionId, "VS Code session cancelled.");
+            await CloseViewerAsync(session.DeviceViewerSessionId, "Device viewer session cancelled.");
             TryKillProcess(session.HostProcessId);
             UpdateSession(orchestrationSessionId, existing => WithStatus(
                 existing,
@@ -277,7 +290,6 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
                 VsCodeDebuggerVisibilityState.Closed));
         }
 
-        return Task.CompletedTask;
     }
 
     private static string ResolveStartupProject(OrchestrationJob job, string workingDirectory)
@@ -747,19 +759,21 @@ error "Could not focus the VS Code window to start debugging."
         OrchestrationJob job,
         CancellationToken cancellationToken)
     {
-        if (!TryBuildDeviceViewerRequest(orchestrationSessionId, job, out var request))
+        var knownWindowTargetIds = CaptureKnownWindowTargetIds();
+        if (!TryBuildDeviceViewerRequest(orchestrationSessionId, job, knownWindowTargetIds, out var request))
         {
             return null;
         }
 
         var viewer = _viewers.Create(request);
+        _launchedApplications.TrackViewerSession(viewer.Id, viewer.Target.DisplayName);
         try
         {
             return await _viewerBootstrap.BootstrapAsync(viewer.Id, cancellationToken: cancellationToken) ?? viewer;
         }
         catch
         {
-            CloseViewer(viewer.Id, "Device viewer bootstrap failed.");
+            await CloseViewerAsync(viewer.Id, "Device viewer bootstrap failed.");
             throw;
         }
     }
@@ -767,6 +781,7 @@ error "Could not focus the VS Code window to start debugging."
     private static bool TryBuildDeviceViewerRequest(
         string orchestrationSessionId,
         OrchestrationJob job,
+        IReadOnlyList<string> knownWindowTargetIds,
         out CreateRemoteViewerSessionRequest request)
     {
         request = new CreateRemoteViewerSessionRequest();
@@ -791,11 +806,27 @@ error "Could not focus the VS Code window to start debugging."
                 JobId = job.Id,
                 SessionId = orchestrationSessionId,
                 VirtualDeviceId = job.DeviceSelection.DeviceId,
-                VirtualDeviceProfileId = job.DeviceSelection.ProfileId
+                VirtualDeviceProfileId = job.DeviceSelection.ProfileId,
+                KnownWindowTargetIds = knownWindowTargetIds.ToArray()
             }
         };
 
         return true;
+    }
+
+    private IReadOnlyList<string> CaptureKnownWindowTargetIds()
+    {
+        try
+        {
+            return _managedViewerRelay.GetCaptureTargets()
+                .Where(target => target.Kind == CaptureTargetKind.Window)
+                .Select(target => target.Id)
+                .ToArray();
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return [];
+        }
     }
 
     private static bool TryMapDeviceViewerTargetKind(ApplicationTargetPlatform platform, out RemoteViewerTargetKind targetKind)
@@ -839,14 +870,14 @@ error "Could not focus the VS Code window to start debugging."
         }
     }
 
-    private void CloseViewer(string? viewerSessionId, string message)
+    private async Task CloseViewerAsync(string? viewerSessionId, string message)
     {
         if (string.IsNullOrWhiteSpace(viewerSessionId))
         {
             return;
         }
 
-        _viewers.Close(viewerSessionId, message);
+        await _viewerBootstrap.CloseAsync(viewerSessionId, message);
     }
 
     private void UpdateSession(string orchestrationSessionId, Func<VsCodeDebugSession, VsCodeDebugSession> update)

--- a/AgentDeck.Runner/Transport/RdpPoc/Contracts/CaptureTargetDescriptor.cs
+++ b/AgentDeck.Runner/Transport/RdpPoc/Contracts/CaptureTargetDescriptor.cs
@@ -3,4 +3,5 @@ namespace RdpPoc.Contracts;
 public sealed record CaptureTargetDescriptor(
     string Id,
     string DisplayName,
-    CaptureTargetKind Kind);
+    CaptureTargetKind Kind,
+    int? OwnerProcessId = null);

--- a/AgentDeck.Runner/Transport/RdpPoc/HostAgent/HostCapturePlatform.cs
+++ b/AgentDeck.Runner/Transport/RdpPoc/HostAgent/HostCapturePlatform.cs
@@ -69,7 +69,8 @@ internal sealed class WindowsHostCapturePlatform : IHostCapturePlatform
                 targets.Add(new CaptureTargetDescriptor(
                     $"window:{process.Id}",
                     $"{process.ProcessName} - {process.MainWindowTitle}",
-                    CaptureTargetKind.Window));
+                    CaptureTargetKind.Window,
+                    process.Id));
             }
             catch
             {
@@ -1220,7 +1221,8 @@ internal sealed class MacOsHostCapturePlatform : IHostCapturePlatform
                 string.IsNullOrWhiteSpace(window.WindowTitle)
                     ? $"{window.OwnerName} (Window {window.WindowId})"
                     : $"{window.OwnerName} - {window.WindowTitle}",
-                CaptureTargetKind.Window)));
+                CaptureTargetKind.Window,
+                window.OwnerPid)));
 
         return targets
             .DistinctBy(target => target.Id, StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary\n- track only runner-created viewer sessions as managed applications, with terminal fallback and resolved process ownership\n- close tracked apps when their viewer closes or when the runner shuts down\n- carry baseline window ids into VS Code/device viewers so tracked cleanup only targets windows opened by the runner\n\n## Testing\n- dotnet build AgentDeck.slnx -c Release\n\nFixes #303