### PR TITLE
Fix runner orchestration and launch edge cases

### DIFF
--- a/AgentDeck.Core/Services/AppInitializer.cs
+++ b/AgentDeck.Core/Services/AppInitializer.cs
@@ -66,13 +66,13 @@ public sealed class AppInitializer
 
     private async void OnConnectionStateChanged(object? sender, RunnerMachineConnectionChangedEventArgs e)
     {
-        if (e.State != HubConnectionState.Connected)
-        {
-            return;
-        }
-
         try
         {
+            if (e.State != HubConnectionState.Connected)
+            {
+                return;
+            }
+
             var settings = await _settingsService.LoadAsync();
             var connectedSessions = new List<TerminalSession>();
 
@@ -91,7 +91,7 @@ public sealed class AppInitializer
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to sync sessions after machine connect");
+            _logger.LogError(ex, "Failed to sync sessions after machine connect.");
         }
     }
 }

--- a/AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj
+++ b/AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgentDeck.Runner\AgentDeck.Runner.csproj" />
+  </ItemGroup>
+</Project>

--- a/AgentDeck.Runner.Tests/OrchestrationExecutionServiceTests.cs
+++ b/AgentDeck.Runner.Tests/OrchestrationExecutionServiceTests.cs
@@ -1,0 +1,51 @@
+using Xunit;
+using AgentDeck.Runner.Services;
+
+namespace AgentDeck.Runner.Tests;
+
+public sealed class OrchestrationExecutionServiceTests
+{
+    [Theory]
+    [InlineData("code --folder-uri \"file:///tmp/a b\" --flag='quoted value'", new[] { "code", "--folder-uri", "file:///tmp/a b", "--flag=quoted value" })]
+    [InlineData("cmd empty='' keep=\"\" backslash\\ space", new[] { "cmd", "empty=", "keep=", "backslash space" })]
+    [InlineData("cmd \"escaped \\\"quote\\\" and \\\\ slash\"", new[] { "cmd", "escaped \"quote\" and \\ slash" })]
+    [InlineData("cmd 'single \\\\ literal'", new[] { "cmd", "single \\\\ literal" })]
+    public void SplitQuotedArguments_UsesDocumentedPosixSubset(string commandLine, string[] expected)
+    {
+        Assert.Equal(expected, OrchestrationExecutionService.SplitQuotedArguments(commandLine));
+    }
+
+    [Fact]
+    public void SplitQuotedArguments_RejectsUnterminatedQuotes()
+    {
+        Assert.Throws<FormatException>(() => OrchestrationExecutionService.SplitQuotedArguments("code \"unterminated"));
+    }
+
+    [Fact]
+    public void SignedCompletionMarker_AcceptsValidHmacAndRejectsSpoofedMarker()
+    {
+        const string marker = "__AGENTDECK_EXIT_test__";
+        const string secret = "secret";
+        var signature = OrchestrationExecutionService.ComputeCompletionSignature(marker, 7, secret);
+        var buffer = $"noise\n{marker}:7:{signature}\nmore";
+
+        Assert.True(OrchestrationExecutionService.TryReadSignedCompletionMarker(ref buffer, marker, secret, out var exitCode));
+        Assert.Equal(7, exitCode);
+        Assert.Equal("more", buffer);
+
+        buffer = $"{marker}:0:not-a-real-signature\n";
+        Assert.False(OrchestrationExecutionService.TryReadSignedCompletionMarker(ref buffer, marker, secret, out _));
+    }
+
+    [Fact]
+    public void SignedCompletionMarker_SkipsSpoofedMarkerBeforeRealMarker()
+    {
+        const string marker = "__AGENTDECK_EXIT_test__";
+        const string secret = "secret";
+        var signature = OrchestrationExecutionService.ComputeCompletionSignature(marker, 3, secret);
+        var buffer = $"{marker}:0:spoofed\n{marker}:3:{signature}\n";
+
+        Assert.True(OrchestrationExecutionService.TryReadSignedCompletionMarker(ref buffer, marker, secret, out var exitCode));
+        Assert.Equal(3, exitCode);
+    }
+}

