### PR TITLE
fix(#331): use non-login bash -c in ShellLaunchBuilder

### DIFF
--- a/AgentDeck.Runner/Services/ShellLaunchBuilder.cs
+++ b/AgentDeck.Runner/Services/ShellLaunchBuilder.cs
@@ -40,9 +40,12 @@ public static class ShellLaunchBuilder
         }
 
         var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
+        // Use -c (non-login) so the wrapper doesn't re-run login profile scripts on every spawn.
+        // The trailing `exec {shellPath}` becomes the user-facing interactive shell which sources
+        // its own rc files as usual.
         return (shellPath,
         [
-            "-lc",
+            "-c",
             $"cd {QuotePosix(workingDirectory)} && {BuildShellCommand(command, arguments)}; exec {shellPath}"
         ]);
     }
@@ -61,9 +64,10 @@ public static class ShellLaunchBuilder
         }
 
         var shellPath = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
+        // Non-login: orchestration shouldn't re-source ~/.profile / ~/.bash_profile on every batch.
         return (shellPath,
         [
-            "-lc",
+            "-c",
             $"cd {QuotePosix(workingDirectory)} && {script}"
         ]);
     }


### PR DESCRIPTION
Switches `BuildInteractiveLaunch` and `BuildBatchLaunch` from `-lc` to `-c` so the orchestrator wrapper doesn't re-execute login profile scripts on every spawn.

The interactive launch still ends in `exec {shell}` — that interactive shell will source its own rc files normally, so the user-facing session is unchanged. Only the throwaway wrapper shell becomes non-login.

### Verification
- `dotnet build AgentDeck.Runner` succeeds.

### Out of scope
Other call sites pass `-lc` directly (MachineSetupService bootstrap, ProjectWorkspaceBootstrapService, RunnerWorkflowPackService, VsCodeDebugSessionService) — those have explicit reasons to want login behavior (setup probes, package managers on PATH) and aren't touched here.

Fixes #331