### PR TITLE
fix(#330): await tasks instead of blocking on .Result

### DIFF
--- a/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
+++ b/AgentDeck.Core/Services/RemoteViewerRelayClient.cs
@@ -147,14 +147,17 @@ public sealed class RemoteViewerRelayClient : IAsyncDisposable
         var remoteControlTask = _coordinatorClient.GetMachineRemoteControlStateAsync(coordinatorUrl, machineId, cancellationToken);
         await Task.WhenAll(viewerSessionsTask, remoteControlTask);
 
-        var session = viewerSessionsTask.Result
+        var viewerSessions = await viewerSessionsTask;
+        var remoteControlState = await remoteControlTask;
+
+        var session = viewerSessions
             .FirstOrDefault(candidate => string.Equals(candidate.Id, viewerSessionId, StringComparison.OrdinalIgnoreCase));
 
         await _sync.WaitAsync(cancellationToken);
         try
         {
             CurrentSession = session;
-            RemoteControlState = remoteControlTask.Result;
+            RemoteControlState = remoteControlState;
             if (session is null)
             {
                 CurrentFrameDataUrl = null;


### PR DESCRIPTION
Replaces `.Result` blocking with `await` on the two tasks already `Task.WhenAll`-ed in `RemoteViewerRelayClient.RefreshAsync`.

### Plan
- Locate both `.Result` calls at lines 150/157.
- Capture awaited values into locals between `WhenAll` and the lock re-entry.
- No behavior change: tasks are completed by `WhenAll`, so awaiting them is synchronous.

### Verification
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj` succeeds.

Fixes #330