### PR TITLE
Harden runner update and catalog trust

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorCapabilityCatalogOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorCapabilityCatalogOptions.cs
@@ -2,7 +2,7 @@ using AgentDeck.Shared.Enums;
 
 namespace AgentDeck.Coordinator.Configuration;
 
-public sealed class CoordinatorCapabilityCatalogOptions
+public sealed class CoordinatorCapabilityCatalogOptions : CoordinatorDefinitionSignatureOptions
 {
     public string CatalogId { get; set; } = "default";
     public string Version { get; set; } = "1";

--- a/AgentDeck.Coordinator/Configuration/CoordinatorDefinitionSignatureOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorDefinitionSignatureOptions.cs
@@ -1,0 +1,11 @@
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Coordinator.Configuration;
+
+public abstract class CoordinatorDefinitionSignatureOptions
+{
+    public string SignatureAlgorithm { get; set; } = RunnerUpdateManifestSigning.RsaSha256Algorithm;
+    public string? SignerId { get; set; }
+    public string? PrivateKeyPem { get; set; }
+    public string? Signature { get; set; }
+}

--- a/AgentDeck.Coordinator/Configuration/CoordinatorSetupCatalogOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorSetupCatalogOptions.cs
@@ -2,7 +2,7 @@ using AgentDeck.Shared.Enums;
 
 namespace AgentDeck.Coordinator.Configuration;
 
-public sealed class CoordinatorSetupCatalogOptions
+public sealed class CoordinatorSetupCatalogOptions : CoordinatorDefinitionSignatureOptions
 {
     public string CatalogId { get; set; } = "default-setup";
     public string Version { get; set; } = "1";

--- a/AgentDeck.Coordinator/Configuration/CoordinatorWorkflowPackOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorWorkflowPackOptions.cs
@@ -1,6 +1,6 @@
 namespace AgentDeck.Coordinator.Configuration;
 
-public sealed class CoordinatorWorkflowPackOptions
+public sealed class CoordinatorWorkflowPackOptions : CoordinatorDefinitionSignatureOptions
 {
     public string PackId { get; set; } = "default-machine-setup";
     public string Version { get; set; } = "1";

--- a/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerDefinitionCatalogService.cs
@@ -65,12 +65,13 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
         };
         ValidateUpdateManifest(_desiredUpdateManifest, options.PublicBaseUrl, securityPolicy);
 
-        _desiredWorkflowPack = new RunnerWorkflowPack
+        var unsignedWorkflowPack = new RunnerWorkflowPack
         {
             PackId = NormalizeRequired(desiredWorkflowPack.PackId, $"{CoordinatorOptions.SectionName}:DesiredWorkflowPack:PackId"),
             Version = NormalizeRequired(desiredWorkflowPack.Version, $"{CoordinatorOptions.SectionName}:DesiredWorkflowPack:Version"),
             DisplayName = NormalizeRequired(desiredWorkflowPack.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredWorkflowPack:DisplayName"),
             Description = NormalizeOptional(desiredWorkflowPack.Description),
+            Provenance = CloneProvenance(unsignedManifest.Provenance),
             Steps = (desiredWorkflowPack.Steps ?? [])
                 .Where(step => !string.IsNullOrWhiteSpace(step.StepId))
                 .Select(step => new RunnerWorkflowStep
@@ -85,15 +86,27 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                         .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
                         .ToDictionary(pair => pair.Key.Trim(), pair => pair.Value, StringComparer.OrdinalIgnoreCase)
                 })
-                .ToArray()
+                .ToArray(),
+            Signature = null
+        };
+        _desiredWorkflowPack = new RunnerWorkflowPack
+        {
+            PackId = unsignedWorkflowPack.PackId,
+            Version = unsignedWorkflowPack.Version,
+            DisplayName = unsignedWorkflowPack.DisplayName,
+            Description = unsignedWorkflowPack.Description,
+            Steps = unsignedWorkflowPack.Steps,
+            Provenance = unsignedWorkflowPack.Provenance,
+            Signature = BuildWorkflowPackSignature(unsignedWorkflowPack, desiredWorkflowPack)
         };
 
-        _desiredCapabilityCatalog = new RunnerCapabilityCatalog
+        var unsignedCapabilityCatalog = new RunnerCapabilityCatalog
         {
             CatalogId = NormalizeRequired(desiredCapabilityCatalog.CatalogId, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:CatalogId"),
             Version = NormalizeRequired(desiredCapabilityCatalog.Version, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:Version"),
             DisplayName = NormalizeRequired(desiredCapabilityCatalog.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog:DisplayName"),
             Description = NormalizeOptional(desiredCapabilityCatalog.Description),
+            Provenance = CloneProvenance(unsignedManifest.Provenance),
             Capabilities = (desiredCapabilityCatalog.Capabilities ?? [])
                 .Where(capability => !string.IsNullOrWhiteSpace(capability.CapabilityId))
                 .Select(capability => new RunnerCapabilityDefinition
@@ -114,15 +127,27 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                         })
                         .ToArray()
                 })
-                .ToArray()
+                .ToArray(),
+            Signature = null
+        };
+        _desiredCapabilityCatalog = new RunnerCapabilityCatalog
+        {
+            CatalogId = unsignedCapabilityCatalog.CatalogId,
+            Version = unsignedCapabilityCatalog.Version,
+            DisplayName = unsignedCapabilityCatalog.DisplayName,
+            Description = unsignedCapabilityCatalog.Description,
+            Capabilities = unsignedCapabilityCatalog.Capabilities,
+            Provenance = unsignedCapabilityCatalog.Provenance,
+            Signature = BuildCapabilityCatalogSignature(unsignedCapabilityCatalog, desiredCapabilityCatalog)
         };
 
-        _desiredSetupCatalog = new RunnerSetupCatalog
+        var unsignedSetupCatalog = new RunnerSetupCatalog
         {
             CatalogId = NormalizeRequired(desiredSetupCatalog.CatalogId, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:CatalogId"),
             Version = NormalizeRequired(desiredSetupCatalog.Version, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:Version"),
             DisplayName = NormalizeRequired(desiredSetupCatalog.DisplayName, $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog:DisplayName"),
             Description = NormalizeOptional(desiredSetupCatalog.Description),
+            Provenance = CloneProvenance(unsignedManifest.Provenance),
             Capabilities = (desiredSetupCatalog.Capabilities ?? [])
                 .Where(capability => !string.IsNullOrWhiteSpace(capability.CapabilityId))
                 .Select(capability => new RunnerSetupCapabilityDefinition
@@ -158,7 +183,18 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                         })
                         .ToArray()
                 })
-                .ToArray()
+                .ToArray(),
+            Signature = null
+        };
+        _desiredSetupCatalog = new RunnerSetupCatalog
+        {
+            CatalogId = unsignedSetupCatalog.CatalogId,
+            Version = unsignedSetupCatalog.Version,
+            DisplayName = unsignedSetupCatalog.DisplayName,
+            Description = unsignedSetupCatalog.Description,
+            Capabilities = unsignedSetupCatalog.Capabilities,
+            Provenance = unsignedSetupCatalog.Provenance,
+            Signature = BuildSetupCatalogSignature(unsignedSetupCatalog, desiredSetupCatalog)
         };
     }
 
@@ -210,6 +246,18 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
             : artifactService.ResolveHostedArtifact(manifest.HostedArtifactPath, options.PublicBaseUrl);
     }
 