--- a/AgentDeck.Runner.Tests/ShellLaunchBuilderTests.cs
+++ b/AgentDeck.Runner.Tests/ShellLaunchBuilderTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+using AgentDeck.Runner.Services;
+
+namespace AgentDeck.Runner.Tests;
+
+public sealed class ShellLaunchBuilderTests
+{
+    [Fact]
+    public void BuildPowerShellSplatCommand_PreservesArgumentsAsArrayElements()
+    {
+        var command = ShellLaunchBuilder.BuildPowerShellSplatCommand(
+            "C:\\Program Files\\AgentDeck\\tool.ps1",
+            ["literal $HOME", "semi;colon", "back`tick", "quote ' here"]);
+
+        Assert.Contains("$agentDeckArgs = @(", command);
+        Assert.Contains("'literal $HOME'", command);
+        Assert.Contains("'semi;colon'", command);
+        Assert.Contains("'back`tick'", command);
+        Assert.Contains("'quote '' here'", command);
+        Assert.Contains("@agentDeckArgs", command);
+    }
+}

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -11,6 +11,7 @@ if (args.Length >= 2 && string.Equals(args[0], RunnerUpdateApplyWorker.HelperMod
 }
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Configuration.AddJsonFile("appsettings.user.json", optional: true, reloadOnChange: true);
 
 var runnerOptions = builder.Configuration
     .GetSection(RunnerOptions.SectionName)

--- a/AgentDeck.Runner/Properties/AssemblyInfo.cs
+++ b/AgentDeck.Runner/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AgentDeck.Runner.Tests")]

--- a/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
+++ b/AgentDeck.Runner/Services/OrchestrationExecutionService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
 using RdpPoc.Contracts;
@@ -18,6 +20,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         public string? MachineId { get; init; }
         public required TaskCompletionSource<int> Completion { get; init; }
         public required string CompletionMarker { get; init; }
+        public required string CompletionMarkerSecret { get; init; }
         public string? ProcessIdMarker { get; init; }
         public bool IsVsCode { get; init; }
         public string MarkerBuffer { get; set; } = string.Empty;
@@ -396,6 +399,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
         var operationId = Guid.NewGuid().ToString("N");
         var completionMarker = $"__AGENTDECK_EXIT_{operationId}__";
+        var completionMarkerSecret = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
         var processIdMarker = isVsCode && OperatingSystem.IsWindows()
             ? $"__AGENTDECK_PID_{operationId}__"
             : null;
@@ -407,6 +411,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             MachineId = job.TargetMachineId,
             Completion = completion,
             CompletionMarker = completionMarker,
+            CompletionMarkerSecret = completionMarkerSecret,
             ProcessIdMarker = processIdMarker,
             IsVsCode = isVsCode
         };
