### PR TITLE
fix(#326): constant-time viewer token compare + 256-bit default

### DIFF
--- a/AgentDeck.Runner/Configuration/DesktopViewerTransportOptions.cs
+++ b/AgentDeck.Runner/Configuration/DesktopViewerTransportOptions.cs
@@ -23,7 +23,7 @@ public sealed class ManagedDesktopViewerTransportOptions
     public TimeSpan FrameInterval { get; set; } = TimeSpan.FromMilliseconds(250);
     public string RelayHubPath { get; set; } = "/hubs/managed-viewer";
     public bool IssueAccessToken { get; set; } = true;
-    public int AccessTokenBytes { get; set; } = 12;
+    public int AccessTokenBytes { get; set; } = 32;
     public Dictionary<string, string> EnvironmentVariables { get; set; } = [];
 
     public bool IsConfigured =>

--- a/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
+++ b/AgentDeck.Runner/Services/ManagedViewerRelayService.cs
@@ -619,7 +619,11 @@ public sealed class ManagedViewerRelayService : IManagedViewerRelayService, IDis
 
     private static void ValidateAccessToken(ActiveRelaySession session, string accessToken)
     {
-        if (!string.Equals(session.AccessToken, accessToken, StringComparison.Ordinal))
+        var expectedBytes = System.Text.Encoding.UTF8.GetBytes(session.AccessToken ?? string.Empty);
+        var actualBytes = System.Text.Encoding.UTF8.GetBytes(accessToken ?? string.Empty);
+
+        if (expectedBytes.Length != actualBytes.Length ||
+            !CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes))
         {
             throw new InvalidOperationException("The supplied viewer token is invalid.");
         }


### PR DESCRIPTION
Closes #326.

## Plan
- Swap `string.Equals` for `CryptographicOperations.FixedTimeEquals` over UTF-8 bytes in `ManagedViewerRelayService.ValidateAccessToken`, eliminating the timing side-channel on viewer token validation.
- Bump `ManagedDesktopViewerTransportOptions.AccessTokenBytes` default from 12 (96-bit) → 32 (256-bit). Tokens stay opaque hex strings; only the on-the-wire length changes (24 → 64 chars) for newly-issued tokens.

## Diff summary
`AgentDeck.Runner/Services/ManagedViewerRelayService.cs`
- `ValidateAccessToken` now encodes both expected and supplied tokens to UTF-8, length-checks, then uses `CryptographicOperations.FixedTimeEquals`. Length mismatches throw the same `InvalidOperationException` as before (note: length itself isn't constant-time, but the token length is fixed at issuance and not attacker-controlled).
- Existing `using System.Security.Cryptography;` covers the new call.

`AgentDeck.Runner/Configuration/DesktopViewerTransportOptions.cs`
- `AccessTokenBytes` default `12` → `32`.
- `DesktopViewerBootstrapService` already reads the same option, so it inherits the new default automatically.

## Compatibility
- Public surface unchanged. Tokens flow through as opaque strings; the only observable difference is that freshly-issued tokens are longer. Operators with an explicit `DesktopViewerTransport:Managed:AccessTokenBytes` override in `appsettings*.json` keep their value.

## Verification
- Targeted code review of the three call sites (`ManagedViewerRelayService.cs:156/170/181`) confirmed they pass the supplied string through; no callers depend on the legacy compare semantics.
- `grep` for `AccessTokenBytes` to confirm no JSON config pins the old default — none does.
- `dotnet build` could not be executed in this cron sandbox (no .NET SDK present). The change is mechanical and uses already-imported APIs; please ensure CI green before merging.

🤖 Opened by cron triage agent.