+    private static RunnerUpdateManifestProvenance? CloneProvenance(RunnerUpdateManifestProvenance? provenance) =>
+        provenance is null
+            ? null
+            : new RunnerUpdateManifestProvenance
+            {
+                SourceRepository = provenance.SourceRepository,
+                SourceRevision = provenance.SourceRevision,
+                BuildIdentifier = provenance.BuildIdentifier,
+                PublishedBy = provenance.PublishedBy,
+                ProvenanceUri = provenance.ProvenanceUri
+            };
+
     private static RunnerUpdateManifestSignature? BuildManifestSignature(
         RunnerUpdateManifest manifest,
         CoordinatorUpdateManifestOptions options)
@@ -243,6 +291,75 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
                 Algorithm = algorithm,
                 SignerId = NormalizeRequired(options.SignerId, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:SignerId"),
                 Value = NormalizeRequired(options.Signature, $"{CoordinatorOptions.SectionName}:DesiredUpdateManifest:Signature")
+            }
+            : null;
+    }
+
+    private static RunnerUpdateManifestSignature? BuildWorkflowPackSignature(
+        RunnerWorkflowPack pack,
+        CoordinatorWorkflowPackOptions options) =>
+        BuildDefinitionSignature(
+            options,
+            $"{CoordinatorOptions.SectionName}:DesiredWorkflowPack",
+            privateKey => RunnerSignedDefinitionPayload.TrySignWorkflowPack(pack, privateKey, out var signatureValue, out var error)
+                ? (true, signatureValue, error)
+                : (false, string.Empty, error));
+
+    private static RunnerUpdateManifestSignature? BuildCapabilityCatalogSignature(
+        RunnerCapabilityCatalog catalog,
+        CoordinatorCapabilityCatalogOptions options) =>
+        BuildDefinitionSignature(
+            options,
+            $"{CoordinatorOptions.SectionName}:DesiredCapabilityCatalog",
+            privateKey => RunnerSignedDefinitionPayload.TrySignCapabilityCatalog(catalog, privateKey, out var signatureValue, out var error)
+                ? (true, signatureValue, error)
+                : (false, string.Empty, error));
+
+    private static RunnerUpdateManifestSignature? BuildSetupCatalogSignature(
+        RunnerSetupCatalog catalog,
+        CoordinatorSetupCatalogOptions options) =>
+        BuildDefinitionSignature(
+            options,
+            $"{CoordinatorOptions.SectionName}:DesiredSetupCatalog",
+            privateKey => RunnerSignedDefinitionPayload.TrySignSetupCatalog(catalog, privateKey, out var signatureValue, out var error)
+                ? (true, signatureValue, error)
+                : (false, string.Empty, error));
+
+    private static RunnerUpdateManifestSignature? BuildDefinitionSignature(
+        CoordinatorDefinitionSignatureOptions options,
+        string optionPath,
+        Func<string, (bool Succeeded, string SignatureValue, string Error)> signer)
+    {
+        var algorithm = NormalizeRequired(options.SignatureAlgorithm, $"{optionPath}:SignatureAlgorithm");
+        if (!string.IsNullOrWhiteSpace(options.PrivateKeyPem))
+        {
+            if (!string.Equals(algorithm, RunnerUpdateManifestSigning.RsaSha256Algorithm, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Coordinator definition auto-signing only supports '{RunnerUpdateManifestSigning.RsaSha256Algorithm}'.");
+            }
+
+            var signerId = NormalizeRequired(options.SignerId, $"{optionPath}:SignerId");
+            var result = signer(options.PrivateKeyPem);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(result.Error);
+            }
+
+            return new RunnerUpdateManifestSignature
+            {
+                Algorithm = algorithm,
+                SignerId = signerId,
+                Value = result.SignatureValue
+            };
+        }
+
+        return HasConfiguredDefinitionSignature(options)
+            ? new RunnerUpdateManifestSignature
+            {
+                Algorithm = algorithm,
+                SignerId = NormalizeRequired(options.SignerId, $"{optionPath}:SignerId"),
+                Value = NormalizeRequired(options.Signature, $"{optionPath}:Signature")
             }
             : null;
     }
@@ -347,6 +464,10 @@ public sealed class RunnerDefinitionCatalogService : IRunnerDefinitionCatalogSer
     private static bool HasConfiguredSignature(CoordinatorUpdateManifestOptions manifest) =>
         !string.IsNullOrWhiteSpace(manifest.SignerId) ||
         !string.IsNullOrWhiteSpace(manifest.Signature);