@@ -437,7 +442,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
         try
         {
-            await _ptyManager.WriteAsync(sessionId, BuildTerminalPhaseInput(command, completionMarker, processIdMarker));
+            await _ptyManager.WriteAsync(sessionId, BuildTerminalPhaseInput(command, completionMarker, completionMarkerSecret, processIdMarker));
             if (attachRuntimeViewer)
             {
                 await TryAttachRuntimeViewerAsync(job, sessionId, knownWindowTargetIds);
@@ -510,7 +515,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         return $"{QuotePosix(command)} {string.Join(" ", arguments.Select(QuotePosix))}";
     }
 
-    private static string BuildTerminalPhaseInput(string command, string completionMarker, string? processIdMarker)
+    internal static string BuildTerminalPhaseInput(string command, string completionMarker, string completionMarkerSecret, string? processIdMarker)
     {
         if (OperatingSystem.IsWindows())
         {
@@ -535,16 +540,36 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             lines.Add("    Write-Error $_");
             lines.Add("    $agentDeckExit = 1");
             lines.Add("}");
-            lines.Add($"Write-Host '{completionMarker}:$agentDeckExit'");
+            lines.Add($"$agentDeckHmac = [System.Security.Cryptography.HMACSHA256]::new([System.Text.Encoding]::UTF8.GetBytes('{completionMarkerSecret}'))");
+            lines.Add($"$agentDeckPayload = '{completionMarker}:' + $agentDeckExit");
+            lines.Add("$agentDeckSignature = [Convert]::ToHexString($agentDeckHmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($agentDeckPayload))).ToLowerInvariant()");
+            lines.Add("Write-Host \"${agentDeckPayload}:$agentDeckSignature\"");
             return string.Join(Environment.NewLine, lines) + Environment.NewLine;
         }
 
+        var signatureCases = BuildPosixCompletionSignatureCases(completionMarker, completionMarkerSecret);
+
         if (!string.IsNullOrWhiteSpace(processIdMarker))
         {
-            return $"agentdeck_exit=1\n{{ {BuildPosixVsCodeWrapper(command, processIdMarker)}; agentdeck_exit=$?; }}\nprintf '{completionMarker}:%s\\n' \"$agentdeck_exit\"\n";
+            return $"agentdeck_exit=1\n{{ {BuildPosixVsCodeWrapper(command, processIdMarker)}; agentdeck_exit=$?; }}\nagentdeck_sig=\ncase \"$agentdeck_exit\" in\n{signatureCases}esac\nprintf '{completionMarker}:%s:%s\\n' \"$agentdeck_exit\" \"$agentdeck_sig\"\n";
         }
 
-        return $"agentdeck_exit=1\n{{ {command}; agentdeck_exit=$?; }}\nprintf '{completionMarker}:%s\\n' \"$agentdeck_exit\"\n";
+        return $"agentdeck_exit=1\n{{ {command}; agentdeck_exit=$?; }}\nagentdeck_sig=\ncase \"$agentdeck_exit\" in\n{signatureCases}esac\nprintf '{completionMarker}:%s:%s\\n' \"$agentdeck_exit\" \"$agentdeck_sig\"\n";
+    }
+
+    private static string BuildPosixCompletionSignatureCases(string completionMarker, string completionMarkerSecret)
+    {
+        var builder = new StringBuilder();
+        for (var exitCode = 0; exitCode <= 255; exitCode++)
+        {
+            builder.Append("  ")
+                .Append(exitCode)
+                .Append(") agentdeck_sig='")
+                .Append(ComputeCompletionSignature(completionMarker, exitCode, completionMarkerSecret))
+                .Append("' ;;\n");
+        }
+
+        return builder.ToString();
     }
 
     private static string BuildPowerShellVsCodeWrapper(string command, string processIdMarker)
@@ -567,36 +592,51 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
     private static string BuildPosixVsCodeWrapper(string command, string processIdMarker) =>
         $"{command} & agentdeck_pid=$!; printf '{processIdMarker}:%s\\n' \"$agentdeck_pid\"; wait \"$agentdeck_pid\"";
 
-    private static IReadOnlyList<string> SplitQuotedArguments(string value)
+    internal static IReadOnlyList<string> SplitQuotedArguments(string value)
     {
         var arguments = new List<string>();
-        var current = new System.Text.StringBuilder();
+        var current = new StringBuilder();
         var quote = '\0';
+        var hasToken = false;
+
         for (var index = 0; index < value.Length; index++)
         {
             var character = value[index];
             if (quote == '\0' && char.IsWhiteSpace(character))
             {
-                if (current.Length > 0)
+                if (hasToken)
                 {
                     arguments.Add(current.ToString());
                     current.Clear();
+                    hasToken = false;
                 }
 
                 continue;
             }
 
-            if (character is '\'' or '"')
+            hasToken = true;
+            if (character == '\\')
             {
-                if (quote == character &&
-                    index + 1 < value.Length &&
-                    value[index + 1] == character)
+                if (quote == '\'')
                 {
                     current.Append(character);
-                    index++;
                     continue;
                 }
 
+                if (index + 1 < value.Length)
+                {
+                    var next = value[index + 1];
+                    if (quote == '"' ? next is '"' or '\\' or '$' or '`' : char.IsWhiteSpace(next) || next is '\'' or '"' or '\\')
+                    {
+                        current.Append(next);
+                        index++;
+                        continue;
+                    }
+                }
+            }
+
+            if (character is '\'' or '"')
+            {
                 if (quote == '\0')
                 {
                     quote = character;
@@ -613,7 +653,12 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             current.Append(character);
         }
 
-        if (current.Length > 0)
+        if (quote != '\0')
+        {
+            throw new FormatException("Command arguments contain an unterminated quote.");
+        }
+
+        if (hasToken)
         {
             arguments.Add(current.ToString());
         }
@@ -623,6 +668,12 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
 
     private static string QuotePosix(string value) =>
         $"'{value.Replace("'", "'\"'\"'")}'";
+
+    internal static string ComputeCompletionSignature(string marker, int exitCode, string secret)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        return Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes($"{marker}:{exitCode}"))).ToLowerInvariant();
+    }
 
     private async Task<bool> FinishIfTerminalAsync(string jobId, int exitCode, string phaseName)
     {
@@ -727,11 +778,11 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         {
             if (viewer is not null)
             {
-                    await _viewerBootstrap.CloseAsync(viewer.Id, "Viewer session closed because runtime viewer attachment failed.");
-                }
-
-                throw;
+                await _viewerBootstrap.CloseAsync(viewer.Id, "Viewer session closed because runtime viewer attachment failed.");
             }
+
+            throw;
+        }
     }
 
     private bool TryBuildRuntimeViewerRequest(
@@ -873,7 +924,7 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
             _ = NotifyHostStartedAsync(session.JobId, processId);
         }
 
