### PR TITLE
Add runner orchestration foundation

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -34,6 +34,8 @@ public sealed class CoordinatorOptions
 
     public TimeSpan WorkerExpiry { get; set; } = TimeSpan.FromSeconds(45);
 
+    public CoordinatorRunnerOrchestrationOptions RunnerOrchestration { get; set; } = new();
+
     public TimeSpan RunnerControlKeepAliveInterval { get; set; } = TimeSpan.FromSeconds(15);
 
     public TimeSpan RunnerControlClientTimeoutInterval { get; set; } = TimeSpan.FromSeconds(60);

--- a/AgentDeck.Coordinator/Configuration/CoordinatorRunnerOrchestrationOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorRunnerOrchestrationOptions.cs
@@ -1,0 +1,43 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Coordinator.Configuration;
+
+public sealed class CoordinatorRunnerOrchestrationOptions
+{
+    public bool Enabled { get; init; } = true;
+    public IReadOnlyList<CoordinatorRunnerOrchestratorProviderOptions> Providers { get; init; } = [];
+    public IReadOnlyList<CoordinatorRunnerOrchestratorTemplateOptions> Templates { get; init; } = [];
+}
+
+public sealed class CoordinatorRunnerOrchestratorProviderOptions
+{
+    public string Id { get; init; } = "portainer-local";
+    public string Name { get; init; } = "Portainer";
+    public RunnerOrchestratorProviderKind Kind { get; init; } = RunnerOrchestratorProviderKind.Portainer;
+    public bool Enabled { get; init; } = true;
+    public string? Description { get; init; }
+    public string? EndpointUrl { get; init; }
+    public string? ApiToken { get; init; }
+    public string? SecretReference { get; init; }
+    public string? DefaultEnvironmentId { get; init; }
+}
+
+public sealed class CoordinatorRunnerOrchestratorTemplateOptions
+{
+    public string Id { get; init; } = "linux-container-default";
+    public string ProviderId { get; init; } = "portainer-local";
+    public string Name { get; init; } = "Linux container runner";
+    public string? Description { get; init; }
+    public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Linux;
+    public string Architecture { get; init; } = "amd64";
+    public string Image { get; init; } = "ghcr.io/dappermickie/agentdeck-runner:latest";
+    public string WorkspaceRoot { get; init; } = "/workspace";
+    public string? WorkspaceVolume { get; init; } = "agentdeck-workspaces";
+    public int RunnerPort { get; init; } = 5000;
+    public string? NetworkName { get; init; }
+    public bool ManagedViewerEnabled { get; init; } = true;
+    public RunnerInstanceLifecyclePolicy DefaultLifecyclePolicy { get; init; } = RunnerInstanceLifecyclePolicy.Ephemeral;
+    public TimeSpan? IdleTimeout { get; init; } = TimeSpan.FromMinutes(30);
+    public TimeSpan? MaxLifetime { get; init; } = TimeSpan.FromHours(8);
+    public IReadOnlyList<string> CapabilityProfile { get; init; } = ["git", "node", "dotnet"];
+}

--- a/AgentDeck.Coordinator/Endpoints/CoordinatorEndpointModules.cs
+++ b/AgentDeck.Coordinator/Endpoints/CoordinatorEndpointModules.cs
@@ -176,6 +176,48 @@ public static class CoordinatorEndpointModules
         app.MapGet("/api/updates/rollouts", async (IWorkerRegistryService registry, CancellationToken cancellationToken) =>
             Results.Ok(await registry.GetUpdateRolloutsAsync(cancellationToken)));
 