+
+    private static bool HasConfiguredDefinitionSignature(CoordinatorDefinitionSignatureOptions definition) =>
+        !string.IsNullOrWhiteSpace(definition.SignerId) ||
+        !string.IsNullOrWhiteSpace(definition.Signature);
 
     private static IReadOnlyDictionary<string, RunnerTrustedManifestSigner> BuildTrustedSignerLookup(IReadOnlyList<RunnerTrustedManifestSigner> signers)
     {

--- a/AgentDeck.Runner/Configuration/RunnerLocalSecurityPolicyOptions.cs
+++ b/AgentDeck.Runner/Configuration/RunnerLocalSecurityPolicyOptions.cs
@@ -1,0 +1,18 @@
+namespace AgentDeck.Runner.Configuration;
+
+/// <summary>Runner-local minimum security policy. Coordinator payloads may only add stricter requirements.</summary>
+public sealed class RunnerLocalSecurityPolicyOptions
+{
+    public const string SectionName = "RunnerLocalSecurityPolicy";
+
+    public bool RequireCoordinatorOriginForArtifacts { get; set; } = true;
+    public bool RequireUpdateArtifactChecksum { get; set; } = true;
+    public bool RequireSignedUpdateManifest { get; set; } = true;
+    public bool RequireManifestProvenance { get; set; } = true;
+    public bool RequireSignedWorkflowPacks { get; set; } = true;
+    public bool RequireSignedCapabilityCatalogs { get; set; } = true;
+    public bool RequireSignedSetupCatalogs { get; set; } = true;
+    public bool AllowDevSignerInProduction { get; set; }
+    public IReadOnlyList<string> TrustedSignerIds { get; set; } = [];
+    public string? TrustedSignersDirectory { get; set; }
+}

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -27,6 +27,8 @@ builder.Services.AddOptions<WorkerCoordinatorOptions>()
     .Bind(builder.Configuration.GetSection(WorkerCoordinatorOptions.SectionName));
 builder.Services.AddOptions<TrustPolicyOptions>()
     .Bind(builder.Configuration.GetSection(TrustPolicyOptions.SectionName));
+builder.Services.AddOptions<RunnerLocalSecurityPolicyOptions>()
+    .Bind(builder.Configuration.GetSection(RunnerLocalSecurityPolicyOptions.SectionName));
 
 builder.WebHost.UseUrls($"http://0.0.0.0:{runnerOptions.Port}");
 
@@ -61,6 +63,7 @@ builder.Services.AddSingleton<IManagedViewerRelayService, ManagedViewerRelayServ
 builder.Services.AddSingleton<IDesktopViewerBootstrapService, DesktopViewerBootstrapService>();
 builder.Services.AddSingleton<IRunnerAuditService, RunnerAuditService>();
 builder.Services.AddSingleton<IRunnerTrustPolicy, RunnerTrustPolicy>();
+builder.Services.AddSingleton<RunnerLocalSecurityPolicy>();
 builder.Services.AddSingleton<IRunnerUpdateStagingService, RunnerUpdateStagingService>();
 builder.Services.AddSingleton<IRunnerWorkflowCatalogService, RunnerWorkflowCatalogService>();
 builder.Services.AddSingleton<IRunnerCapabilityCatalogService, RunnerCapabilityCatalogService>();

--- a/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerCapabilityCatalogService.cs
@@ -13,15 +13,18 @@ public sealed class RunnerCapabilityCatalogService : IRunnerCapabilityCatalogSer
 
     private readonly WorkerCoordinatorOptions _options;
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);
+    private readonly RunnerLocalSecurityPolicy _localSecurityPolicy;
     private readonly ILogger<RunnerCapabilityCatalogService> _logger;
     private RunnerCapabilityCatalog? _currentCatalog;
     private RunnerCapabilityCatalogStatus _currentStatus;
 
     public RunnerCapabilityCatalogService(
         IOptions<WorkerCoordinatorOptions> options,
+        RunnerLocalSecurityPolicy localSecurityPolicy,
         ILogger<RunnerCapabilityCatalogService> logger)
     {
         _options = options.Value;
+        _localSecurityPolicy = localSecurityPolicy;
         _logger = logger;
         _currentCatalog = LoadPersistedCatalog();
         _currentStatus = NormalizePersistedState(_currentCatalog, LoadPersistedStatus());
@@ -112,6 +115,15 @@ public sealed class RunnerCapabilityCatalogService : IRunnerCapabilityCatalogSer
                 {
                     throw new InvalidOperationException(
                         $"Coordinator capability catalog version '{catalog.Version}' did not match desired version '{desiredCatalogVersion}'.");
+                }
+
+                if (_localSecurityPolicy.RequireSignedCapabilityCatalogs || catalog.Signature is not null)
+                {
+                    _localSecurityPolicy.VerifySignedDefinition(
+                        "capability catalog",
+                        catalog.Signature,
+                        catalog.Provenance,
+                        (string publicKeyPem, out string error) => RunnerSignedDefinitionPayload.VerifySignature(catalog, publicKeyPem, out error));
                 }
 
                 Directory.CreateDirectory(GetCapabilityCatalogRoot());

--- a/AgentDeck.Runner/Services/RunnerLocalSecurityPolicy.cs
+++ b/AgentDeck.Runner/Services/RunnerLocalSecurityPolicy.cs
@@ -1,0 +1,165 @@
+using AgentDeck.Runner.Configuration;
+using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Runner.Services;
+
+public delegate bool RunnerDefinitionSignatureVerifier(string publicKeyPem, out string error);
+
+public sealed class RunnerLocalSecurityPolicy
+{
+    private readonly WorkerCoordinatorOptions _coordinatorOptions;
+    private readonly RunnerLocalSecurityPolicyOptions _localOptions;
+    private readonly IHostEnvironment _environment;
+    private IReadOnlyList<RunnerTrustedManifestSigner>? _trustedSigners;
+
+    public RunnerLocalSecurityPolicy(
+        IOptions<WorkerCoordinatorOptions> coordinatorOptions,
+        IOptions<RunnerLocalSecurityPolicyOptions> localOptions,
+        IHostEnvironment environment)
+    {
+        _coordinatorOptions = coordinatorOptions.Value;
+        _localOptions = localOptions.Value;
+        _environment = environment;
+    }
+
+    public RunnerControlPlaneSecurityPolicy EnforceMinimums(RunnerControlPlaneSecurityPolicy coordinatorPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(coordinatorPolicy);
+
+        var localSignerIds = GetAllowedLocalSignerIds();
+        var coordinatorSignerIds = coordinatorPolicy.TrustedManifestSignerIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var effectiveSignerIds = localSignerIds.Count == 0
+            ? coordinatorSignerIds.ToArray()
+            : coordinatorSignerIds.Count == 0
+                ? localSignerIds.ToArray()
+                : localSignerIds.Where(coordinatorSignerIds.Contains).ToArray();
+
+        var requiresSignedDefinitions = _localOptions.RequireSignedWorkflowPacks ||
+            _localOptions.RequireSignedCapabilityCatalogs ||
+            _localOptions.RequireSignedSetupCatalogs;
+
+        if ((_localOptions.RequireSignedUpdateManifest || requiresSignedDefinitions) && effectiveSignerIds.Length == 0)
+        {
+            throw new InvalidOperationException("Runner local security policy requires signed coordinator definitions but no trusted signer ids are available.");
+        }
+
+        return new RunnerControlPlaneSecurityPolicy
+        {
+            PolicyVersion = coordinatorPolicy.PolicyVersion,
+            AllowUpdateStaging = coordinatorPolicy.AllowUpdateStaging,
+            RequireCoordinatorOriginForArtifacts = _localOptions.RequireCoordinatorOriginForArtifacts || coordinatorPolicy.RequireCoordinatorOriginForArtifacts,
+            RequireUpdateArtifactChecksum = _localOptions.RequireUpdateArtifactChecksum || coordinatorPolicy.RequireUpdateArtifactChecksum,
+            RequireSignedUpdateManifest = _localOptions.RequireSignedUpdateManifest || coordinatorPolicy.RequireSignedUpdateManifest,
+            RequireManifestProvenance = _localOptions.RequireManifestProvenance || coordinatorPolicy.RequireManifestProvenance,
+            TrustedManifestSignerIds = effectiveSignerIds,
+            AllowWorkflowPackExecution = coordinatorPolicy.AllowWorkflowPackExecution,
+            AllowUpdateApply = coordinatorPolicy.AllowUpdateApply
+        };
+    }
+
+    public IReadOnlyList<RunnerTrustedManifestSigner> GetTrustedSigners() =>
+        _trustedSigners ??= LoadTrustedSigners();
+
+    public void VerifySignedDefinition(string payloadName, RunnerUpdateManifestSignature? signature, RunnerUpdateManifestProvenance? provenance, RunnerDefinitionSignatureVerifier verifier)
+    {
+        if (provenance is null || string.IsNullOrWhiteSpace(provenance.SourceRepository) || string.IsNullOrWhiteSpace(provenance.SourceRevision))
+        {
+            throw new InvalidOperationException($"Coordinator {payloadName} did not include required provenance.");
+        }
+
+        if (signature is null)
+        {
+            throw new InvalidOperationException($"Coordinator {payloadName} did not include a signature.");
+        }
+
+        var allowedSignerIds = GetAllowedLocalSignerIds();
+        if (allowedSignerIds.Count > 0 && !allowedSignerIds.Contains(signature.SignerId, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Coordinator {payloadName} signer '{signature.SignerId}' is not trusted by the runner-local security policy.");
+        }
+
+        var signer = GetTrustedSigners()
+            .FirstOrDefault(candidate => string.Equals(candidate.SignerId, signature.SignerId, StringComparison.OrdinalIgnoreCase));
+        if (signer is null)
+        {
+            throw new InvalidOperationException($"Runner does not have a trusted public key configured for signer '{signature.SignerId}'.");
+        }
+
+        if (!verifier(signer.PublicKeyPem, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+    }
+
+    public bool RequireSignedWorkflowPacks => _localOptions.RequireSignedWorkflowPacks;
+    public bool RequireSignedCapabilityCatalogs => _localOptions.RequireSignedCapabilityCatalogs;
+    public bool RequireSignedSetupCatalogs => _localOptions.RequireSignedSetupCatalogs;
+
+    private HashSet<string> GetAllowedLocalSignerIds()
+    {
+        var signerIds = _localOptions.TrustedSignerIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (signerIds.Count == 0)
+        {
+            foreach (var signer in GetTrustedSigners())
+            {
+                signerIds.Add(signer.SignerId.Trim());
+            }
+        }
+
+        if (!_localOptions.AllowDevSignerInProduction && !_environment.IsDevelopment())
+        {
+            signerIds.Remove("agentdeck-dev");
+        }
+
+        return signerIds;
+    }
+
+    private IReadOnlyList<RunnerTrustedManifestSigner> LoadTrustedSigners()
+    {
+        var signers = new Dictionary<string, RunnerTrustedManifestSigner>(StringComparer.OrdinalIgnoreCase);
+        foreach (var signer in _coordinatorOptions.TrustedManifestSigners)
+        {
+            AddSigner(signers, signer.SignerId, signer.PublicKeyPem);
+        }
+
+        var signersDirectory = ResolveSignersDirectory();
+        if (Directory.Exists(signersDirectory))
+        {
+            foreach (var file in Directory.EnumerateFiles(signersDirectory, "*.pem", SearchOption.TopDirectoryOnly))
+            {
+                AddSigner(signers, Path.GetFileNameWithoutExtension(file), File.ReadAllText(file));
+            }
+        }
+
+        return signers.Values.ToArray();
+    }
+
+    private string ResolveSignersDirectory() =>
+        string.IsNullOrWhiteSpace(_localOptions.TrustedSignersDirectory)
+            ? Path.Combine(AppContext.BaseDirectory, "signers.d")
+            : Path.GetFullPath(_localOptions.TrustedSignersDirectory);
+
+    private static void AddSigner(IDictionary<string, RunnerTrustedManifestSigner> signers, string? signerId, string? publicKeyPem)
+    {
+        if (string.IsNullOrWhiteSpace(signerId) || string.IsNullOrWhiteSpace(publicKeyPem))
+        {
+            return;
+        }
+
+        signers[signerId.Trim()] = new RunnerTrustedManifestSigner
+        {
+            SignerId = signerId.Trim(),
+            PublicKeyPem = publicKeyPem.Trim()
+        };
+    }
+}

--- a/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
+++ b/AgentDeck.Runner/Services/RunnerSetupCatalogService.cs
@@ -13,15 +13,18 @@ public sealed class RunnerSetupCatalogService : IRunnerSetupCatalogService, IDis
 
     private readonly WorkerCoordinatorOptions _options;
     private readonly SemaphoreSlim _reconcileGate = new(1, 1);
+    private readonly RunnerLocalSecurityPolicy _localSecurityPolicy;
     private readonly ILogger<RunnerSetupCatalogService> _logger;
     private RunnerSetupCatalog? _currentCatalog;
     private RunnerSetupCatalogStatus _currentStatus;
 
     public RunnerSetupCatalogService(
         IOptions<WorkerCoordinatorOptions> options,
+        RunnerLocalSecurityPolicy localSecurityPolicy,
         ILogger<RunnerSetupCatalogService> logger)
     {
         _options = options.Value;
+        _localSecurityPolicy = localSecurityPolicy;
         _logger = logger;
         _currentCatalog = LoadPersistedCatalog();
         _currentStatus = NormalizePersistedState(_currentCatalog, LoadPersistedStatus());
@@ -112,6 +115,15 @@ public sealed class RunnerSetupCatalogService : IRunnerSetupCatalogService, IDis
                 {
                     throw new InvalidOperationException(
                         $"Coordinator setup catalog version '{catalog.Version}' did not match desired version '{desiredCatalogVersion}'.");
+                }
+
+                if (_localSecurityPolicy.RequireSignedSetupCatalogs || catalog.Signature is not null)
+                {
+                    _localSecurityPolicy.VerifySignedDefinition(
+                        "setup catalog",
+                        catalog.Signature,
+                        catalog.Provenance,
+                        (string publicKeyPem, out string error) => RunnerSignedDefinitionPayload.VerifySignature(catalog, publicKeyPem, out error));
                 }
 
                 Directory.CreateDirectory(GetSetupCatalogRoot());

--- a/AgentDeck.Runner/Services/RunnerUpdateApplyPlan.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateApplyPlan.cs
@@ -10,6 +10,8 @@ internal sealed class RunnerUpdateApplyPlan
     public required string ArtifactPath { get; init; }
     public required string SourceInstallDirectory { get; init; }
     public required string CandidateInstallDirectory { get; init; }
+    public required string ApplyWorkerPath { get; init; }
+    public required string ApplyWorkerSha256 { get; init; }
     public TimeSpan ProcessExitTimeout { get; init; } = TimeSpan.FromMinutes(2);
     public DateTimeOffset ApplyStartedAt { get; init; } = DateTimeOffset.UtcNow;
 }

--- a/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Security.Cryptography;
 using System.Text.Json;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
@@ -21,6 +22,7 @@ internal static class RunnerUpdateApplyWorker
                 JsonOptions)
                 ?? throw new InvalidOperationException($"Runner update apply plan '{planPath}' was empty.");
 
+            await VerifyApplyWorkerIntegrityAsync(plan, cancellationToken);
             await WaitForTargetExitAsync(plan.TargetProcessId, plan.ProcessExitTimeout, cancellationToken);
 
             if (!File.Exists(plan.ArtifactPath))
@@ -74,6 +76,31 @@ internal static class RunnerUpdateApplyWorker
         finally
         {
             TryDeleteFile(planPath);
+        }
+    }
+
+    private static async Task VerifyApplyWorkerIntegrityAsync(RunnerUpdateApplyPlan plan, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(plan.ApplyWorkerPath) || string.IsNullOrWhiteSpace(plan.ApplyWorkerSha256))
+        {
+            throw new InvalidOperationException("Runner update apply plan did not include apply-worker integrity metadata.");
+        }
+
+        var currentWorkerPath = Environment.ProcessPath;
+        if (string.Equals(Path.GetFileNameWithoutExtension(currentWorkerPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            currentWorkerPath = typeof(RunnerUpdateApplyWorker).Assembly.Location;
+        }
+
+        if (!string.Equals(Path.GetFullPath(currentWorkerPath ?? string.Empty), Path.GetFullPath(plan.ApplyWorkerPath), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Runner update apply helper path did not match the planned helper path.");
+        }
+
+        var actualSha256 = await ComputeSha256Async(plan.ApplyWorkerPath, cancellationToken);
+        if (!string.Equals(actualSha256, plan.ApplyWorkerSha256, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Runner update apply helper SHA-256 did not match the planned helper hash.");
         }
     }
 
@@ -224,6 +251,13 @@ internal static class RunnerUpdateApplyWorker
         var tempPath = Path.Combine(directory, $"{Path.GetFileName(statusPath)}.{Guid.NewGuid():N}.tmp");
         await File.WriteAllTextAsync(tempPath, JsonSerializer.Serialize(status, JsonOptions), cancellationToken);
         File.Move(tempPath, statusPath, overwrite: true);
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     private static void TryDeleteFile(string path)

--- a/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateStagingService.cs
@@ -20,17 +20,20 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
     private readonly ILogger<RunnerUpdateStagingService> _logger;
     private readonly IHostApplicationLifetime _hostApplicationLifetime;
     private readonly IRunnerAuditService _audit;
+    private readonly RunnerLocalSecurityPolicy _localSecurityPolicy;
     private RunnerUpdateStatus? _currentStatus;
 
     public RunnerUpdateStagingService(
         IOptions<WorkerCoordinatorOptions> options,
         IHostApplicationLifetime hostApplicationLifetime,
         IRunnerAuditService audit,
+        RunnerLocalSecurityPolicy localSecurityPolicy,
         ILogger<RunnerUpdateStagingService> logger)
     {
         _options = options.Value;
         _hostApplicationLifetime = hostApplicationLifetime;
         _audit = audit;
+        _localSecurityPolicy = localSecurityPolicy;
         _logger = logger;
         _currentStatus = LoadPersistedStatus();
     }
@@ -61,14 +64,16 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
                 return await UpdateStatusAsync(null, cancellationToken);
             }
 
-            if (!desiredState.SecurityPolicy.AllowUpdateStaging)
+            var securityPolicy = _localSecurityPolicy.EnforceMinimums(desiredState.SecurityPolicy);
+
+            if (!securityPolicy.AllowUpdateStaging)
             {
                 return await UpdateStatusAsync(new RunnerUpdateStatus
                 {
                     State = RunnerUpdateStageState.Failed,
                     ManifestId = desiredState.DesiredUpdateManifest.DefinitionId,
                     ManifestVersion = desiredState.DesiredUpdateManifest.Version,
-                    FailureMessage = $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit runner-side update staging."
+                    FailureMessage = $"Coordinator security policy {securityPolicy.PolicyVersion} does not permit runner-side update staging."
                 }, cancellationToken);
             }
 
@@ -137,32 +142,32 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
                     }, cancellationToken);
                 }
 
-                if ((desiredState.SecurityPolicy.RequireManifestProvenance || manifest.Provenance is not null) &&
+                if ((securityPolicy.RequireManifestProvenance || manifest.Provenance is not null) &&
                     !RunnerUpdateManifestSigning.HasRequiredProvenance(manifest, out var provenanceError))
                 {
                     throw new InvalidOperationException(provenanceError);
                 }
 
-                if (desiredState.SecurityPolicy.RequireSignedUpdateManifest || manifest.Signature is not null)
+                if (securityPolicy.RequireSignedUpdateManifest || manifest.Signature is not null)
                 {
                     if (manifest.Signature is null)
                     {
                         throw new InvalidOperationException("Coordinator update manifest did not include a signature.");
                     }
 
-                    if (desiredState.SecurityPolicy.TrustedManifestSignerIds.Count == 0)
+                    if (securityPolicy.TrustedManifestSignerIds.Count == 0)
                     {
                         throw new InvalidOperationException(
-                            $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not declare any trusted manifest signer ids.");
+                            $"Effective runner security policy {securityPolicy.PolicyVersion} does not declare any trusted manifest signer ids.");
                     }
 
-                    if (!desiredState.SecurityPolicy.TrustedManifestSignerIds.Contains(manifest.Signature.SignerId, StringComparer.OrdinalIgnoreCase))
+                    if (!securityPolicy.TrustedManifestSignerIds.Contains(manifest.Signature.SignerId, StringComparer.OrdinalIgnoreCase))
                     {
                         throw new InvalidOperationException(
-                            $"Coordinator update manifest signer '{manifest.Signature.SignerId}' is not trusted by security policy {desiredState.SecurityPolicy.PolicyVersion}.");
+                            $"Coordinator update manifest signer '{manifest.Signature.SignerId}' is not trusted by effective security policy {securityPolicy.PolicyVersion}.");
                     }
 
-                    var signer = _options.TrustedManifestSigners
+                    var signer = _localSecurityPolicy.GetTrustedSigners()
                         .FirstOrDefault(candidate => string.Equals(candidate.SignerId, manifest.Signature.SignerId, StringComparison.OrdinalIgnoreCase));
                     if (signer is null)
                     {
@@ -193,13 +198,13 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
 
                 if (_options.DownloadUpdatePayload)
                 {
-                    if (desiredState.SecurityPolicy.RequireUpdateArtifactChecksum &&
+                    if (securityPolicy.RequireUpdateArtifactChecksum &&
                         string.IsNullOrWhiteSpace(manifest.Sha256))
                     {
                         throw new InvalidOperationException("Coordinator update manifest did not include a SHA-256 checksum.");
                     }
 
-                    var artifactUri = GetValidatedArtifactUri(coordinatorClient, desiredState.SecurityPolicy, manifest.ArtifactUrl);
+                    var artifactUri = GetValidatedArtifactUri(coordinatorClient, securityPolicy, manifest.ArtifactUrl);
                     var artifactPath = Path.Combine(stagingDirectory, GetArtifactFileName(artifactUri));
                     var tempArtifactPath = Path.Combine(stagingDirectory, $"{Path.GetFileName(artifactPath)}.{Guid.NewGuid():N}.tmp");
                     try
@@ -213,7 +218,7 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
                             await source.CopyToAsync(destination, cancellationToken);
                         }
 
-                        if (desiredState.SecurityPolicy.RequireUpdateArtifactChecksum)
+                        if (securityPolicy.RequireUpdateArtifactChecksum)
                         {
                             var actualSha256 = await ComputeSha256Async(tempArtifactPath, cancellationToken);
                             if (!string.Equals(actualSha256, manifest.Sha256, StringComparison.OrdinalIgnoreCase))
@@ -475,10 +480,12 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
         RunnerDesiredState desiredState,
         CancellationToken cancellationToken)
     {
-        if (!desiredState.SecurityPolicy.AllowUpdateApply)
+        var securityPolicy = _localSecurityPolicy.EnforceMinimums(desiredState.SecurityPolicy);
+
+        if (!securityPolicy.AllowUpdateApply)
         {
             throw new InvalidOperationException(
-                $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit runner-side update apply.");
+                $"Coordinator security policy {securityPolicy.PolicyVersion} does not permit runner-side update apply.");
         }
 
         if (string.IsNullOrWhiteSpace(stagedStatus.StagedArtifactPath) || !File.Exists(stagedStatus.StagedArtifactPath))
@@ -511,6 +518,8 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
         };
 
         await UpdateStatusAsync(applyStatus, cancellationToken);
+        var applyWorkerPath = GetApplyWorkerPath();
+        var applyWorkerSha256 = await ComputeSha256Async(applyWorkerPath, cancellationToken);
         await WriteTextAtomicallyAsync(
             planPath,
             JsonSerializer.Serialize(new RunnerUpdateApplyPlan
@@ -523,6 +532,8 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
                 ArtifactPath = stagedStatus.StagedArtifactPath,
                 SourceInstallDirectory = AppContext.BaseDirectory,
                 CandidateInstallDirectory = candidateInstallDirectory,
+                ApplyWorkerPath = applyWorkerPath,
+                ApplyWorkerSha256 = applyWorkerSha256,
                 ProcessExitTimeout = _options.UpdateApplyProcessExitTimeout,
                 ApplyStartedAt = applyStartedAt
             }, JsonOptions),
@@ -546,6 +557,15 @@ public sealed class RunnerUpdateStagingService : IRunnerUpdateStagingService, ID
             TargetId = targetId,
             TargetDisplayName = targetDisplayName
         };
+
+    private static string GetApplyWorkerPath()
+    {
+        var processPath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Runner update apply could not determine the current process path.");
+        return string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase)
+            ? typeof(RunnerUpdateStagingService).Assembly.Location
+            : processPath;
+    }
 
     private void StartApplyWorker(string planPath)
     {

--- a/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
+++ b/AgentDeck.Runner/Services/RunnerWorkflowPackService.cs
@@ -17,6 +17,7 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
     private readonly WorkerCoordinatorOptions _options;
     private readonly IMachineCapabilityService _capabilities;
     private readonly IMachineSetupService _machineSetup;
+    private readonly RunnerLocalSecurityPolicy _localSecurityPolicy;
     private readonly ILogger<RunnerWorkflowPackService> _logger;
     private RunnerWorkflowPackStatus? _currentStatus;
 
@@ -24,11 +25,13 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
         IOptions<WorkerCoordinatorOptions> options,
         IMachineCapabilityService capabilities,
         IMachineSetupService machineSetup,
+        RunnerLocalSecurityPolicy localSecurityPolicy,
         ILogger<RunnerWorkflowPackService> logger)
     {
         _options = options.Value;
         _capabilities = capabilities;
         _machineSetup = machineSetup;
+        _localSecurityPolicy = localSecurityPolicy;
         _logger = logger;
         _currentStatus = LoadPersistedStatus();
     }
@@ -68,6 +71,7 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
         try
         {
             var currentStatus = GetCurrentStatusSnapshot();
+            var securityPolicy = _localSecurityPolicy.EnforceMinimums(desiredState.SecurityPolicy);
             if (desiredState.DesiredWorkflowPack is null)
             {
                 return await UpdateStatusAsync(null, cancellationToken);
@@ -75,7 +79,7 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
 
             var desiredPackId = desiredState.DesiredWorkflowPack.DefinitionId;
             var desiredPackVersion = desiredState.DesiredWorkflowPack.Version;
-            if (!desiredState.SecurityPolicy.AllowWorkflowPackExecution)
+            if (!securityPolicy.AllowWorkflowPackExecution)
             {
                 return await UpdateStatusAsync(new RunnerWorkflowPackStatus
                 {
@@ -84,7 +88,7 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
                     PackVersion = desiredPackVersion,
                     LocalPackPath = GetRetainedLocalPackPath(currentStatus, desiredPackId, desiredPackVersion),
                     FetchedAt = GetRetainedFetchedAt(currentStatus, desiredPackId, desiredPackVersion),
-                    StatusMessage = $"Coordinator security policy {desiredState.SecurityPolicy.PolicyVersion} does not permit workflow pack execution."
+                    StatusMessage = $"Coordinator security policy {securityPolicy.PolicyVersion} does not permit workflow pack execution."
                 }, cancellationToken);
             }
 
@@ -150,6 +154,15 @@ public sealed class RunnerWorkflowPackService : IRunnerWorkflowPackService, IDis
                         FetchedAt = GetRetainedFetchedAt(currentStatus, desiredPackId, desiredPackVersion),
                         FailureMessage = $"Coordinator workflow pack version '{pack.Version}' did not match desired version '{desiredPackVersion}'."
                     }, cancellationToken);
+                }
+
+                if (_localSecurityPolicy.RequireSignedWorkflowPacks || pack.Signature is not null)
+                {
+                    _localSecurityPolicy.VerifySignedDefinition(
+                        "workflow pack",
+                        pack.Signature,
+                        pack.Provenance,
+                        (string publicKeyPem, out string error) => RunnerSignedDefinitionPayload.VerifySignature(pack, publicKeyPem, out error));
                 }
 
                 var packDirectory = Path.Combine(GetWorkflowPackRoot(), SanitizePathComponent(pack.PackId), SanitizePathComponent(pack.Version));

--- a/AgentDeck.Runner/appsettings.json
+++ b/AgentDeck.Runner/appsettings.json
@@ -17,6 +17,18 @@
       "IssueAccessToken": true
     }
   },
