### PR TITLE
fix(#328): pin WorkingDirectory for workflow/capability shells

### DIFF
--- a/AgentDeck.Runner/Services/MachineSetupService.cs
+++ b/AgentDeck.Runner/Services/MachineSetupService.cs
@@ -248,6 +248,14 @@ public sealed class MachineSetupService : IMachineSetupService
             startInfo.ArgumentList.Add(argument);
         }
 
+        // Pin the working directory to a per-invocation temp dir so capability
+        // install scripts can't write relative paths into the runner install
+        // directory (which contains appsettings.json and signing public keys).
+        var workingDirectory = Path.Combine(Path.GetTempPath(),
+            "agentdeck-capability-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workingDirectory);
+        startInfo.WorkingDirectory = workingDirectory;
+
         using var process = new Process { StartInfo = startInfo };
 
         try
@@ -256,6 +264,18 @@ public sealed class MachineSetupService : IMachineSetupService
         }
         catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
         {
+            try
+            {
+                if (Directory.Exists(workingDirectory))
+                {
+                    Directory.Delete(workingDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+
             return new MachineCapabilityInstallResult
             {
                 CapabilityId = capabilityId,
@@ -276,6 +296,18 @@ public sealed class MachineSetupService : IMachineSetupService
 
         var standardOutput = await standardOutputTask;
         var standardError = await standardErrorTask;
+
+        try
+        {
+            if (Directory.Exists(workingDirectory))
+            {
+                Directory.Delete(workingDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
 
         if (process.ExitCode != 0)
         {

--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -537,6 +537,14 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
             startInfo.ArgumentList.Add(commandText);
         }
 
+        // Pin the working directory to a per-invocation temp dir so any relative
+        // writes (./something) by the workflow step don't land in the runner
+        // install directory next to appsettings.json or signing keys.
+        var workingDirectory = Path.Combine(Path.GetTempPath(),
+            "agentdeck-workflow-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workingDirectory);
+        startInfo.WorkingDirectory = workingDirectory;
+
         startInfo.UseShellExecute = false;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
@@ -549,6 +557,17 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
         }
         catch (Exception ex)
         {
+            try
+            {
+                if (Directory.Exists(workingDirectory))
+                {
+                    Directory.Delete(workingDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
             return new ShellCommandResult(false, -1, string.Empty, ex.Message);
         }
 
@@ -570,6 +589,18 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
         var standardErrorTask = process.StandardError.ReadToEndAsync();
         await Task.WhenAll(standardOutputTask, standardErrorTask, process.WaitForExitAsync());
         cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            if (Directory.Exists(workingDirectory))
+            {
+                Directory.Delete(workingDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup; do not fail the step over a leftover temp dir
+        }
 
         return new ShellCommandResult(
             process.ExitCode == 0,


### PR DESCRIPTION
Closes #328.

## Change
- `RunnerWorkflowPackService.RunShellCommandAsync`: create a per-invocation `Path.GetTempPath()/agentdeck-workflow-<guid>` directory and assign it to `ProcessStartInfo.WorkingDirectory`. Best-effort cleanup on success and on the `process.Start()` failure path.
- `MachineSetupService` (capability install ProcessStartInfo): same pattern with `agentdeck-capability-<guid>`. Cleanup on success path and on the `InvalidOperationException/Win32Exception` failure path.

## Why
Previously these steps inherited the runner's CWD (install dir, next to `appsettings.json` and signing keys). Any relative write (`./foo`) by a workflow/capability step would land there.

## Verification
`dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj` — green, 0 warnings.