+        app.MapGet("/api/runner-orchestration", (IRunnerOrchestrationService orchestration) =>
+            Results.Ok(orchestration.GetCatalog()));
+
+        app.MapGet("/api/runner-orchestration/providers/{providerId}", (string providerId, IRunnerOrchestrationService orchestration) =>
+            orchestration.GetProvider(providerId) is { } provider
+                ? Results.Ok(provider)
+                : Results.NotFound());
+
+        app.MapGet("/api/runner-orchestration/templates/{templateId}", (string templateId, IRunnerOrchestrationService orchestration) =>
+            orchestration.GetTemplate(templateId) is { } template
+                ? Results.Ok(template)
+                : Results.NotFound());
+
+        app.MapGet("/api/runner-orchestration/instances/{instanceId}", (string instanceId, IRunnerOrchestrationService orchestration) =>
+            orchestration.GetInstance(instanceId) is { } instance
+                ? Results.Ok(instance)
+                : Results.NotFound());
+
+        app.MapGet("/api/runner-orchestration/instances/{instanceId}/events", async (string instanceId, IRunnerOrchestrationService orchestration, CancellationToken cancellationToken) =>
+            Results.Ok(await orchestration.GetInstanceEventsAsync(instanceId, cancellationToken)));
+
+        app.MapPost("/api/runner-orchestration/instances", async (CreateRunnerOrchestratorInstanceRequest request, IRunnerOrchestrationService orchestration, CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                return Results.Ok(await orchestration.CreateInstanceAsync(request, cancellationToken));
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { message = ex.Message });
+            }
+        });
+
+        app.MapPost("/api/runner-orchestration/instances/{instanceId}/lifecycle/{state}", async (string instanceId, RunnerInstanceLifecycleState state, IRunnerOrchestrationService orchestration, CancellationToken cancellationToken) =>
+            await orchestration.UpdateInstanceLifecycleAsync(instanceId, state, cancellationToken) is { } instance
+                ? Results.Ok(instance)
+                : Results.NotFound());
+
         app.MapGet("/api/machines/{machineId}/updates/rollout", async (string machineId, IWorkerRegistryService registry, CancellationToken cancellationToken) =>
             await registry.GetUpdateRolloutAsync(machineId, cancellationToken) is { } rollout
                 ? Results.Ok(rollout)

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -40,6 +40,7 @@ builder.Services.AddSingleton<IProjectRegistryService, ProjectRegistryService>()
 builder.Services.AddSingleton<IProjectSessionRegistryService, ProjectSessionRegistryService>();
 builder.Services.AddSingleton<IProjectOpenService, ProjectOpenService>();
 builder.Services.AddSingleton<IMachineRemoteControlRegistryService, MachineRemoteControlRegistryService>();
+builder.Services.AddSingleton<IRunnerOrchestrationService, RunnerOrchestrationService>();
 builder.Services.AddSingleton<RunnerBrokerService>();
 builder.Services.AddSingleton<IRunnerBrokerService>(static services => services.GetRequiredService<RunnerBrokerService>());
 

--- a/AgentDeck.Coordinator/Services/RunnerOrchestration/IRunnerOrchestrationService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerOrchestration/IRunnerOrchestrationService.cs
@@ -1,0 +1,15 @@
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+
+namespace AgentDeck.Coordinator.Services;
+
+public interface IRunnerOrchestrationService
+{
+    RunnerOrchestratorCatalog GetCatalog();
+    RunnerOrchestratorProvider? GetProvider(string providerId);
+    RunnerOrchestratorTemplate? GetTemplate(string templateId);
+    RunnerOrchestratorInstance? GetInstance(string instanceId);
+    Task<RunnerOrchestratorInstance> CreateInstanceAsync(CreateRunnerOrchestratorInstanceRequest request, CancellationToken cancellationToken = default);
+    Task<RunnerOrchestratorInstance?> UpdateInstanceLifecycleAsync(string instanceId, RunnerInstanceLifecycleState requestedState, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<RunnerOrchestratorInstanceEvent>> GetInstanceEventsAsync(string instanceId, CancellationToken cancellationToken = default);
+}

--- a/AgentDeck.Coordinator/Services/RunnerOrchestration/RunnerOrchestrationService.cs
+++ b/AgentDeck.Coordinator/Services/RunnerOrchestration/RunnerOrchestrationService.cs
@@ -1,0 +1,405 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using AgentDeck.Coordinator.Configuration;
+using AgentDeck.Shared.Enums;
+using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+
+namespace AgentDeck.Coordinator.Services;
+
+public sealed class RunnerOrchestrationService : IRunnerOrchestrationService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<CoordinatorOptions> _options;
+    private readonly ILogger<RunnerOrchestrationService> _logger;
+    private readonly ConcurrentDictionary<string, RunnerOrchestratorInstance> _instances = new(StringComparer.OrdinalIgnoreCase);
+
+    public RunnerOrchestrationService(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<CoordinatorOptions> options,
+        ILogger<RunnerOrchestrationService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    public RunnerOrchestratorCatalog GetCatalog() => new()
+    {
+        Providers = BuildProviders(),
+        Templates = BuildTemplates(),
+        Instances = _instances.Values.OrderByDescending(instance => instance.UpdatedAt).ToArray()
+    };
+
+    public RunnerOrchestratorProvider? GetProvider(string providerId) =>
+        BuildProviders().FirstOrDefault(provider => string.Equals(provider.Id, providerId, StringComparison.OrdinalIgnoreCase));
+
+    public RunnerOrchestratorTemplate? GetTemplate(string templateId) =>
+        BuildTemplates().FirstOrDefault(template => string.Equals(template.Id, templateId, StringComparison.OrdinalIgnoreCase));
+
+    public RunnerOrchestratorInstance? GetInstance(string instanceId) =>
+        _instances.TryGetValue(instanceId, out var instance) ? instance : null;
+
+    public async Task<RunnerOrchestratorInstance> CreateInstanceAsync(CreateRunnerOrchestratorInstanceRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TemplateId);
+
+        var template = GetTemplate(request.TemplateId) ?? throw new ArgumentException($"Runner template '{request.TemplateId}' was not found.", nameof(request));
+        var provider = GetProvider(template.ProviderId) ?? throw new InvalidOperationException($"Runner provider '{template.ProviderId}' was not found.");
+        if (!provider.Enabled)
+        {
+            throw new InvalidOperationException($"Runner provider '{provider.Name}' is disabled.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var instanceId = $"runner-{Guid.NewGuid():N}";
+        var machineId = $"agentdeck-{instanceId}";
+        var instanceName = string.IsNullOrWhiteSpace(request.Name) ? template.Name : request.Name.Trim();
+        var instance = new RunnerOrchestratorInstance
+        {
+            Id = instanceId,
+            ProviderId = provider.Id,
+            TemplateId = template.Id,
+            Name = instanceName,
+            MachineId = machineId,
+            HostPlatform = template.HostPlatform,
+            LifecyclePolicy = request.LifecyclePolicy,
+            State = RunnerInstanceLifecycleState.Creating,
+            StatusMessage = $"Creating {template.Name} through {provider.Name}.",
+            CreatedAt = now,
+            UpdatedAt = now,
+            ExpiresAt = request.LifecyclePolicy == RunnerInstanceLifecyclePolicy.Persistent ? null : now.Add(template.MaxLifetime ?? TimeSpan.FromHours(8)),
+            Events = [CreateEvent("Runner request accepted by coordinator.")]
+        };
+        _instances[instance.Id] = instance;
+
+        try
+        {
+            if (provider.Kind == RunnerOrchestratorProviderKind.Portainer && provider.Configured)
+            {
+                instance = await CreatePortainerContainerAsync(provider, template, instance, request, cancellationToken);
+            }
+            else
+            {
+                instance = WithEvent(instance, RunnerInstanceLifecycleState.Failed,
+                    provider.Kind == RunnerOrchestratorProviderKind.Portainer
+                        ? "Portainer provider is not configured. Add EndpointUrl, ApiToken, and DefaultEnvironmentId in coordinator configuration."
+                        : $"Provider kind {provider.Kind} is modeled but no adapter implementation is available yet.",
+                    level: "warning");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create runner instance {InstanceId} with provider {ProviderId}", instance.Id, provider.Id);
+            instance = WithEvent(instance, RunnerInstanceLifecycleState.Failed, ex.Message, level: "error");
+        }
+
+        _instances[instance.Id] = instance;
+        return instance;
+    }
+
+    public async Task<RunnerOrchestratorInstance?> UpdateInstanceLifecycleAsync(string instanceId, RunnerInstanceLifecycleState requestedState, CancellationToken cancellationToken = default)
+    {
+        if (!_instances.TryGetValue(instanceId, out var instance))
+        {
+            return null;
+        }
+
+        var provider = GetProvider(instance.ProviderId);
+        if (provider?.Kind == RunnerOrchestratorProviderKind.Portainer && provider.Configured && !string.IsNullOrWhiteSpace(instance.ProviderResourceId))
+        {
+            try
+            {
+                if (requestedState is RunnerInstanceLifecycleState.Stopped or RunnerInstanceLifecycleState.Deleting or RunnerInstanceLifecycleState.Deleted)
+                {
+                    await StopPortainerContainerAsync(provider, instance.ProviderResourceId, cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to update Portainer lifecycle for runner instance {InstanceId}", instanceId);
+                instance = WithEvent(instance, RunnerInstanceLifecycleState.Failed, ex.Message, level: "error");
+                _instances[instance.Id] = instance;
+                return instance;
+            }
+        }
+
+        var message = requestedState switch
+        {
+            RunnerInstanceLifecycleState.Stopped => "Runner instance stopped.",
+            RunnerInstanceLifecycleState.Deleting or RunnerInstanceLifecycleState.Deleted => "Runner instance marked for deletion.",
+            RunnerInstanceLifecycleState.Idle => "Runner instance marked idle.",
+            _ => $"Runner instance moved to {requestedState}."
+        };
+        instance = WithEvent(instance, requestedState, message);
+        _instances[instance.Id] = instance;
+        return instance;
+    }
+
+    public Task<IReadOnlyList<RunnerOrchestratorInstanceEvent>> GetInstanceEventsAsync(string instanceId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<RunnerOrchestratorInstanceEvent>>(
+            _instances.TryGetValue(instanceId, out var instance) ? instance.Events : []);
+
+    private IReadOnlyList<RunnerOrchestratorProvider> BuildProviders()
+    {
+        var configured = _options.CurrentValue.RunnerOrchestration.Providers;
+        var providers = configured.Count > 0
+            ? configured
+            : [new CoordinatorRunnerOrchestratorProviderOptions
+            {
+                Id = "portainer-local",
+                Name = "Portainer",
+                Kind = RunnerOrchestratorProviderKind.Portainer,
+                Description = "Create Linux AgentDeck runner containers through Portainer.",
+                SecretReference = "Coordinator:RunnerOrchestration:Providers:0:ApiToken"
+            }];
+
+        return providers.Select(provider => new RunnerOrchestratorProvider
+        {
+            Id = provider.Id,
+            Name = provider.Name,
+            Kind = provider.Kind,
+            Enabled = provider.Enabled,
+            Description = provider.Description,
+            EndpointUrl = provider.EndpointUrl,
+            SecretReference = provider.SecretReference,
+            DefaultEnvironmentId = provider.DefaultEnvironmentId,
+            Configured = provider.Kind != RunnerOrchestratorProviderKind.Portainer ||
+                (!string.IsNullOrWhiteSpace(provider.EndpointUrl) && !string.IsNullOrWhiteSpace(provider.ApiToken) && !string.IsNullOrWhiteSpace(provider.DefaultEnvironmentId)),
+            StatusMessage = string.IsNullOrWhiteSpace(provider.EndpointUrl)
+                ? "Provider configured as a template; endpoint and secret are still required before it can create runners."
+                : "Provider configured.",
+            Capabilities = provider.Kind == RunnerOrchestratorProviderKind.Portainer
+                ? new RunnerOrchestratorProviderCapability
+                {
+                    SupportsLinux = true,
+                    SupportsContainers = true,
+                    SupportsVolumes = true,
+                    ViewerProviders = [RemoteViewerProviderKind.Managed, RemoteViewerProviderKind.Vnc]
+                }
+                : new RunnerOrchestratorProviderCapability()
+        }).ToArray();
+    }
+
+    private IReadOnlyList<RunnerOrchestratorTemplate> BuildTemplates()
+    {
+        var configured = _options.CurrentValue.RunnerOrchestration.Templates;
+        var templates = configured.Count > 0
+            ? configured
+            : [new CoordinatorRunnerOrchestratorTemplateOptions
+            {
+                Id = "linux-portainer-runner",
+                ProviderId = "portainer-local",
+                Name = "Linux Portainer runner",
+                Description = "Default ephemeral Linux container runner created through Portainer."
+            }];
+
+        return templates.Select(template => new RunnerOrchestratorTemplate
+        {
+            Id = template.Id,
+            ProviderId = template.ProviderId,
+            Name = template.Name,
+            Description = template.Description,
+            HostPlatform = template.HostPlatform,
+            Architecture = template.Architecture,
+            Image = template.Image,
+            WorkspaceRoot = template.WorkspaceRoot,
+            WorkspaceVolume = template.WorkspaceVolume,
+            RunnerPort = template.RunnerPort,
+            NetworkName = template.NetworkName,
+            ManagedViewerEnabled = template.ManagedViewerEnabled,
+            DefaultLifecyclePolicy = template.DefaultLifecyclePolicy,
+            IdleTimeout = template.IdleTimeout,
+            MaxLifetime = template.MaxLifetime,
+            CapabilityProfile = template.CapabilityProfile
+        }).ToArray();
+    }
+
+    private async Task<RunnerOrchestratorInstance> CreatePortainerContainerAsync(
+        RunnerOrchestratorProvider provider,
+        RunnerOrchestratorTemplate template,
+        RunnerOrchestratorInstance instance,
+        CreateRunnerOrchestratorInstanceRequest request,
+        CancellationToken cancellationToken)
+    {
+        var optionsProvider = _options.CurrentValue.RunnerOrchestration.Providers
+            .First(source => string.Equals(source.Id, provider.Id, StringComparison.OrdinalIgnoreCase));
+        var baseUrl = optionsProvider.EndpointUrl!.TrimEnd('/') + "/";
+        var endpointId = optionsProvider.DefaultEnvironmentId!;
+        using var httpClient = _httpClientFactory.CreateClient();
+        httpClient.BaseAddress = new Uri(baseUrl, UriKind.Absolute);
+        httpClient.DefaultRequestHeaders.Add("X-API-Key", optionsProvider.ApiToken!);
+
+        instance = WithEvent(instance, RunnerInstanceLifecycleState.Booting, "Requesting Portainer container creation.");
+        _instances[instance.Id] = instance;
+
+        var env = new Dictionary<string, string>(request.Environment, StringComparer.OrdinalIgnoreCase)
+        {
+            ["Coordinator__MachineId"] = instance.MachineId ?? instance.Id,
+            ["Coordinator__MachineName"] = instance.Name,
+            ["Coordinator__CoordinatorUrl"] = request.CoordinatorUrl ?? _options.CurrentValue.PublicBaseUrl ?? "http://host.docker.internal:5001",
+            ["Runner__WorkspaceRoot"] = template.WorkspaceRoot,
+            ["Runner__Port"] = template.RunnerPort.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["DesktopViewerTransport__Managed__Enabled"] = template.ManagedViewerEnabled ? "true" : "false"
+        };
+
+        var createRequest = new PortainerContainerCreateRequest
+        {
+            Image = template.Image,
+            Env = env.Select(pair => $"{pair.Key}={pair.Value}").ToArray(),
+            ExposedPorts = new Dictionary<string, object> { [$"{template.RunnerPort}/tcp"] = new() },
+            HostConfig = new PortainerHostConfig
+            {
+                NetworkMode = template.NetworkName,
+                Binds = string.IsNullOrWhiteSpace(template.WorkspaceVolume)
+                    ? []
+                    : [$"{template.WorkspaceVolume}:{template.WorkspaceRoot}"],
+                PortBindings = new Dictionary<string, IReadOnlyList<PortainerPortBinding>>
+                {
+                    [$"{template.RunnerPort}/tcp"] = [new PortainerPortBinding { HostPort = string.Empty }]
+                },
+                RestartPolicy = new PortainerRestartPolicy
+                {
+                    Name = request.LifecyclePolicy == RunnerInstanceLifecyclePolicy.Ephemeral ? "no" : "unless-stopped"
+                }
+            },
+            Labels = new Dictionary<string, string>
+            {
+                ["agentdeck.managed"] = "true",
+                ["agentdeck.instanceId"] = instance.Id,
+                ["agentdeck.templateId"] = template.Id,
+                ["agentdeck.lifecycle"] = request.LifecyclePolicy.ToString()
+            }
+        };
+
+        using var createResponse = await httpClient.PostAsJsonAsync(
+            $"api/endpoints/{Uri.EscapeDataString(endpointId)}/docker/containers/create?name={Uri.EscapeDataString(instance.Id)}",
+            createRequest,
+            cancellationToken);
+        if (!createResponse.IsSuccessStatusCode)
+        {
+            var error = await createResponse.Content.ReadAsStringAsync(cancellationToken);
+            throw new InvalidOperationException($"Portainer rejected runner creation with HTTP {(int)createResponse.StatusCode}: {error}");
+        }
+
+        var createResult = await createResponse.Content.ReadFromJsonAsync<PortainerContainerCreateResult>(cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("Portainer returned an empty container creation response.");
+        instance = instance.WithResource(createResult.Id, $"Portainer container {createResult.Id} created; starting it now.", RunnerInstanceLifecycleState.Booting);
+        _instances[instance.Id] = instance;
+
+        using var startResponse = await httpClient.PostAsync(
+            $"api/endpoints/{Uri.EscapeDataString(endpointId)}/docker/containers/{Uri.EscapeDataString(createResult.Id)}/start",
+            content: null,
+            cancellationToken);
+        if (!startResponse.IsSuccessStatusCode)
+        {
+            var error = await startResponse.Content.ReadAsStringAsync(cancellationToken);
+            throw new InvalidOperationException($"Portainer created the container but could not start it with HTTP {(int)startResponse.StatusCode}: {error}");
+        }
+
+        return WithEvent(instance, RunnerInstanceLifecycleState.Registering,
+            "Runner container started. Waiting for it to register with the coordinator.");
+    }
+
+    private async Task StopPortainerContainerAsync(RunnerOrchestratorProvider provider, string containerId, CancellationToken cancellationToken)
+    {
+        var optionsProvider = _options.CurrentValue.RunnerOrchestration.Providers
+            .First(source => string.Equals(source.Id, provider.Id, StringComparison.OrdinalIgnoreCase));
+        using var httpClient = _httpClientFactory.CreateClient();
+        httpClient.BaseAddress = new Uri(optionsProvider.EndpointUrl!.TrimEnd('/') + "/", UriKind.Absolute);
+        httpClient.DefaultRequestHeaders.Add("X-API-Key", optionsProvider.ApiToken!);
+        using var response = await httpClient.PostAsync(
+            $"api/endpoints/{Uri.EscapeDataString(optionsProvider.DefaultEnvironmentId!)}/docker/containers/{Uri.EscapeDataString(containerId)}/stop",
+            content: null,
+            cancellationToken);
+        if (!response.IsSuccessStatusCode && response.StatusCode != System.Net.HttpStatusCode.NotModified)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new InvalidOperationException($"Portainer could not stop runner container with HTTP {(int)response.StatusCode}: {error}");
+        }
+    }
+
+    private static RunnerOrchestratorInstance WithEvent(RunnerOrchestratorInstance instance, RunnerInstanceLifecycleState state, string message, string level = "info") => new()
+    {
+        Id = instance.Id,
+        ProviderId = instance.ProviderId,
+        TemplateId = instance.TemplateId,
+        Name = instance.Name,
+        State = state,
+        LifecyclePolicy = instance.LifecyclePolicy,
+        HostPlatform = instance.HostPlatform,
+        MachineId = instance.MachineId,
+        ProviderResourceId = instance.ProviderResourceId,
+        EndpointUrl = instance.EndpointUrl,
+        StatusMessage = message,
+        CreatedAt = instance.CreatedAt,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = instance.ExpiresAt,
+        Events = instance.Events.Concat([CreateEvent(message, level)]).ToArray()
+    };
+
+    private static RunnerOrchestratorInstanceEvent CreateEvent(string message, string level = "info") => new()
+    {
+        Timestamp = DateTimeOffset.UtcNow,
+        Message = message,
+        Level = level
+    };
+
+    private sealed class PortainerContainerCreateRequest
+    {
+        public string Image { get; init; } = string.Empty;
+        public IReadOnlyList<string> Env { get; init; } = [];
+        public IReadOnlyDictionary<string, object> ExposedPorts { get; init; } = new Dictionary<string, object>();
+        public PortainerHostConfig HostConfig { get; init; } = new();
+        public IReadOnlyDictionary<string, string> Labels { get; init; } = new Dictionary<string, string>();
+    }
+
+    private sealed class PortainerHostConfig
+    {
+        public string? NetworkMode { get; init; }
+        public IReadOnlyList<string> Binds { get; init; } = [];
+        public IReadOnlyDictionary<string, IReadOnlyList<PortainerPortBinding>> PortBindings { get; init; } = new Dictionary<string, IReadOnlyList<PortainerPortBinding>>();
+        public PortainerRestartPolicy RestartPolicy { get; init; } = new();
+    }
+
+    private sealed class PortainerPortBinding
+    {
+        public string HostIp { get; init; } = string.Empty;
+        public string HostPort { get; init; } = string.Empty;
+    }
+
+    private sealed class PortainerRestartPolicy
+    {
+        public string Name { get; init; } = "no";
+    }
+
+    private sealed class PortainerContainerCreateResult
+    {
+        [JsonPropertyName("Id")]
+        public string Id { get; init; } = string.Empty;
+    }
+}
+
+file static class RunnerOrchestratorInstanceExtensions
+{
+    public static RunnerOrchestratorInstance WithResource(this RunnerOrchestratorInstance instance, string resourceId, string message, RunnerInstanceLifecycleState state) => new()
+    {
+        Id = instance.Id,
+        ProviderId = instance.ProviderId,
+        TemplateId = instance.TemplateId,
+        Name = instance.Name,
+        State = state,
+        LifecyclePolicy = instance.LifecyclePolicy,
+        HostPlatform = instance.HostPlatform,
+        MachineId = instance.MachineId,
+        ProviderResourceId = resourceId,
+        EndpointUrl = instance.EndpointUrl,
+        StatusMessage = message,
+        CreatedAt = instance.CreatedAt,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = instance.ExpiresAt,
+        Events = instance.Events.Concat([new RunnerOrchestratorInstanceEvent { Message = message }]).ToArray()
+    };
+}

--- a/AgentDeck.Core.Client/Services/CoordinatorApiClient.cs
+++ b/AgentDeck.Core.Client/Services/CoordinatorApiClient.cs
@@ -52,6 +52,66 @@ public sealed class CoordinatorApiClient : ICoordinatorApiClient
         }
     }
 
+    public async Task<RunnerOrchestratorCatalog> GetRunnerOrchestrationCatalogAsync(string coordinatorUrl, CancellationToken cancellationToken = default)
+    {
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            return await httpClient.GetFromJsonAsync<RunnerOrchestratorCatalog>("api/runner-orchestration", cancellationToken) ?? new RunnerOrchestratorCatalog();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator runner orchestration catalog lookup failed for {CoordinatorUrl}", coordinatorUrl);
+            throw;
+        }
+    }
+
+    public async Task<RunnerOrchestratorInstance?> CreateRunnerInstanceAsync(string coordinatorUrl, CreateRunnerOrchestratorInstanceRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsJsonAsync("api/runner-orchestration/instances", request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = await TryReadErrorMessageAsync(response, cancellationToken);
+                throw new InvalidOperationException(message ?? $"Coordinator rejected runner creation with HTTP {(int)response.StatusCode}.");
+            }
+
+            return await response.Content.ReadFromJsonAsync<RunnerOrchestratorInstance>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Coordinator runner creation failed for template {TemplateId}", request.TemplateId);
+            throw;
+        }
+    }
+
+    public async Task<RunnerOrchestratorInstance?> UpdateRunnerInstanceLifecycleAsync(string coordinatorUrl, string instanceId, RunnerInstanceLifecycleState state, CancellationToken cancellationToken = default)
+    {
+        using var httpClient = CreateClient(coordinatorUrl);
+        try
+        {
+            using var response = await httpClient.PostAsync(
+                $"api/runner-orchestration/instances/{Uri.EscapeDataString(instanceId)}/lifecycle/{state}",
+                content: null,
+                cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<RunnerOrchestratorInstance>(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Coordinator runner lifecycle update failed for instance {InstanceId}", instanceId);
+            throw;
+        }
+    }
+
     public async Task<IReadOnlyList<ProjectDefinition>> GetProjectsAsync(string coordinatorUrl, CancellationToken cancellationToken = default)
     {
         using var httpClient = CreateClient(coordinatorUrl);

--- a/AgentDeck.Core.Client/Services/ICoordinatorApiClient.cs
+++ b/AgentDeck.Core.Client/Services/ICoordinatorApiClient.cs
@@ -10,6 +10,12 @@ public interface ICoordinatorApiClient
 
     Task<IReadOnlyList<RegisteredRunnerMachine>> GetMachinesAsync(string coordinatorUrl, CancellationToken cancellationToken = default);
 
+    Task<RunnerOrchestratorCatalog> GetRunnerOrchestrationCatalogAsync(string coordinatorUrl, CancellationToken cancellationToken = default);
+
+    Task<RunnerOrchestratorInstance?> CreateRunnerInstanceAsync(string coordinatorUrl, CreateRunnerOrchestratorInstanceRequest request, CancellationToken cancellationToken = default);
+
+    Task<RunnerOrchestratorInstance?> UpdateRunnerInstanceLifecycleAsync(string coordinatorUrl, string instanceId, RunnerInstanceLifecycleState state, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<ProjectDefinition>> GetProjectsAsync(string coordinatorUrl, CancellationToken cancellationToken = default);
 
     Task<ProjectDefinition> UpsertProjectAsync(string coordinatorUrl, ProjectDefinition project, CancellationToken cancellationToken = default);

--- a/AgentDeck.Core/Models/CompanionDashboardState.cs
+++ b/AgentDeck.Core/Models/CompanionDashboardState.cs
@@ -10,6 +10,7 @@ public sealed class CompanionDashboardState
     public bool CoordinatorReachable { get; init; }
     public string? CoordinatorErrorMessage { get; init; }
     public IReadOnlyList<CompanionMachineSummary> Machines { get; init; } = [];
+    public RunnerOrchestratorCatalog RunnerOrchestration { get; init; } = new();
     public IReadOnlyList<CompanionProjectSummary> Projects { get; init; } = [];
     public IReadOnlyList<ProjectSessionRecord> ProjectSessions { get; init; } = [];
     public IReadOnlyList<CompanionViewerSurfaceSummary> ViewerSurfaces { get; init; } = [];

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -156,6 +156,72 @@
             <p class="error-message">@_errorMessage</p>
         }
 
+        <div class="settings-callout">
+            <strong>Create runner capacity</strong>
+            <span>Use configured provider templates to create Linux/Windows/macOS runners on demand. Portainer is the first adapter; unsupported OS/provider combinations stay visible as planning targets instead of becoming dead-end buttons.</span>
+        </div>
+
+        @if (_runnerOrchestrationCatalog.Templates.Count == 0)
+        {
+            <p class="settings-card__description">No runner templates are published by the coordinator yet.</p>
+        }
+        else
+        {
+            <div class="project-template-grid">
+                @foreach (var template in _runnerOrchestrationCatalog.Templates.OrderBy(template => template.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    var provider = GetRunnerProvider(template.ProviderId);
+                    <article class="project-template-card">
+                        <div class="project-template-card__header">
+                            <div>
+                                <h3>@template.Name</h3>
+                                <p>@template.HostPlatform • @(provider?.Name ?? template.ProviderId)</p>
+                            </div>
+                            <span class="machine-badge">@template.DefaultLifecyclePolicy</span>
+                        </div>
+                        <p class="project-template-target__note">@(template.Description ?? $"Creates an AgentDeck runner from {template.Image}.")</p>
+                        <p class="project-template-target__note">Capabilities: @string.Join(", ", template.CapabilityProfile)</p>
+                        @if (provider is not null && !provider.Configured)
+                        {
+                            <p class="error-message">@provider.StatusMessage</p>
+                        }
+                        <div class="project-machine-card__actions">
+                            <button class="btn btn-primary"
+                                    disabled="@(_creatingRunnerTemplateId == template.Id || provider is null || !provider.Enabled)"
+                                    @onclick="() => CreateRunnerFromTemplateAsync(template)">
+                                @(_creatingRunnerTemplateId == template.Id ? "Creating..." : "Create runner")
+                            </button>
+                        </div>
+                    </article>
+                }
+            </div>
+        }
+
+        @if (_runnerOrchestrationCatalog.Instances.Count > 0)
+        {
+            <div class="machine-list machine-list--settings">
+                @foreach (var instance in _runnerOrchestrationCatalog.Instances.OrderByDescending(instance => instance.UpdatedAt))
+                {
+                    <article class="machine-card">
+                        <span class="machine-card__title">@instance.Name</span>
+                        <span class="machine-card__url">@instance.StatusMessage</span>
+                        <span class="machine-card__meta">
+                            <span class="machine-badge">@instance.HostPlatform</span>
+                            <span class="machine-state machine-state--@(instance.State is RunnerInstanceLifecycleState.Failed or RunnerInstanceLifecycleState.Stopped ? "disconnected" : "connected")">@instance.State</span>
+                            @if (!string.IsNullOrWhiteSpace(instance.MachineId))
+                            {
+                                <span class="machine-badge">@instance.MachineId</span>
+                            }
+                        </span>
+                        @if (instance.Events.Count > 0)
+                        {
+                            <span class="settings-card__description">Latest: @instance.Events[^1].Message</span>
+                        }
+                    </article>
+                }
+            </div>
+        }
+
         <div class="machine-layout">
             <div class="machine-list machine-list--settings">
                 @foreach (var machine in _settings.Machines)
@@ -759,6 +825,8 @@
     private string? _activeCapabilityAction;
     private MachineCapabilityInstallResult? _lastCapabilityInstallResult;
     private IReadOnlyList<RegisteredRunnerMachine> _registeredMachines = [];
+    private RunnerOrchestratorCatalog _runnerOrchestrationCatalog = new();
+    private string? _creatingRunnerTemplateId;
     private bool _registeredMachinesBusy;
     private string? _registeredMachinesErrorMessage;
     private bool _coordinatorReachable;
@@ -1061,6 +1129,50 @@
         return RefreshMachineCapabilitiesAsync();
     }
 
+    private RunnerOrchestratorProvider? GetRunnerProvider(string providerId) =>
+        _runnerOrchestrationCatalog.Providers.FirstOrDefault(provider => string.Equals(provider.Id, providerId, StringComparison.OrdinalIgnoreCase));
+
+    private async Task CreateRunnerFromTemplateAsync(RunnerOrchestratorTemplate template)
+    {
+        if (string.IsNullOrWhiteSpace(_settings.CoordinatorUrl))
+        {
+            ToastService.Show("Set a coordinator URL before creating a runner.", ToastKind.Warning);
+            return;
+        }
+
+        _creatingRunnerTemplateId = template.Id;
+        try
+        {
+            var instance = await CoordinatorClient.CreateRunnerInstanceAsync(
+                _settings.CoordinatorUrl,
+                new CreateRunnerOrchestratorInstanceRequest
+                {
+                    TemplateId = template.Id,
+                    Name = $"{template.Name} {DateTimeOffset.Now:HHmm}",
+                    LifecyclePolicy = template.DefaultLifecyclePolicy,
+                    CoordinatorUrl = _settings.CoordinatorUrl
+                });
+
+            if (instance is null)
+            {
+                ToastService.Show("The coordinator did not return a runner instance.", ToastKind.Warning);
+                return;
+            }
+
+            ToastService.Show($"Runner {instance.Name} is {instance.State}. Refresh the directory once it registers.", instance.State == RunnerInstanceLifecycleState.Failed ? ToastKind.Warning : ToastKind.Success);
+            await RefreshCoordinatorDirectoryAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create runner from template {TemplateId}", template.Id);
+            ToastService.Show($"Failed to create runner: {ex.Message}", ToastKind.Error);
+        }
+        finally
+        {
+            _creatingRunnerTemplateId = null;
+        }
+    }
+
     private async Task RefreshCoordinatorDirectoryAsync()
     {
         _registeredMachinesBusy = true;
@@ -1085,6 +1197,7 @@
             }
 
             _registeredMachines = await CoordinatorClient.GetMachinesAsync(_settings.CoordinatorUrl);
+            _runnerOrchestrationCatalog = await CoordinatorClient.GetRunnerOrchestrationCatalogAsync(_settings.CoordinatorUrl);
             await SyncMachinesFromCoordinatorDirectoryAsync(_registeredMachines);
         }
         catch (Exception ex)

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -31,6 +31,7 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
         var coordinatorReachable = false;
         string? coordinatorError = null;
         IReadOnlyList<RegisteredRunnerMachine> registeredMachines = [];
+        RunnerOrchestratorCatalog runnerOrchestration = new();
         IReadOnlyList<ProjectDefinition> projects = [];
         IReadOnlyList<ProjectSessionRecord> projectSessions = [];
 
@@ -42,6 +43,7 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                 if (coordinatorReachable)
                 {
                     registeredMachines = await _coordinator.GetMachinesAsync(settings.CoordinatorUrl, cancellationToken);
+                    runnerOrchestration = await _coordinator.GetRunnerOrchestrationCatalogAsync(settings.CoordinatorUrl, cancellationToken);
                     projects = await _coordinator.GetProjectsAsync(settings.CoordinatorUrl, cancellationToken);
                     projectSessions = await _coordinator.GetProjectSessionsAsync(settings.CoordinatorUrl, cancellationToken: cancellationToken);
                 }
@@ -105,6 +107,7 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
             CoordinatorReachable = coordinatorReachable,
             CoordinatorErrorMessage = coordinatorError,
             Machines = machines,
+            RunnerOrchestration = runnerOrchestration,
             Projects = projectSummaries,
             ProjectSessions = projectSessions,
             ViewerSurfaces = viewerSurfaces,

--- a/AgentDeck.Shared/Enums/RunnerInstanceLifecyclePolicy.cs
+++ b/AgentDeck.Shared/Enums/RunnerInstanceLifecyclePolicy.cs
@@ -1,0 +1,9 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>How AgentDeck should treat created runner lifetime.</summary>
+public enum RunnerInstanceLifecyclePolicy
+{
+    Ephemeral,
+    Reusable,
+    Persistent
+}

--- a/AgentDeck.Shared/Enums/RunnerInstanceLifecycleState.cs
+++ b/AgentDeck.Shared/Enums/RunnerInstanceLifecycleState.cs
@@ -1,0 +1,17 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Lifecycle state for a runner instance created by an orchestrator provider.</summary>
+public enum RunnerInstanceLifecycleState
+{
+    Creating,
+    Booting,
+    Registering,
+    Ready,
+    Busy,
+    Idle,
+    Draining,
+    Stopped,
+    Failed,
+    Deleting,
+    Deleted
+}

--- a/AgentDeck.Shared/Enums/RunnerOrchestratorProviderKind.cs
+++ b/AgentDeck.Shared/Enums/RunnerOrchestratorProviderKind.cs
@@ -1,0 +1,13 @@
+namespace AgentDeck.Shared.Enums;
+
+/// <summary>Provider family that can create AgentDeck runner capacity on demand.</summary>
+public enum RunnerOrchestratorProviderKind
+{
+    Portainer,
+    Docker,
+    Kubernetes,
+    CloudVm,
+    LocalLauncher,
+    MacPool,
+    WindowsPool
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/CreateRunnerOrchestratorInstanceRequest.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/CreateRunnerOrchestratorInstanceRequest.cs
@@ -1,0 +1,14 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class CreateRunnerOrchestratorInstanceRequest
+{
+    public string TemplateId { get; init; } = string.Empty;
+    public string? Name { get; init; }
+    public RunnerInstanceLifecyclePolicy LifecyclePolicy { get; init; } = RunnerInstanceLifecyclePolicy.Ephemeral;
+    public string? CoordinatorUrl { get; init; }
+    public string? ProjectId { get; init; }
+    public string? ProjectName { get; init; }
+    public IReadOnlyDictionary<string, string> Environment { get; init; } = new Dictionary<string, string>();
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorCatalog.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorCatalog.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorCatalog
+{
+    public IReadOnlyList<RunnerOrchestratorProvider> Providers { get; init; } = [];
+    public IReadOnlyList<RunnerOrchestratorTemplate> Templates { get; init; } = [];
+    public IReadOnlyList<RunnerOrchestratorInstance> Instances { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorInstance.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorInstance.cs
@@ -1,0 +1,22 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorInstance
+{
+    public string Id { get; init; } = string.Empty;
+    public string ProviderId { get; init; } = string.Empty;
+    public string TemplateId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public RunnerInstanceLifecycleState State { get; init; } = RunnerInstanceLifecycleState.Creating;
+    public RunnerInstanceLifecyclePolicy LifecyclePolicy { get; init; } = RunnerInstanceLifecyclePolicy.Ephemeral;
+    public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Linux;
+    public string? MachineId { get; init; }
+    public string? ProviderResourceId { get; init; }
+    public string? EndpointUrl { get; init; }
+    public string? StatusMessage { get; init; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? ExpiresAt { get; init; }
+    public IReadOnlyList<RunnerOrchestratorInstanceEvent> Events { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorInstanceEvent.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorInstanceEvent.cs
@@ -1,0 +1,8 @@
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorInstanceEvent
+{
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+    public string Message { get; init; } = string.Empty;
+    public string Level { get; init; } = "info";
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorProvider.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorProvider.cs
@@ -1,0 +1,18 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorProvider
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public RunnerOrchestratorProviderKind Kind { get; init; } = RunnerOrchestratorProviderKind.Portainer;
+    public string? Description { get; init; }
+    public bool Enabled { get; init; } = true;
+    public bool Configured { get; init; }
+    public string? EndpointUrl { get; init; }
+    public string? SecretReference { get; init; }
+    public string? DefaultEnvironmentId { get; init; }
+    public string? StatusMessage { get; init; }
+    public RunnerOrchestratorProviderCapability Capabilities { get; init; } = new();
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorProviderCapability.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorProviderCapability.cs
@@ -1,0 +1,16 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorProviderCapability
+{
+    public bool SupportsLinux { get; init; }
+    public bool SupportsWindows { get; init; }
+    public bool SupportsMacOS { get; init; }
+    public bool SupportsContainers { get; init; }
+    public bool SupportsVirtualMachines { get; init; }
+    public bool SupportsGpu { get; init; }
+    public bool SupportsVolumes { get; init; }
+    public bool SupportsSnapshots { get; init; }
+    public IReadOnlyList<RemoteViewerProviderKind> ViewerProviders { get; init; } = [];
+}

--- a/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorTemplate.cs
+++ b/AgentDeck.Shared/Models/RunnerOrchestration/RunnerOrchestratorTemplate.cs
@@ -1,0 +1,25 @@
+using AgentDeck.Shared.Enums;
+
+namespace AgentDeck.Shared.Models;
+
+public sealed class RunnerOrchestratorTemplate
+{
+    public string Id { get; init; } = string.Empty;
+    public string ProviderId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public RunnerHostPlatform HostPlatform { get; init; } = RunnerHostPlatform.Linux;
+    public string Architecture { get; init; } = "amd64";
+    public string Image { get; init; } = "ghcr.io/dappermickie/agentdeck-runner:latest";
+    public string WorkspaceRoot { get; init; } = "/workspace";
+    public string? WorkspaceVolume { get; init; }
+    public int? CpuLimit { get; init; }
+    public int? MemoryMb { get; init; }
+    public string? NetworkName { get; init; }
+    public int RunnerPort { get; init; } = 5000;
+    public bool ManagedViewerEnabled { get; init; } = true;
+    public RunnerInstanceLifecyclePolicy DefaultLifecyclePolicy { get; init; } = RunnerInstanceLifecyclePolicy.Ephemeral;
+    public TimeSpan? IdleTimeout { get; init; } = TimeSpan.FromMinutes(30);
+    public TimeSpan? MaxLifetime { get; init; } = TimeSpan.FromHours(8);
+    public IReadOnlyList<string> CapabilityProfile { get; init; } = ["git", "node", "dotnet"];
+}

--- a/AgentDeck/AgentDeck.csproj
+++ b/AgentDeck/AgentDeck.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.30" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.30" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.50" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.50" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
   </ItemGroup>
 

--- a/AgentDeck/Platforms/Linux/Main.cs
+++ b/AgentDeck/Platforms/Linux/Main.cs
@@ -1,9 +1,11 @@
+using Microsoft.Maui.Platform.Linux;
+
 namespace AgentDeck.Platforms.Linux;
 
 internal class Program
 {
     public static void Main(string[] args)
     {
-        MauiProgram.CreateMauiApp().Run();
+        LinuxApplication.Run(MauiProgram.CreateMauiApp(), args);
     }
 }


### PR DESCRIPTION
## Summary
- add provider-neutral runner orchestration models for providers, templates, instances, lifecycle policies, and catalog state
- add coordinator orchestration service/endpoints with an initial Portainer container adapter and lifecycle controls
- surface runner templates/instances in Settings so users can create on-demand runner capacity from the coordinator
- align MAUI/OpenMaui package versions and update Linux entrypoint for the newer OpenMaui runtime

Closes #375

## Validation
- `dotnet restore AgentDeck.slnx`
- `dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore`
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`

## Notes
- Full `dotnet build AgentDeck.slnx --no-restore` still cannot complete in this environment because the Android SDK is not installed (`XA5300`).