+  "RunnerLocalSecurityPolicy": {
+    "RequireCoordinatorOriginForArtifacts": true,
+    "RequireUpdateArtifactChecksum": true,
+    "RequireSignedUpdateManifest": true,
+    "RequireManifestProvenance": true,
+    "RequireSignedWorkflowPacks": true,
+    "RequireSignedCapabilityCatalogs": true,
+    "RequireSignedSetupCatalogs": true,
+    "AllowDevSignerInProduction": false,
+    "TrustedSignerIds": ["agentdeck-dev"],
+    "TrustedSignersDirectory": ""
+  },
   "Coordinator": {
     "MachineId": "local-machine",
     "MachineName": "Local machine",

--- a/AgentDeck.Shared/Models/RunnerCapabilityCatalog.cs
+++ b/AgentDeck.Shared/Models/RunnerCapabilityCatalog.cs
@@ -9,6 +9,8 @@ public sealed class RunnerCapabilityCatalog
     public required string DisplayName { get; init; }
     public string? Description { get; init; }
     public IReadOnlyList<RunnerCapabilityDefinition> Capabilities { get; init; } = [];
+    public RunnerUpdateManifestProvenance? Provenance { get; init; }
+    public RunnerUpdateManifestSignature? Signature { get; init; }
 }
 
 public sealed class RunnerCapabilityDefinition