-        if (TryReadMarkedInt(ref markerBuffer, session.CompletionMarker, out var exitCode))
+        if (TryReadSignedCompletionMarker(ref markerBuffer, session.CompletionMarker, session.CompletionMarkerSecret, out var exitCode))
         {
             session.CompletionOutputTail = session.RecentOutputTail;
             _logger.LogInformation(
@@ -930,6 +981,47 @@ public sealed class OrchestrationExecutionService : IOrchestrationExecutionServi
         var rawValue = buffer[valueStart..lineEnd].Trim();
         buffer = buffer[(lineEnd + 1)..];
         return int.TryParse(rawValue, out value);
+    }
+
+    internal static bool TryReadSignedCompletionMarker(ref string buffer, string marker, string secret, out int value)
+    {
+        value = 0;
+
+        while (true)
+        {
+            var markerIndex = buffer.IndexOf(marker, StringComparison.Ordinal);
+            if (markerIndex < 0)
+            {
+                return false;
+            }
+
+            var valueStart = markerIndex + marker.Length + 1;
+            if (valueStart > buffer.Length)
+            {
+                return false;
+            }
+
+            var lineEnd = buffer.IndexOfAny(['\r', '\n'], valueStart);
+            if (lineEnd < 0)
+            {
+                return false;
+            }
+
+            var rawFields = buffer[valueStart..lineEnd].Trim().Split(':', count: 2);
+            var remainingBuffer = buffer[(lineEnd + 1)..];
+            if (rawFields.Length == 2 &&
+                int.TryParse(rawFields[0], out value) &&
+                CryptographicOperations.FixedTimeEquals(
+                    Encoding.ASCII.GetBytes(ComputeCompletionSignature(marker, value, secret)),
+                    Encoding.ASCII.GetBytes(rawFields[1].Trim())))
+            {
+                buffer = remainingBuffer;
+                return true;
+            }
+
+            value = 0;
+            buffer = remainingBuffer;
+        }
     }
 
     private static string TrimMarkerBuffer(string buffer) =>

--- a/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
@@ -161,9 +161,73 @@ internal static class RunnerUpdateApplyWorker
 
     private static void CopyLocalConfiguration(string sourceInstallDirectory, string candidateInstallDirectory)
     {
-        foreach (var file in Directory.GetFiles(sourceInstallDirectory, "appsettings*.json", SearchOption.TopDirectoryOnly))
+        var sourceUserSettingsPath = Path.Combine(sourceInstallDirectory, "appsettings.user.json");
+        var candidateUserSettingsPath = Path.Combine(candidateInstallDirectory, "appsettings.user.json");
+        if (File.Exists(sourceUserSettingsPath))
         {
-            File.Copy(file, Path.Combine(candidateInstallDirectory, Path.GetFileName(file)), overwrite: true);
+            File.Copy(sourceUserSettingsPath, candidateUserSettingsPath, overwrite: true);
+            return;
+        }
+
+        var legacySettingsPath = Path.Combine(sourceInstallDirectory, "appsettings.json");
+        if (!File.Exists(legacySettingsPath))
+        {
+            return;
+        }
+
+        var migratedUserSettings = BuildLegacyUserSettingsOverlay(legacySettingsPath);
+        if (migratedUserSettings is null)
+        {
+            return;
+        }
+
+        File.WriteAllText(candidateUserSettingsPath, migratedUserSettings);
+    }
+
+    private static string? BuildLegacyUserSettingsOverlay(string legacySettingsPath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(legacySettingsPath));
+        var root = document.RootElement;
+        var overlay = new Dictionary<string, object?>();
+
+        CopySectionProperties(root, overlay, "Runner", ["WorkspaceRoot", "Port", "AllowedOrigins"]);
+        CopySectionProperties(root, overlay, "Coordinator",
+        [
+            "MachineId",
+            "MachineName",
+            "CoordinatorUrl",
+            "ControlChannelTransport",
+            "AdvertisedRunnerUrl",
+            "AllowInsecureHttpCoordinatorForLoopback",
+            "AllowInsecureHttpCoordinatorForDevelopment",
+            "DownloadUpdatePayload",
+            "UpdateApplyProcessExitTimeout"
+        ]);
+
+        return overlay.Count == 0
+            ? null
+            : JsonSerializer.Serialize(overlay, JsonOptions);
+    }
+
+    private static void CopySectionProperties(JsonElement root, Dictionary<string, object?> overlay, string sectionName, IReadOnlyCollection<string> propertyNames)
+    {
+        if (!root.TryGetProperty(sectionName, out var section) || section.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var sectionOverlay = new Dictionary<string, object?>();
+        foreach (var property in section.EnumerateObject())
+        {
+            if (propertyNames.Contains(property.Name))
+            {
+                sectionOverlay[property.Name] = property.Value.Deserialize<object?>(JsonOptions);
+            }
+        }
+
+        if (sectionOverlay.Count > 0)
+        {
+            overlay[sectionName] = sectionOverlay;
         }
     }
 

--- a/AgentDeck.Runner/Services/ShellLaunchBuilder.cs
+++ b/AgentDeck.Runner/Services/ShellLaunchBuilder.cs
@@ -74,7 +74,7 @@ public static class ShellLaunchBuilder
         return commandName is "pwsh" or "powershell" or "bash" or "sh" or "cmd";
     }
 
