### PR TITLE
fix(#341): default AllowedOrigins to deny ([])

### DIFF
--- a/AgentDeck.Runner/Configuration/RunnerOptions.cs
+++ b/AgentDeck.Runner/Configuration/RunnerOptions.cs
@@ -15,8 +15,9 @@ public sealed class RunnerOptions
     /// <summary>Port the Kestrel server listens on. Default 5000.</summary>
     public int Port { get; set; } = 5000;
 
-    /// <summary>Origins allowed for CORS. Use ["*"] for development.</summary>
-    public string[] AllowedOrigins { get; set; } = ["*"];
+    /// <summary>Origins allowed for CORS. Defaults to deny (empty); set to ["*"] for development opt-in,
+    /// or list explicit origins (e.g., the local WebView origin) for production.</summary>
+    public string[] AllowedOrigins { get; set; } = [];
 
     /// <summary>Default shell command when no command is specified in CreateTerminalRequest. Auto-detected from OS if null.</summary>
     public string? DefaultShell { get; set; }

--- a/AgentDeck.Runner/appsettings.json
+++ b/AgentDeck.Runner/appsettings.json
@@ -2,7 +2,7 @@
   "Runner": {
     "WorkspaceRoot": "",
     "Port": 5000,
-    "AllowedOrigins": ["*"]
+    "AllowedOrigins": []
   },
   "DesktopViewerTransport": {
     "Managed": {


### PR DESCRIPTION
Closes #341.

## Change
- `RunnerOptions.AllowedOrigins` code default: `["*"]` → `[]`
- `AgentDeck.Runner/appsettings.json` `AllowedOrigins`: `["*"]` → `[]`
- Updated XML doc to describe the new default.

CORS logic in `Program.cs` already handles empty as deny (`WithOrigins(empty)` permits no cross-origin callers); wildcard now requires explicit opt-in.

## Verification
`dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj` — green, 0 warnings.