### PR TITLE
docs(#342): default ASPNETCORE_ENVIRONMENT=Production in Dockerfile + README

### DIFF
--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000
+ENV ASPNETCORE_ENVIRONMENT=Production
 ENV AGENTDECK_WORKSPACE=/workspace
 
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker run --rm \
   agentdeck-runner
 ```
 
-The image exposes port `5000`, defaults the workspace to `/workspace`, and falls back to `/bin/sh` if `/bin/bash` is unavailable.
+The image exposes port `5000`, defaults the workspace to `/workspace`, sets `ASPNETCORE_ENVIRONMENT=Production` so detailed error responses are off, and falls back to `/bin/sh` if `/bin/bash` is unavailable. Override with `-e ASPNETCORE_ENVIRONMENT=Development` if you want development-only diagnostics (verbose SignalR errors, dev-only middleware, etc.) — never in a deployment exposed to untrusted networks.
 
 The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
 


### PR DESCRIPTION
Adds `ENV ASPNETCORE_ENVIRONMENT=Production` to `AgentDeck.Runner/Dockerfile` and documents the override in the README's Docker section. No code change; `builder.Environment.IsDevelopment()` gates in `Coordinator/Program.cs` and `Runner/Program.cs` are unchanged.

Fixes #342