### PR TITLE
Fix VS Code debug launch flow on runner-backed sessions

### DIFF
--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -396,7 +396,9 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
         var operationId = Guid.NewGuid().ToString("N");
         var completionMarker = $"__AGENTDECK_EXIT_{operationId}__";
-        var processIdMarker = isVsCode ? $"__AGENTDECK_PID_{operationId}__" : null;
+        var processIdMarker = isVsCode && OperatingSystem.IsWindows()
+            ? $"__AGENTDECK_PID_{operationId}__"
+            : null;
         var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         var activeSession = new ActiveSession
         {


### PR DESCRIPTION
## Summary\n- keep Windows PID capture for VS Code debug launches\n- stop using the special background PID wrapper on non-Windows runners\n- let POSIX VS Code debug launches behave like a normal working terminal code .-style launch\n\n## Testing\n- dotnet build AgentDeck.slnx -c Release\n\nFixes #309