--- a/AgentDeck.Shared/Models/RunnerSetupCatalog.cs
+++ b/AgentDeck.Shared/Models/RunnerSetupCatalog.cs
@@ -9,6 +9,8 @@ public sealed class RunnerSetupCatalog
     public required string DisplayName { get; init; }
     public string? Description { get; init; }
     public IReadOnlyList<RunnerSetupCapabilityDefinition> Capabilities { get; init; } = [];
+    public RunnerUpdateManifestProvenance? Provenance { get; init; }
+    public RunnerUpdateManifestSignature? Signature { get; init; }
 }
 
 public sealed class RunnerSetupCapabilityDefinition

--- a/AgentDeck.Shared/Models/RunnerSignedDefinitionPayload.cs
+++ b/AgentDeck.Shared/Models/RunnerSignedDefinitionPayload.cs
@@ -1,0 +1,131 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Canonical signing helpers for coordinator-published runner definitions that can drive local execution.</summary>
+public static class RunnerSignedDefinitionPayload
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static bool VerifySignature(RunnerWorkflowPack pack, string publicKeyPem, out string error) =>
+        VerifySignature("workflow pack", pack.Signature, BuildSigningPayload(pack), publicKeyPem, out error);
+
+    public static bool VerifySignature(RunnerCapabilityCatalog catalog, string publicKeyPem, out string error) =>
+        VerifySignature("capability catalog", catalog.Signature, BuildSigningPayload(catalog), publicKeyPem, out error);
+
+    public static bool VerifySignature(RunnerSetupCatalog catalog, string publicKeyPem, out string error) =>
+        VerifySignature("setup catalog", catalog.Signature, BuildSigningPayload(catalog), publicKeyPem, out error);
+
+    public static bool TrySignWorkflowPack(RunnerWorkflowPack pack, string privateKeyPem, out string signatureValue, out string error) =>
+        TrySign(BuildSigningPayload(pack), privateKeyPem, out signatureValue, out error);
+
+    public static bool TrySignCapabilityCatalog(RunnerCapabilityCatalog catalog, string privateKeyPem, out string signatureValue, out string error) =>
+        TrySign(BuildSigningPayload(catalog), privateKeyPem, out signatureValue, out error);
+
+    public static bool TrySignSetupCatalog(RunnerSetupCatalog catalog, string privateKeyPem, out string signatureValue, out string error) =>
+        TrySign(BuildSigningPayload(catalog), privateKeyPem, out signatureValue, out error);
+
+    public static string BuildSigningPayload(RunnerWorkflowPack pack) => JsonSerializer.Serialize(new
+    {
+        pack.PackId,
+        pack.Version,
+        pack.DisplayName,
+        pack.Description,
+        pack.Steps,
+        pack.Provenance
+    }, JsonOptions);
+
+    public static string BuildSigningPayload(RunnerCapabilityCatalog catalog) => JsonSerializer.Serialize(new
+    {
+        catalog.CatalogId,
+        catalog.Version,
+        catalog.DisplayName,
+        catalog.Description,
+        catalog.Capabilities,
+        catalog.Provenance
+    }, JsonOptions);
+
+    public static string BuildSigningPayload(RunnerSetupCatalog catalog) => JsonSerializer.Serialize(new
+    {
+        catalog.CatalogId,
+        catalog.Version,
+        catalog.DisplayName,
+        catalog.Description,
+        catalog.Capabilities,
+        catalog.Provenance
+    }, JsonOptions);
+
+    private static bool VerifySignature(string payloadName, RunnerUpdateManifestSignature? signature, string payload, string publicKeyPem, out string error)
+    {
+        if (signature is null)
+        {
+            error = $"Signed {payloadName} signature is required.";
+            return false;
+        }
+
+        if (!string.Equals(signature.Algorithm, RunnerUpdateManifestSigning.RsaSha256Algorithm, StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Unsupported {payloadName} signature algorithm '{signature.Algorithm}'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(publicKeyPem))
+        {
+            error = $"Trusted {payloadName} signer public key is required.";
+            return false;
+        }
+
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Convert.FromBase64String(signature.Value);
+        }
+        catch (FormatException)
+        {
+            error = $"{payloadName} signature for signer '{signature.SignerId}' is not valid Base64.";
+            return false;
+        }
+
+        try
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(publicKeyPem);
+            var verified = rsa.VerifyData(Encoding.UTF8.GetBytes(payload), signatureBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            error = verified ? string.Empty : $"{payloadName} signature verification failed for signer '{signature.SignerId}'.";
+            return verified;
+        }
+        catch (CryptographicException)
+        {
+            error = $"Trusted {payloadName} signer public key for '{signature.SignerId}' is invalid.";
+            return false;
+        }
+    }
+
+    private static bool TrySign(string payload, string privateKeyPem, out string signatureValue, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(privateKeyPem))
+        {
+            signatureValue = string.Empty;
+            error = "Definition signing private key is required.";
+            return false;
+        }
+
+        try
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(privateKeyPem);
+            var signatureBytes = rsa.SignData(Encoding.UTF8.GetBytes(payload), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            signatureValue = Convert.ToBase64String(signatureBytes);
+            error = string.Empty;
+            return true;
+        }
+        catch (CryptographicException)
+        {
+            signatureValue = string.Empty;
+            error = "Definition signing private key is invalid.";
+            return false;
+        }
+    }
+}

