### PR TITLE
refactor(#338): extract shared JsonSerializerOptions defaults

### DIFF
--- a/AgentDeck.Core/Services/ConnectionSettingsService.cs
+++ b/AgentDeck.Core/Services/ConnectionSettingsService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using AgentDeck.Core.Models;
+using AgentDeck.Shared.Json;
 
 namespace AgentDeck.Core.Services;
 
@@ -7,7 +8,7 @@ namespace AgentDeck.Core.Services;
 public sealed class ConnectionSettingsService : IConnectionSettingsService
 {
     private readonly string _filePath;
-    private static readonly JsonSerializerOptions _json = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions _json = JsonDefaults.Indented;
 
     private sealed class LegacyConnectionSettings
     {

--- a/AgentDeck.Runner/Services/DesktopViewerBootstrapService.cs
+++ b/AgentDeck.Runner/Services/DesktopViewerBootstrapService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Options;
 
@@ -149,7 +150,7 @@ public sealed class DesktopViewerBootstrapService : IDesktopViewerBootstrapServi
         }
     }
 
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.Web;
     private static readonly TimeSpan OutputDrainTimeout = TimeSpan.FromSeconds(5);
     private readonly ConcurrentDictionary<string, ActiveDesktopTransport> _activeTransports = new();
     private readonly IRemoteViewerSessionService _viewers;

--- a/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Options;
 
@@ -9,7 +10,7 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class RunnerCapabilityCatalogService : IRunnerCapabilityCatalogService, IDisposable
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.WebIndented;
 
     private readonly WorkerCoordinatorOptions _options;
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);

--- a/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Options;
 
@@ -9,7 +10,7 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class RunnerSetupCatalogService : IRunnerSetupCatalogService, IDisposable
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.WebIndented;
 
     private readonly WorkerCoordinatorOptions _options;
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);

--- a/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 
 namespace AgentDeck.Runner.Services;
@@ -9,7 +10,7 @@ namespace AgentDeck.Runner.Services;
 internal static class RunnerUpdateApplyWorker
 {
     public const string HelperModeSwitch = "--runner-update-apply-worker";
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.WebIndented;
 
     public static async Task<int> RunAsync(string planPath, CancellationToken cancellationToken = default)
     {

--- a/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -12,7 +13,7 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, IDisposable
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.WebIndented;
 
     private readonly Lock _lock = new();
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);

--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AgentDeck.Runner.Configuration;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using Microsoft.Extensions.Options;
 
@@ -10,7 +11,7 @@ namespace AgentDeck.Runner.Services;
 
 public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDisposable
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.WebIndented;
 
     private readonly Lock _lock = new();
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);

--- a/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
+++ b/AgentDeck.Runner/Services/VsCodeDebugSessionService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Json;
 using AgentDeck.Shared.Models;
 using RdpPoc.Contracts;
 
@@ -25,10 +26,7 @@ public sealed class VsCodeDebugSessionService : IVsCodeDebugSessionService
         public int? HostProcessId { get; set; }
     }
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true
-    };
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.Indented;
 
     private readonly ConcurrentDictionary<string, ActiveDebugSession> _sessions = new();
     private readonly ConcurrentDictionary<string, VsCodeDebugSession> _sessionRecords = new();

--- a/AgentDeck.Shared/Json/JsonDefaults.cs
+++ b/AgentDeck.Shared/Json/JsonDefaults.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace AgentDeck.Shared.Json;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> instances used across services.
+/// Prefer these over per-service copies so settings (naming, casing, indentation)
+/// stay consistent and so we don't pay the per-instance metadata cache cost.
+/// </summary>
+public static class JsonDefaults
+{
+    /// <summary>
+    /// Web defaults (camelCase, case-insensitive property name matching, allows
+    /// reading numbers from strings). Compact output.
+    /// </summary>
+    public static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Web defaults with <see cref="JsonSerializerOptions.WriteIndented"/> = true.
+    /// Useful for on-disk catalog/state files that humans may eyeball.
+    /// </summary>
+    public static readonly JsonSerializerOptions WebIndented = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Default (PascalCase) options with indented output. Used by callers that
+    /// don't want web-style camelCase, e.g. legacy on-disk formats.
+    /// </summary>
+    public static readonly JsonSerializerOptions Indented = new()
+    {
+        WriteIndented = true
+    };
+}


### PR DESCRIPTION
Adds `AgentDeck.Shared.Json.JsonDefaults` with three preset `JsonSerializerOptions` instances:

- `Web` — `new(JsonSerializerDefaults.Web)`
- `WebIndented` — same + `WriteIndented = true`
- `Indented` — default (PascalCase) + indented, for legacy on-disk formats

Rewired 8 services to use them:

- AgentDeck.Core: `ConnectionSettingsService`
- AgentDeck.Runner: `DesktopViewerBootstrapService`, `RunnerCapabilityCatalogService`, `RunnerSetupCatalogService`, `RunnerUpdateStagingService`, `RunnerUpdateApplyWorker`, `RunnerWorkflowPackService`, `VsCodeDebugSessionService`

No behavior change — same option values, just consolidated so they can't drift.

### Verification
- `dotnet build` clean for `AgentDeck.Shared`, `AgentDeck.Runner`, `AgentDeck.Core`.

Fixes #338