### PR TITLE
Hide failed or unavailable viewer sessions from live process tabs

### DIFF
--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -648,7 +648,10 @@
         foreach (var machineId in machinesToQuery)
         {
             viewers.AddRange((await CoordinatorClient.GetMachineViewerSessionsAsync(_coordinatorUrl, machineId))
-                .Where(viewer => !string.IsNullOrWhiteSpace(viewer.JobId) && jobIds.Contains(viewer.JobId)));
+                .Where(viewer =>
+                    IsVisibleRuntimeViewer(viewer) &&
+                    !string.IsNullOrWhiteSpace(viewer.JobId) &&
+                    jobIds.Contains(viewer.JobId)));
         }
 
         _projectJobs = jobs
@@ -1421,6 +1424,9 @@
         viewer.Provider == RemoteViewerProviderKind.Managed &&
         viewer.Status == RemoteViewerSessionStatus.Ready &&
         !string.IsNullOrWhiteSpace(viewer.MachineId);
+
+    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer) =>
+        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
 
     private bool CanCancelJob(OrchestrationJob job) =>
         _cancellingJobId != job.Id &&

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -368,8 +368,9 @@
         var jobIds = _runtimeJobs.Select(job => job.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
         _runtimeViewers = viewersTask.Result
             .Where(viewer =>
-                (!string.IsNullOrWhiteSpace(viewer.JobId) && jobIds.Contains(viewer.JobId)) ||
-                (!string.IsNullOrWhiteSpace(viewer.Target.JobId) && jobIds.Contains(viewer.Target.JobId)))
+                IsVisibleRuntimeViewer(viewer) &&
+                ((!string.IsNullOrWhiteSpace(viewer.JobId) && jobIds.Contains(viewer.JobId)) ||
+                 (!string.IsNullOrWhiteSpace(viewer.Target.JobId) && jobIds.Contains(viewer.Target.JobId))))
             .OrderByDescending(viewer => viewer.UpdatedAt)
             .ToArray();
         _remoteControlState = remoteControlTask.Result;
@@ -931,6 +932,9 @@
         viewer.Provider == RemoteViewerProviderKind.Managed &&
         viewer.Status == RemoteViewerSessionStatus.Ready &&
         !string.IsNullOrWhiteSpace(viewer.MachineId);
+
+    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer) =>
+        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
 
     private bool IsActiveViewerControlledByCurrentCompanion() =>
         _activeSurface?.Viewer is not null &&


### PR DESCRIPTION
## Summary\n- filter failed and closed runtime viewer sessions out of project viewer lists\n- apply the same filtering to project-session runtime surface tabs\n- keep active requested/preparing/ready viewers visible\n\n## Testing\n- dotnet build AgentDeck.slnx -c Release\n\nFixes #311