### PR TITLE
feat: align product UX and viewer surfaces

### DIFF
--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -757,7 +757,7 @@ app.MapPost("/api/machines/{machineId}/viewers/sessions/{viewerSessionId}/contro
             var existingState = await ReconcileMachineRemoteControlAsync(machineId, remoteControl, runners, cancellationToken, viewers);
             var targetViewer = viewers.FirstOrDefault(viewer =>
                 string.Equals(viewer.Id, viewerSessionId.Trim(), StringComparison.OrdinalIgnoreCase));
-            if (targetViewer is null || targetViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+            if (targetViewer is null || targetViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
             {
                 return Results.NotFound(new { message = $"Machine '{machineId}' no longer exposes viewer session '{viewerSessionId}'." });
             }
@@ -1195,7 +1195,7 @@ static async Task<MachineRemoteControlState?> ReconcileMachineRemoteControlAsync
     viewers ??= await runners.GetViewerSessionsAsync(machineId, cancellationToken);
     var activeViewer = viewers.FirstOrDefault(viewer =>
         string.Equals(viewer.Id, state.ViewerSessionId, StringComparison.OrdinalIgnoreCase));
-    if (activeViewer is null || activeViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+    if (activeViewer is null || activeViewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
     {
         remoteControl.ClearState(machineId, state.ViewerSessionId);
         return null;

--- a/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerBrokerService.cs
@@ -128,7 +128,7 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
     {
         ArgumentNullException.ThrowIfNull(session);
         var sanitized = AnnotateViewerSession(machineId, session);
-        if (sanitized.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+        if (sanitized.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
         {
             _viewerSessions.TryRemove(sanitized.Id, out _);
             _viewerFrames.TryRemove(sanitized.Id, out _);
@@ -364,7 +364,7 @@ public sealed class RunnerBrokerService : IRunnerBrokerService
         }
 
         var annotated = AnnotateViewerSession(entry.MachineId, session);
-        if (annotated.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+        if (annotated.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
         {
             _viewerSessions.TryRemove(annotated.Id, out _);
             _viewerFrames.TryRemove(annotated.Id, out _);

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -55,7 +55,7 @@
     },
     "DesiredCapabilityCatalog": {
       "CatalogId": "default-capabilities",
-      "Version": "1",
+      "Version": "2",
       "DisplayName": "Default Capability Catalog",
       "Description": "Coordinator-authored capability probes for the built-in runner tool and SDK checks.",
       "Capabilities": [
@@ -124,6 +124,70 @@
             {
               "FileName": "dotnet",
               "Arguments": [ "--list-sdks" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "git",
+          "DisplayName": "Git",
+          "Category": "cli",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "git",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "docker",
+          "DisplayName": "Docker CLI",
+          "Category": "cli",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "docker",
+              "Arguments": [ "--version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "jdk",
+          "DisplayName": "Java JDK",
+          "Category": "sdk",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "javac",
+              "Arguments": [ "-version" ]
+            },
+            {
+              "FileName": "java",
+              "Arguments": [ "-version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "go",
+          "DisplayName": "Go",
+          "Category": "sdk",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "go",
+              "Arguments": [ "version" ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "pwsh",
+          "DisplayName": "PowerShell 7",
+          "Category": "cli",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "pwsh",
+              "Arguments": [ "--version" ]
             }
           ]
         }

--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -17,7 +17,7 @@
         <nav class="sidebar-nav">
             <a class="nav-item @(IsActive("/") ? "active" : "")" href="/">
                 <span class="nav-icon">⌂</span>
-                <span class="nav-label">Dashboard</span>
+                <span class="nav-label">Projects</span>
             </a>
 
             <div class="nav-section-header">Project Links</div>
@@ -106,14 +106,17 @@
         </main>
 
         <nav class="mobile-nav" aria-label="Primary">
-            <NavLink class="mobile-nav__item" href="/" Match="NavLinkMatch.All">
+            <NavLink class="mobile-nav__item" href="/" Match="NavLinkMatch.All" title="Projects">
                 <span class="mobile-nav__icon">⌂</span>
+                <span class="mobile-nav__label">Projects</span>
             </NavLink>
-            <NavLink class="mobile-nav__item" href="/terminals">
+            <NavLink class="mobile-nav__item" href="/terminals" title="Terminals">
                 <span class="mobile-nav__icon">▣</span>
+                <span class="mobile-nav__label">Terminals</span>
             </NavLink>
-            <NavLink class="mobile-nav__item" href="/settings">
+            <NavLink class="mobile-nav__item" href="/settings" title="Settings">
                 <span class="mobile-nav__icon">⚙</span>
+                <span class="mobile-nav__label">Settings</span>
             </NavLink>
         </nav>
     </div>

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -1418,15 +1418,28 @@
     }
 
     private static bool CanControlViewer(RemoteViewerSession viewer) =>
-        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed and not RemoteViewerSessionStatus.Unavailable;
 
     private static bool CanOpenInAppViewer(RemoteViewerSession viewer) =>
         viewer.Provider == RemoteViewerProviderKind.Managed &&
         viewer.Status == RemoteViewerSessionStatus.Ready &&
         !string.IsNullOrWhiteSpace(viewer.MachineId);
 
-    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer) =>
-        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer)
+    {
+        if (viewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
+        {
+            return false;
+        }
+
+        if ((viewer.Status is RemoteViewerSessionStatus.Requested or RemoteViewerSessionStatus.Preparing) &&
+            DateTimeOffset.UtcNow - viewer.UpdatedAt > TimeSpan.FromMinutes(5))
+        {
+            return false;
+        }
+
+        return true;
+    }
 
     private bool CanCancelJob(OrchestrationJob job) =>
         _cancellingJobId != job.Id &&

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -129,6 +129,17 @@
                     <div class="terminal-area terminal-area--single project-session-terminal">
                         <TerminalPanel Session="_attachedTerminalSession!" IsActive="true" />
                     </div>
+                    @if (CanCreateManagedTerminalWindowViewer())
+                    {
+                        <div class="project-runtime-card__actions">
+                            <button class="btn btn-accent"
+                                    disabled="@_viewerActionInProgress"
+                                    @onclick="CreateManagedTerminalWindowViewerAsync">
+                                @(_viewerActionInProgress ? "Requesting viewer..." : "Add managed window viewer")
+                            </button>
+                        </div>
+                        <p class="surface-details-card__note">First-pass window surfacing creates a managed viewer tied to this terminal session. Automatic child-window discovery remains platform dependent.</p>
+                    }
                 }
                 else
                 {
@@ -366,13 +377,16 @@
             .ToArray();
 
         var jobIds = _runtimeJobs.Select(job => job.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        _runtimeViewers = viewersTask.Result
+        var machineCanAdvertiseLiveViewers = _sessionMachine?.IsOnline == true;
+        _runtimeViewers = machineCanAdvertiseLiveViewers
+            ? viewersTask.Result
             .Where(viewer =>
                 IsVisibleRuntimeViewer(viewer) &&
                 ((!string.IsNullOrWhiteSpace(viewer.JobId) && jobIds.Contains(viewer.JobId)) ||
                  (!string.IsNullOrWhiteSpace(viewer.Target.JobId) && jobIds.Contains(viewer.Target.JobId))))
             .OrderByDescending(viewer => viewer.UpdatedAt)
-            .ToArray();
+            .ToArray()
+            : [];
         _remoteControlState = remoteControlTask.Result;
     }
 
@@ -694,7 +708,7 @@
     private static ProjectSessionSurfaceStatus MapViewerStatus(RemoteViewerSessionStatus status) => status switch
     {
         RemoteViewerSessionStatus.Ready => ProjectSessionSurfaceStatus.Ready,
-        RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Closed => ProjectSessionSurfaceStatus.Failed,
+        RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Unavailable => ProjectSessionSurfaceStatus.Failed,
         _ => ProjectSessionSurfaceStatus.Requested
     };
 
@@ -756,7 +770,7 @@
         var shouldSyncActiveViewer =
             activeViewer is not null &&
             !string.IsNullOrWhiteSpace(activeViewerMachineId) &&
-            activeViewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed &&
+            activeViewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed and not RemoteViewerSessionStatus.Unavailable &&
             (mode is ProjectSessionControlRequestMode.Request or ProjectSessionControlRequestMode.ForceTakeover ||
              IsActiveViewerControlledByCurrentCompanion());
 
@@ -809,6 +823,63 @@
         catch (Exception ex)
         {
             return $"Project-session control updated, but syncing viewer control for {viewer.Target.DisplayName} failed: {ex.Message}";
+        }
+    }
+
+
+    private bool CanCreateManagedTerminalWindowViewer() =>
+        _activeSurface?.Kind == ProjectSessionSurfaceKind.Terminal &&
+        _attachedTerminalSession is not null &&
+        _projectSession is not null &&
+        !string.IsNullOrWhiteSpace(_coordinatorUrl) &&
+        !string.IsNullOrWhiteSpace(_projectSession.MachineId);
+
+    private async Task CreateManagedTerminalWindowViewerAsync()
+    {
+        if (!CanCreateManagedTerminalWindowViewer())
+        {
+            return;
+        }
+
+        _viewerActionInProgress = true;
+        try
+        {
+            var session = await CoordinatorClient.CreateMachineViewerSessionAsync(
+                _coordinatorUrl!,
+                _projectSession!.MachineId!,
+                new CreateMachineViewerSessionRequest
+                {
+                    Viewer = new CreateRemoteViewerSessionRequest
+                    {
+                        MachineId = _projectSession.MachineId,
+                        MachineName = _projectSession.MachineName,
+                        JobId = _activeSurface?.Job?.Id,
+                        Target = new RemoteViewerTarget
+                        {
+                            Kind = RemoteViewerTargetKind.Window,
+                            DisplayName = $"{_attachedTerminalSession!.Name} window",
+                            SessionId = _attachedTerminalSession.Id,
+                            JobId = _activeSurface?.Job?.Id
+                        }
+                    }
+                });
+
+            Toasts.Show(
+                session?.StatusMessage ?? "Requested a managed window viewer for this terminal.",
+                session?.Status == RemoteViewerSessionStatus.Failed ? ToastKind.Warning : ToastKind.Info);
+            await LoadAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Warning);
+        }
+        catch (Exception ex)
+        {
+            Toasts.Show(ex.Message, ToastKind.Error);
+        }
+        finally
+        {
+            _viewerActionInProgress = false;
         }
     }
 
@@ -926,15 +997,28 @@
 
     private bool CanControlActiveViewer() =>
         _activeSurface?.Viewer is not null &&
-        _activeSurface.Viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+        _activeSurface.Viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed and not RemoteViewerSessionStatus.Unavailable;
 
     private static bool CanOpenInAppViewer(RemoteViewerSession viewer) =>
         viewer.Provider == RemoteViewerProviderKind.Managed &&
         viewer.Status == RemoteViewerSessionStatus.Ready &&
         !string.IsNullOrWhiteSpace(viewer.MachineId);
 
-    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer) =>
-        viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+    private static bool IsVisibleRuntimeViewer(RemoteViewerSession viewer)
+    {
+        if (viewer.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
+        {
+            return false;
+        }
+
+        if ((viewer.Status is RemoteViewerSessionStatus.Requested or RemoteViewerSessionStatus.Preparing) &&
+            DateTimeOffset.UtcNow - viewer.UpdatedAt > TimeSpan.FromMinutes(5))
+        {
+            return false;
+        }
+
+        return true;
+    }
 
     private bool IsActiveViewerControlledByCurrentCompanion() =>
         _activeSurface?.Viewer is not null &&

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -408,7 +408,7 @@
 
     private bool CanOpenControlActions() =>
         ViewerClient.CurrentSession is not null &&
-        ViewerClient.CurrentSession.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed;
+        ViewerClient.CurrentSession.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed and not RemoteViewerSessionStatus.Unavailable;
 
     private bool CanSendNativeWindowShortcut() =>
         _machineHostPlatform == AgentDeck.Shared.Enums.RunnerHostPlatform.MacOS &&

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -10,14 +10,22 @@
     <div class="page-header settings-page__header">
         <div>
             <h1>Settings</h1>
-            <p>Manage the coordinator API, coordinator-brokered runner access, and machine setup from one place.</p>
+            <p>Connect to a coordinator, choose runner machines, inspect setup capabilities, manage runner updates, and keep advanced machine details in one place.</p>
         </div>
     </div>
 
-    <div class="settings-card settings-page__card">
+    <nav class="settings-nav" aria-label="Settings sections">
+        <a href="#connection">Connection</a>
+        <a href="#machines">Machines</a>
+        <a href="#setup-capabilities">Setup &amp; Capabilities</a>
+        <a href="#runner-updates">Runner Updates</a>
+        <a href="#advanced">Advanced</a>
+    </nav>
+
+    <div id="connection" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
-                <h2>Coordinator API</h2>
+                <h2>Connection</h2>
                 <p class="settings-card__description">Use one coordinator as the only client-facing endpoint. The companion now routes terminal and machine-control traffic through the coordinator instead of connecting to runners directly.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
@@ -129,10 +137,10 @@
         }
     </div>
 
-    <div class="settings-card settings-page__card">
+    <div id="machines" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
-                <h2>Runner Machines</h2>
+                <h2>Machines</h2>
                 <p class="settings-card__description">Choose coordinator-discovered runner machines, keep local preferences like auto-connect/default terminal, and control how new terminals are created through the coordinator.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
@@ -233,13 +241,17 @@
     @if (SelectedMachine is not null)
     {
         <div class="settings-page__details">
-            <div class="settings-card settings-page__card settings-card--status">
+            <div id="runner-updates" class="settings-card settings-page__card settings-card--status settings-card--anchored">
                 <div class="settings-card__header settings-page__section-header">
                     <div>
-                        <h2>Connection Status</h2>
-                        <p class="settings-card__description">@SelectedMachine?.Name</p>
+                        <h2>Runner Updates</h2>
+                        <p class="settings-card__description">Rollout intent, catalog reconciliation, and current state for @SelectedMachine?.Name.</p>
                     </div>
                 </div>
+                    <div class="settings-callout">
+                        <strong>Update lane</strong>
+                        <span>Use this section when a runner advertises a desired manifest or workflow pack. General machine editing stays above; setup tools stay below.</span>
+                    </div>
                     <div class="settings-status-list">
                     <div class="settings-status-row">
                         <span class="settings-status-row__label">State</span>
@@ -502,11 +514,11 @@
                     </div>
                 </div>
 
-            <div class="settings-card settings-page__card">
+            <div id="setup-capabilities" class="settings-card settings-page__card settings-card--anchored">
                 <div class="settings-card__header settings-page__section-header">
                     <div>
-                        <h2>Machine Setup</h2>
-                        <p class="settings-card__description">@SelectedMachine!.Name</p>
+                        <h2>Setup &amp; Capabilities</h2>
+                        <p class="settings-card__description">Tool/SDK detection and setup actions for @SelectedMachine!.Name.</p>
                     </div>
                     <div class="form-actions form-actions--toolbar">
                         <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
@@ -692,6 +704,41 @@
                         </div>
                     }
                 }
+            </div>
+
+            <div id="advanced" class="settings-card settings-page__card settings-card--anchored">
+                <div class="settings-card__header settings-page__section-header">
+                    <div>
+                        <h2>Advanced</h2>
+                        <p class="settings-card__description">Low-level coordinator and runner identifiers useful for debugging support issues.</p>
+                    </div>
+                </div>
+
+                <div class="settings-status-list">
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">Machine id</span>
+                        <code class="settings-status-row__value">@SelectedMachine!.Id</code>
+                    </div>
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">Coordinator URL</span>
+                        <code class="settings-status-row__value">@_settings.CoordinatorUrl</code>
+                    </div>
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">Advertised runner URL</span>
+                        <code class="settings-status-row__value">@(!string.IsNullOrWhiteSpace(SelectedMachine.RunnerUrl) ? SelectedMachine.RunnerUrl : "Not advertised")</code>
+                    </div>
+                    @if (SelectedRegisteredMachine is not null)
+                    {
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Registered as</span>
+                            <span class="settings-status-row__value">@SelectedRegisteredMachine.MachineName</span>
+                        </div>
+                        <div class="settings-status-row">
+                            <span class="settings-status-row__label">Last seen</span>
+                            <span class="settings-status-row__value">@SelectedRegisteredMachine.LastSeenAt.ToLocalTime().ToString("g")</span>
+                        </div>
+                    }
+                </div>
             </div>
         </div>
     }

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -2342,3 +2342,75 @@ html, body {
     background: rgba(137, 180, 250, 0.16);
     border-color: rgba(137, 180, 250, 0.4);
 }
+
+.settings-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0 1.5rem;
+    padding: 0.75rem;
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 10px;
+    background: rgba(17,17,27,0.55);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    backdrop-filter: blur(12px);
+}
+
+.settings-nav a {
+    color: var(--color-subtext);
+    text-decoration: none;
+    padding: 0.4rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,0.08);
+    font-size: 0.8rem;
+}
+
+.settings-nav a:hover {
+    color: var(--color-text);
+    border-color: rgba(137,180,250,0.35);
+    background: rgba(137,180,250,0.12);
+}
+
+.settings-card--anchored {
+    scroll-margin-top: 5rem;
+}
+
+.settings-callout {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin: 0 0 1rem;
+    padding: 0.85rem 1rem;
+    border-radius: 8px;
+    border: 1px solid rgba(137,180,250,0.18);
+    background: rgba(137,180,250,0.08);
+    color: var(--color-subtext);
+    font-size: 0.82rem;
+}
+
+.settings-callout strong {
+    color: var(--color-text);
+}
+
+.mobile-nav__label {
+    display: none;
+    font-size: 0.62rem;
+    line-height: 1;
+}
+
+@media (max-width: 640px) {
+    .mobile-nav__item {
+        flex-direction: column;
+        gap: 0.2rem;
+        width: auto;
+        min-width: 4.25rem;
+        padding: 0.35rem 0.55rem;
+        height: auto;
+    }
+
+    .mobile-nav__label {
+        display: inline;
+    }
+}

--- a/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
+++ b/AgentDeck.Runner/Services/CoordinatorRunnerConnectionService.cs
@@ -677,7 +677,7 @@ public sealed class CoordinatorRunnerConnectionService : BackgroundService, IAsy
         {
             await _publisher.PublishViewerSessionUpdatedAsync(viewer, cancellationToken);
             if (viewer.Provider == RemoteViewerProviderKind.Managed &&
-                viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed &&
+                viewer.Status is not RemoteViewerSessionStatus.Closed and not RemoteViewerSessionStatus.Failed and not RemoteViewerSessionStatus.Unavailable &&
                 _managedViewerRelay.GetLatestFrame(viewer.Id) is { } frame)
             {
                 await _publisher.PublishViewerFrameAsync(

--- a/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
+++ b/AgentDeck.Runner/Services/RemoteViewerSessionService.cs
@@ -251,12 +251,16 @@ public sealed class RemoteViewerSessionService : IRemoteViewerSessionService
             (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Preparing) => true,
             (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Failed) => true,
             (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Requested, RemoteViewerSessionStatus.Unavailable) => true,
             (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Ready) => true,
             (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Failed) => true,
             (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Preparing, RemoteViewerSessionStatus.Unavailable) => true,
             (RemoteViewerSessionStatus.Ready, RemoteViewerSessionStatus.Closed) => true,
             (RemoteViewerSessionStatus.Ready, RemoteViewerSessionStatus.Failed) => true,
+            (RemoteViewerSessionStatus.Ready, RemoteViewerSessionStatus.Unavailable) => true,
             (RemoteViewerSessionStatus.Failed, RemoteViewerSessionStatus.Closed) => true,
+            (RemoteViewerSessionStatus.Unavailable, RemoteViewerSessionStatus.Closed) => true,
             _ => false
         };
     }
@@ -323,7 +327,7 @@ public sealed class RemoteViewerSessionService : IRemoteViewerSessionService
     private void PruneTerminalSessions(string protectedSessionId)
     {
         var orderedTerminalSessions = _sessions.Values
-            .Where(session => session.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed)
+            .Where(session => session.Status is RemoteViewerSessionStatus.Closed or RemoteViewerSessionStatus.Failed or RemoteViewerSessionStatus.Unavailable)
             .OrderByDescending(session => session.UpdatedAt)
             .ThenByDescending(session => session.CreatedAt)
             .ThenBy(session => session.Id, StringComparer.Ordinal)

--- a/AgentDeck.Shared/Enums/RemoteViewerSessionStatus.cs
+++ b/AgentDeck.Shared/Enums/RemoteViewerSessionStatus.cs
@@ -7,5 +7,6 @@ public enum RemoteViewerSessionStatus
     Preparing,
     Ready,
     Failed,
-    Closed
+    Closed,
+    Unavailable
 }

--- a/docs/product-vision-alignment.md
+++ b/docs/product-vision-alignment.md
@@ -1,0 +1,19 @@
+# Product vision alignment
+
+AgentDeck is being steered toward "any workflow / any CLI / any IDE" rather than a closed .NET-only launcher. The current implementation moves a few surfaces in that direction:
+
+- **Settings IA:** Settings now has first-class lanes for Connection, Machines, Setup & Capabilities, Runner Updates, and Advanced diagnostics.
+- **Projects-first navigation:** The main dashboard remains project-led, with mobile navigation explicitly exposing Projects as the primary entry point.
+- **Capability breadth:** The default capability catalog now probes Git, Docker CLI, Java JDK, Go, and PowerShell 7 in addition to the existing GitHub, Copilot, Node, Python, and .NET checks.
+- **Viewer lifecycle trust:** Closed, failed, unavailable, stale, or offline-machine viewer sessions are filtered out of live project/process surface tabs.
+- **Managed terminal window surfacing:** Project-session terminals can request a managed window viewer tied to the owning terminal session. Automatic child-window discovery remains platform-specific follow-up work.
+
+## Deferred follow-up
+
+These larger architecture items remain intentionally out of this slice:
+
+1. Replace closed workload/launch-driver enums with extensible models.
+2. User-managed CLI presets and terminal quick actions.
+3. Auth/authz and coordinator persistence.
+4. Native child-process window inventory per platform for fully automatic managed-terminal window surfacing.
+5. Companion workflow-pack marketplace/discovery UX.


### PR DESCRIPTION
## Summary
- Reorganized Settings around Connection, Machines, Setup & Capabilities, Runner Updates, and Advanced diagnostics.
- Added default capability probes for Git, Docker CLI, Java JDK, Go, and PowerShell 7.
- Improved live viewer filtering so closed/failed/unavailable/stale sessions and offline-machine sessions do not appear as active project/process tabs.
- Added a first-pass managed-terminal window viewer action that creates a managed window viewer tied to the terminal session.
- Documented product-vision alignment and made Projects clearer in mobile navigation.

## Fully implemented
- #308: live project/process viewer tab filtering for failed, closed, unavailable, stale preparing/requested viewers, and offline machines.
- The capability-catalog portion of #73: coordinator-authored probes now include Git, Docker CLI, JDK, Go, and PowerShell 7.

## Partially addressed / deferred
- #285: Settings IA has the requested high-level lanes, but this does not close the broader redesign tracking issue.
- #310: UI/data-model plumbing can request a managed terminal window viewer; automatic OS-specific child-window discovery/capture is deferred.
- #313: Adds product-positioning docs, broader capability probes, and onboarding/nav improvements; extensible workloads/drivers, user-managed CLI presets, auth/persistence, and marketplace-style workflow discovery remain deferred.

## Validation
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore` (passes; existing nullable warning in `ProjectDetails.razor` remains)
- `dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore`
- `dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj --no-restore`

Note: full `dotnet build AgentDeck.slnx` still fails on the existing MAUI package downgrade (`Microsoft.Maui.Controls` 10.0.50 -> 10.0.30).

Closes #308.
Partially addresses #73.
Partially addresses #285.
Partially addresses #310.
Partially addresses #313.
