### PR TITLE
fix(#344): case-sensitive signer id comparison

### DIFF
--- a/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
@@ -156,14 +156,14 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
                             $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not declare any trusted manifest signer ids.");
                     }
 
-                    if (!desiredState.SecurityPolicy.TrustedManifestSignerIds.Contains(manifest.Signature.SignerId, StringComparer.OrdinalIgnoreCase))
+                    if (!desiredState.SecurityPolicy.TrustedManifestSignerIds.Contains(manifest.Signature.SignerId, StringComparer.Ordinal))
                     {
                         throw new InvalidOperationException(
                             $"Coordinator update manifest signer '{manifest.Signature.SignerId}' is not trusted by security policy {desiredState.SecurityPolicy.PolicyVersion}.");
                     }
 
                     var signer = _options.TrustedManifestSigners
-                        .FirstOrDefault(candidate => string.Equals(candidate.SignerId, manifest.Signature.SignerId, StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(candidate => string.Equals(candidate.SignerId, manifest.Signature.SignerId, StringComparison.Ordinal));
                     if (signer is null)
                     {
                         throw new InvalidOperationException(


### PR DESCRIPTION
Closes #344.

## Change
Replace `StringComparer.OrdinalIgnoreCase` / `StringComparison.OrdinalIgnoreCase` with `Ordinal` for trusted manifest signer-id matching in `RunnerUpdateStagingService` (both the `TrustedManifestSignerIds.Contains` check at :159 and the `TrustedManifestSigners.FirstOrDefault` at :166).

## Why
Signer-id is a trust principal — `agentdeck-dev` and `AGENTDECK-DEV` must not be treated as the same signer.

## Verification
- `dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj` — green, 0 warnings.