--- a/AgentDeck.Shared/Models/RunnerWorkflowPack.cs
+++ b/AgentDeck.Shared/Models/RunnerWorkflowPack.cs
@@ -8,4 +8,6 @@ public sealed class RunnerWorkflowPack
     public required string DisplayName { get; init; }
     public string? Description { get; init; }
     public IReadOnlyList<RunnerWorkflowStep> Steps { get; init; } = [];
+    public RunnerUpdateManifestProvenance? Provenance { get; init; }
+    public RunnerUpdateManifestSignature? Signature { get; init; }
 }

--- a/docs/runner-signing-keys.md
+++ b/docs/runner-signing-keys.md
@@ -1,0 +1,75 @@
+# Runner signing keys
+
+Runner update manifests, workflow packs, capability catalogs, and setup catalogs should be signed with a per-deployment RSA key. The built-in `agentdeck-dev` public key is for local development only; runners refuse that signer outside Development unless `RunnerLocalSecurityPolicy:AllowDevSignerInProduction=true` is set explicitly.
+
+## Generate a deployment key
+
+Linux/macOS:
+
+```bash
+tools/generate-signing-key.sh my-deployment
+```
+
+Windows PowerShell:
+
+```powershell
+./tools/generate-signing-key.ps1 -SignerId my-deployment
+```
+
+This creates:
+
+- `signers.d/my-deployment.private.pem` — private key; keep only on the coordinator/signing host.
+- `signers.d/my-deployment.pem` — public key; copy to each runner's `signers.d/` directory or configure it in `Coordinator:TrustedManifestSigners`.
+
+## Configure runners
+
+Prefer drop-in public keys so appsettings does not need editing:
+
+```text
+<runner install>/signers.d/my-deployment.pem
+```
+
+Set the runner-local signer allow-list:
+
+```json
+{
+  "RunnerLocalSecurityPolicy": {
+    "TrustedSignerIds": ["my-deployment"]
+  }
+}
+```
+
+The runner treats coordinator policy as additive. A coordinator can require stricter checks, but cannot disable signed manifests, provenance, artifact checksums/origin checks, or signed executable catalogs below the runner-local minimums.
+
+## Rotate keys
+
+1. Generate the new key pair.
+2. Distribute the new public key to runners under `signers.d/<new-id>.pem`.
+3. Temporarily allow both signer ids in `RunnerLocalSecurityPolicy:TrustedSignerIds`.
+4. Update coordinator signing config to use the new private key and signer id.
+5. After all runners have accepted signed payloads from the new signer, remove the old signer id and public key.
+
+## Sign coordinator definitions
+
+For each coordinator-published executable definition, configure either `PrivateKeyPem` (auto-sign at startup) or a precomputed detached `Signature` with the signer id:
+
+```json
+{
+  "Coordinator": {
+    "DesiredWorkflowPack": {
+      "SignerId": "my-deployment",
+      "PrivateKeyPem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+    },
+    "DesiredCapabilityCatalog": {
+      "SignerId": "my-deployment",
+      "PrivateKeyPem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+    },
+    "DesiredSetupCatalog": {
+      "SignerId": "my-deployment",
+      "PrivateKeyPem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+    }
+  }
+}
+```
+
+Do not commit private keys. Prefer environment-specific secret configuration.