-    private static string BuildShellCommand(string command, IReadOnlyList<string> arguments)
+    internal static string BuildShellCommand(string command, IReadOnlyList<string> arguments)
     {
         if (arguments.Count == 0)
         {
@@ -83,10 +83,20 @@ public static class ShellLaunchBuilder
 
         if (OperatingSystem.IsWindows())
         {
-            return $"& {QuotePowerShell(command)} {string.Join(" ", arguments.Select(QuotePowerShell))}";
+            return BuildPowerShellSplatCommand(command, arguments);
         }
 
         return $"{QuotePosix(command)} {string.Join(" ", arguments.Select(QuotePosix))}";
+    }
+
+    internal static string BuildPowerShellSplatCommand(string command, IReadOnlyList<string> arguments)
+    {
+        if (arguments.Count == 0)
+        {
+            return $"& {QuotePowerShell(command)}";
+        }
+
+        return $"$agentDeckArgs = @({string.Join(", ", arguments.Select(QuotePowerShell))}); & {QuotePowerShell(command)} @agentDeckArgs";
     }
 
     private static string QuotePowerShell(string value) =>

--- a/AgentDeck.slnx
+++ b/AgentDeck.slnx
@@ -4,4 +4,5 @@
   <Project Path="AgentDeck.Runner/AgentDeck.Runner.csproj" />
   <Project Path="AgentDeck.Shared/AgentDeck.Shared.csproj" />
   <Project Path="AgentDeck/AgentDeck.csproj" />
+  <Project Path="AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj" />
 </Solution>

--- a/AgentDeck/App.xaml.cs
+++ b/AgentDeck/App.xaml.cs
@@ -1,15 +1,18 @@
 using AgentDeck.Core.Services;
+using Microsoft.Extensions.Logging;
 
 namespace AgentDeck;
 
 public partial class App : Application
 {
     private readonly AppInitializer _initializer;
+    private readonly ILogger<App> _logger;
 
-    public App(AppInitializer initializer)
+    public App(AppInitializer initializer, ILogger<App> logger)
     {
         InitializeComponent();
         _initializer = initializer;
+        _logger = logger;
     }
 
     protected override Window CreateWindow(IActivationState? activationState) =>
@@ -17,7 +20,14 @@ public partial class App : Application
 
     protected override async void OnStart()
     {
-        base.OnStart();
-        await _initializer.InitializeAsync();
+        try
+        {
+            base.OnStart();
+            await _initializer.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "App startup initialization failed.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- sign orchestration completion markers with per-job HMAC validation so command output cannot spoof success
- wrap MAUI/AppInitializer async lifecycle handlers with logging
- add appsettings.user.json overlay loading and preserve/migrate user config during runner update apply without overwriting new defaults
- formalize VS Code command argument splitting and switch Windows shell launch to PowerShell array splatting for argument fidelity
- add runner tests for signed markers, splitting, and PowerShell argument construction

Closes #327
Closes #329
Closes #333
Closes #335
Closes #336

## Tests
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj`
- `dotnet build AgentDeck.Runner/AgentDeck.Runner.csproj`
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj`

## Known blocker
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0` currently fails restore on Linux with existing package downgrade NU1605: `OpenMaui.Controls.Linux 10.0.50.7` requires `Microsoft.Maui.Controls >= 10.0.50`, while the project pins `Microsoft.Maui.Controls 10.0.30`.