--- a/tools/generate-signing-key.ps1
+++ b/tools/generate-signing-key.ps1
@@ -1,0 +1,20 @@
+param(
+    [Parameter(Mandatory=$true)][string]$SignerId,
+    [string]$OutputDirectory = "signers.d"
+)
+
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+$privateKey = Join-Path $OutputDirectory "$SignerId.private.pem"
+$publicKey = Join-Path $OutputDirectory "$SignerId.pem"
+
+if ((Test-Path $privateKey) -or (Test-Path $publicKey)) {
+    throw "Refusing to overwrite existing key material in $OutputDirectory"
+}
+
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out $privateKey
+openssl rsa -pubout -in $privateKey -out $publicKey
+
+Write-Host "Generated signer '$SignerId'"
+Write-Host "  private: $privateKey  (keep secret; configure only on the coordinator/signing host)"
+Write-Host "  public:  $publicKey   (copy to runner signers.d/ or configure Coordinator:TrustedManifestSigners)"

--- a/tools/generate-signing-key.sh
+++ b/tools/generate-signing-key.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+signer_id="${1:-}"
+out_dir="${2:-signers.d}"
+
+if [[ -z "$signer_id" ]]; then
+  echo "usage: $0 <signer-id> [output-directory]" >&2
+  exit 2
+fi
+
+mkdir -p "$out_dir"
+private_key="$out_dir/$signer_id.private.pem"
+public_key="$out_dir/$signer_id.pem"
+
+if [[ -e "$private_key" || -e "$public_key" ]]; then
+  echo "refusing to overwrite existing key material in $out_dir" >&2
+  exit 1
+fi
+
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out "$private_key"
+openssl rsa -pubout -in "$private_key" -out "$public_key"
+chmod 600 "$private_key"
+chmod 644 "$public_key"
+
+echo "Generated signer '$signer_id'"
+echo "  private: $private_key  (keep secret; configure only on the coordinator/signing host)"
+echo "  public:  $public_key   (copy to runner signers.d/ or configure Coordinator:TrustedManifestSigners)"


### PR DESCRIPTION
## Summary
- Enforce runner-local minimum security policy for update manifests/artifacts so coordinator policy cannot downgrade signed manifest, provenance, checksum, origin, or signer requirements.
- Add signed/provenanced workflow pack, capability catalog, and setup catalog support with runner verification before shell-capable catalog execution paths are used.
- Add `signers.d/*.pem` trusted signer drop-ins, local signer allow-listing, dev-signer production guard option, signing-key generation scripts, and key rotation docs.
- Add apply-worker self-integrity metadata and startup SHA-256 verification before applying staged updates.

Closes #322
Closes #323
Closes #348
Closes #351

## Tests
- `dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj`
- `dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj`

## Notes
- Full `dotnet build AgentDeck.slnx` is currently blocked by an existing MAUI package downgrade (`Microsoft.Maui.Controls` 10.0.50 -> 10.0.30) in `AgentDeck/AgentDeck.csproj`.
