### PR TITLE
Improve onboarding and workspace UX

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -8,32 +8,58 @@
 <div class="workspace-dashboard">
     <div class="page-header workspace-dashboard__header">
         <div>
-            <h1>Projects</h1>
-            <p>Track runner readiness, open projects on workers, and reopen live project sessions through Project Links without mixing them into standalone terminals.</p>
+            <h1>Welcome to AgentDeck</h1>
+            <p>Connect a workspace, make sure you have somewhere to run it, then jump back into the last thing you were doing.</p>
         </div>
     </div>
 
     <div class="workspace-dashboard__content">
+        <section class="setup-checklist" aria-label="Setup checklist">
+            <article class="setup-checklist__intro">
+                <span class="eyebrow">Next best step</span>
+                <h2>@GetNextActionTitle()</h2>
+                <p>@GetNextActionDescription()</p>
+                <div class="setup-checklist__actions">
+                    <a class="btn btn-primary" href="@GetNextActionHref()">@GetNextActionLabel()</a>
+                    @if (_dashboard.ProjectSessions.Count > 0)
+                    {
+                        var recentSession = _dashboard.ProjectSessions.OrderByDescending(session => session.UpdatedAt).First();
+                        <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(recentSession.ProjectId)">Resume last workspace</a>
+                    }
+                </div>
+            </article>
+            <div class="setup-checklist__steps">
+                @foreach (var step in GetSetupSteps())
+                {
+                    <article class="setup-step setup-step--@step.StateClass">
+                        <span class="setup-step__status">@step.StatusLabel</span>
+                        <strong>@step.Title</strong>
+                        <p>@step.Description</p>
+                    </article>
+                }
+            </div>
+        </section>
+
         <section class="dashboard-summary-grid">
             <article class="dashboard-summary-card">
-                <span class="dashboard-summary-card__label">Coordinator</span>
+                <span class="dashboard-summary-card__label">Connection</span>
                 <strong>@GetCoordinatorSummary()</strong>
                 <span class="dashboard-summary-card__subtext">@GetCoordinatorSubtext()</span>
             </article>
             <article class="dashboard-summary-card">
-                <span class="dashboard-summary-card__label">Machines</span>
+                <span class="dashboard-summary-card__label">Your machines</span>
                 <strong>@_dashboard.Machines.Count</strong>
                 <span class="dashboard-summary-card__subtext">@GetMachineSummary()</span>
             </article>
             <article class="dashboard-summary-card">
-                <span class="dashboard-summary-card__label">Project sessions</span>
+                <span class="dashboard-summary-card__label">Open workspaces</span>
                 <strong>@_dashboard.ProjectSessions.Count</strong>
-                <span class="dashboard-summary-card__subtext">Live sessions modeled separately from terminal-only routing</span>
+                <span class="dashboard-summary-card__subtext">Things you can resume right now</span>
             </article>
             <article class="dashboard-summary-card">
-                <span class="dashboard-summary-card__label">Active terminals</span>
+                <span class="dashboard-summary-card__label">Terminals</span>
                 <strong>@GetStandaloneTerminalCount()</strong>
-                <span class="dashboard-summary-card__subtext">Standalone sessions visible through dedicated terminal pages</span>
+                <span class="dashboard-summary-card__subtext">Standalone shell sessions</span>
             </article>
         </section>
 
@@ -56,14 +82,19 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Machine readiness</h2>
-                        <p>Coordinator-discovered runners and the targets they can currently host.</p>
+                        <h2>Your machines</h2>
+                        <p>Where AgentDeck can run projects right now, with plain-language setup blockers.</p>
                     </div>
                 </div>
 
                 @if (_dashboard.Machines.Count == 0)
                 {
-                    <p>No worker machines are currently visible through the coordinator.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">▣</div>
+                        <h3>No machines yet</h3>
+                        <p>Create a runner from Settings, or start one with the quickstart command in the README.</p>
+                        <a class="btn btn-primary" href="/settings">Create or connect a runner</a>
+                    </div>
                 }
                 else
                 {
@@ -77,20 +108,12 @@
                                         <p>@GetPlatformLabel(machine.HostPlatform)</p>
                                     </div>
                                     <span class="machine-state machine-state--@(machine.IsOnline ? "connected" : "disconnected")">
-                                        @(machine.IsOnline ? "Online" : "Offline")
+                                        @GetMachineHealthLabel(machine)
                                     </span>
                                 </div>
                                 <p class="project-machine-card__meta">
-                                    Agent @machine.AgentVersion
+                                    @GetMachineReadinessSummary(machine)
                                     <span>• last seen @machine.LastSeenAt.ToLocalTime().ToString("g")</span>
-                                    @if (machine.IsConnected)
-                                    {
-                                        <span>• companion connected</span>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
-                                    {
-                                        <span>• security @machine.SecurityPolicyVersion</span>
-                                    }
                                 </p>
                                 @if (HasControlPlaneSignals(machine))
                                 {
@@ -143,15 +166,20 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Projects</h2>
-                        <p>Open a project page to choose a machine, inspect workspaces, and jump into its live sessions.</p>
+                        <h2>Workspaces</h2>
+                        <p>Import a repo, choose where it should run, and open a terminal or app surface.</p>
                     </div>
-                    <a class="btn btn-primary" href="/projects/new">New project</a>
+                    <a class="btn btn-primary" href="/projects/new">Import or create workspace</a>
                 </div>
 
                 @if (_dashboard.Projects.Count == 0)
                 {
-                    <p>No coordinator-managed projects are registered yet.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">＋</div>
+                        <h3>No workspaces yet</h3>
+                        <p>Paste a GitHub URL or start from a template. Advanced project fields can wait.</p>
+                        <a class="btn btn-primary" href="/projects/new">Create your first workspace</a>
+                    </div>
                 }
                 else
                 {
@@ -205,8 +233,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Viewer surfaces</h2>
-                        <p>Viewer experiences are still modeled separately from terminals so remote windows, emulators, simulators, and VS Code can surface independently.</p>
+                        <h2>Things AgentDeck can open</h2>
+                        <p>Terminals, desktops, app windows, VS Code, emulators, simulators, logs, and job output appear here when machines support them.</p>
                     </div>
                 </div>
 
@@ -249,6 +277,105 @@
         string.IsNullOrWhiteSpace(session.CompanionId)
             ? "No controller companion recorded"
             : $"Controller {session.CompanionId}";
+
+    private IEnumerable<SetupStep> GetSetupSteps()
+    {
+        yield return new SetupStep(
+            "Connect",
+            _dashboard.CoordinatorReachable ? "Done" : _dashboard.CoordinatorConfigured ? "Fix" : "Start",
+            _dashboard.CoordinatorReachable ? "Coordinator is reachable." : "Connect to a coordinator so AgentDeck can load projects and machines.",
+            _dashboard.CoordinatorReachable ? "complete" : "todo");
+        yield return new SetupStep(
+            "Create a runner",
+            _dashboard.Machines.Any(machine => machine.IsOnline) ? "Done" : "Next",
+            _dashboard.Machines.Any(machine => machine.IsOnline) ? "At least one machine is online." : "Create or connect somewhere for projects to run.",
+            _dashboard.Machines.Any(machine => machine.IsOnline) ? "complete" : "todo");
+        yield return new SetupStep(
+            "Verify tools",
+            _dashboard.Machines.Any(machine => machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)) ? "Done" : "Check",
+            "AgentDeck will call out missing tools before you open a workspace.",
+            _dashboard.Machines.Any(machine => machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)) ? "complete" : "todo");
+        yield return new SetupStep(
+            "Open a workspace",
+            _dashboard.Projects.Count > 0 ? "Done" : "Next",
+            _dashboard.Projects.Count > 0 ? "Projects are ready to open." : "Import a repo or start from a template.",
+            _dashboard.Projects.Count > 0 ? "complete" : "todo");
+    }
+
+    private string GetNextActionTitle()
+    {
+        if (!_dashboard.CoordinatorReachable)
+        {
+            return _dashboard.CoordinatorConfigured ? "Fix the connection" : "Connect AgentDeck";
+        }
+
+        if (!_dashboard.Machines.Any(machine => machine.IsOnline))
+        {
+            return "Create your first runner";
+        }
+
+        return _dashboard.Projects.Count == 0 ? "Import your first workspace" : "Resume or open a workspace";
+    }
+
+    private string GetNextActionDescription()
+    {
+        if (!_dashboard.CoordinatorReachable)
+        {
+            return _dashboard.CoordinatorConfigured
+                ? "The saved coordinator URL did not respond. Check the URL or start the coordinator."
+                : "Add the coordinator URL once, then AgentDeck can discover runners and projects for you.";
+        }
+
+        if (!_dashboard.Machines.Any(machine => machine.IsOnline))
+        {
+            return "Use the runner templates in Settings to create capacity, or connect an existing runner. No raw IDs required.";
+        }
+
+        return _dashboard.Projects.Count == 0
+            ? "Paste a GitHub URL or choose a template. You can keep advanced launch profile details collapsed."
+            : "Pick up where you left off or open a project on a ready machine.";
+    }
+
+    private string GetNextActionHref() =>
+        !_dashboard.CoordinatorReachable || !_dashboard.Machines.Any(machine => machine.IsOnline)
+            ? "/settings"
+            : _dashboard.Projects.Count == 0 ? "/projects/new" : "/";
+
+    private string GetNextActionLabel() =>
+        !_dashboard.CoordinatorReachable ? "Open connection setup" :
+        !_dashboard.Machines.Any(machine => machine.IsOnline) ? "Create or connect a runner" :
+        _dashboard.Projects.Count == 0 ? "Import workspace" : "View workspaces";
+
+    private static string GetMachineHealthLabel(CompanionMachineSummary machine)
+    {
+        if (!machine.IsOnline)
+        {
+            return "Offline";
+        }
+
+        return machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)
+            ? "Ready"
+            : "Needs setup";
+    }
+
+    private static string GetMachineReadinessSummary(CompanionMachineSummary machine)
+    {
+        if (!machine.IsOnline)
+        {
+            return "This machine is not currently reachable";
+        }
+
+        var readyTargets = machine.SupportedTargets.Count(target => target.Status == MachineTargetSupportStatus.Supported);
+        var setupTargets = machine.SupportedTargets.Count(target => target.Status == MachineTargetSupportStatus.RequiresSetup);
+        if (readyTargets > 0)
+        {
+            return setupTargets > 0
+                ? $"Ready for {readyTargets} target(s); {setupTargets} need tools"
+                : $"Ready for {readyTargets} target(s)";
+        }
+
+        return setupTargets > 0 ? "Tools need setup before this machine can run projects" : "No supported project targets advertised yet";
+    }
 
     private static string GetProjectSessionLocationLabel(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.MachineName)
@@ -424,6 +551,8 @@
 
     private void OnSettingsChanged(object? sender, ConnectionSettings settings) =>
         _ = RefreshDashboardAsync();
+
+    private sealed record SetupStep(string Title, string StatusLabel, string Description, string StateClass);
 
     public async ValueTask DisposeAsync()
     {

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -37,8 +37,8 @@
             </div>
             <div class="project-page__actions">
                 <a class="btn btn-accent" href="/">Dashboard</a>
-                <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_project.Definition.Id)/edit">Edit project</a>
-                <button class="btn btn-accent" @onclick="RefreshRuntimeAsync">Refresh runtime state</button>
+                <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_project.Definition.Id)/edit">Edit workspace</a>
+                <button class="btn btn-accent" @onclick="RefreshRuntimeAsync">Refresh open items</button>
             </div>
         </div>
 
@@ -46,8 +46,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Open on machine</h2>
-                        <p>Project opening initializes a coordinator-managed workspace and creates the first terminal-backed project session on that worker.</p>
+                        <h2>Where do you want to run this?</h2>
+                        <p>Pick a ready machine. AgentDeck will prepare the workspace and open the first terminal for you.</p>
                     </div>
                 </div>
 
@@ -133,12 +133,12 @@
                                 <button class="btn btn-primary"
                                         disabled="@(_openingMachineId == machine.MachineId || !CanOpenProjectOnMachine(machine))"
                                         @onclick="() => OpenProjectAsync(machine.MachineId, navigateToSession: true)">
-                                    @(_openingMachineId == machine.MachineId ? "Opening..." : "Open project")
+                                    @(_openingMachineId == machine.MachineId ? "Opening..." : "Open workspace")
                                 </button>
                                 <button class="btn btn-accent"
                                         disabled="@(!machine.IsOnline || _viewerActionMachineId == machine.MachineId)"
                                         @onclick="() => OpenDesktopViewerAsync(machine, forceTakeover: false)">
-                                    @(_viewerActionMachineId == machine.MachineId ? "Working..." : "Open desktop viewer")
+                                    @(_viewerActionMachineId == machine.MachineId ? "Working..." : "Open desktop")
                                 </button>
                                 @if (remoteControlState is not null && !IsCurrentRemoteController(remoteControlState))
                                 {
@@ -165,8 +165,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Launch profiles</h2>
-                        <p>Queue real run and debug jobs through the coordinator, with host selection, device selection, and live viewer/job state tied to the selected machine.</p>
+                        <h2>Run or debug</h2>
+                        <p>Choose the machine and device AgentDeck should use. Detailed job and viewer state stays available after launch.</p>
                     </div>
                 </div>
 

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -37,8 +37,8 @@
     {
         <div class="page-header project-editor__header">
             <div>
-                <h1>@(_isExistingProject ? "Edit project" : "New project")</h1>
-                <p>Manage coordinator-backed project metadata and launch profiles without dropping to manual API calls.</p>
+                <h1>@(_isExistingProject ? "Edit workspace" : "Import workspace")</h1>
+                <p>Paste a repo, pick a template, and only open advanced launch details if you need them.</p>
             </div>
             <div class="project-page__actions">
                 @if (_isExistingProject)
@@ -56,21 +56,55 @@
         </div>
 
         <div class="project-editor__content">
+            <section class="dashboard-section-card setup-wizard-card">
+                <div class="dashboard-section-card__header">
+                    <div>
+                        <span class="eyebrow">Simple setup</span>
+                        <h2>Start with a repository or template</h2>
+                        <p>AgentDeck can fill in the raw project fields for you. Advanced IDs and launch commands stay editable below.</p>
+                    </div>
+                </div>
+                <div class="project-editor__grid">
+                    <div class="form-field project-editor__field--full">
+                        <label for="quick-repo-url">GitHub or Git repository URL</label>
+                        <div class="inline-action-field">
+                            <input id="quick-repo-url" class="input" @bind="_quickRepositoryUrl" placeholder="https://github.com/owner/repo" />
+                            <button class="btn btn-primary" type="button" @onclick="ApplyRepositoryUrl">Use repo</button>
+                        </div>
+                        <span class="form-hint">Supports GitHub HTTPS, SSH, and owner/repo shorthand.</span>
+                    </div>
+                </div>
+                <div class="project-template-grid project-template-grid--compact">
+                    @foreach (var template in SimpleTemplates)
+                    {
+                        <button type="button" class="project-template-card project-template-card--button" @onclick="() => ApplySimpleTemplate(template)">
+                            <div class="project-template-card__header">
+                                <div>
+                                    <h3>@template.Name</h3>
+                                    <p>@template.Description</p>
+                                </div>
+                                <span class="machine-badge">@template.Workload</span>
+                            </div>
+                        </button>
+                    }
+                </div>
+            </section>
+
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Project basics</h2>
-                        <p>These values become the coordinator-managed project record that the dashboard and project pages consume.</p>
+                        <h2>Workspace basics</h2>
+                        <p>Name the workspace and choose the broad app type. AgentDeck uses this to recommend machines and tools.</p>
                     </div>
                 </div>
 
                 <div class="project-editor__grid">
                     <div class="form-field">
-                        <label for="project-id">Project ID</label>
+                        <label for="project-id">Workspace ID</label>
                         <input id="project-id" class="input" @bind="_editor.ProjectId" disabled="@_isExistingProject" />
                     </div>
                     <div class="form-field">
-                        <label for="project-name">Project name</label>
+                        <label for="project-name">Workspace name</label>
                         <input id="project-name" class="input" @bind="_editor.Name" />
                     </div>
                     <div class="form-field">
@@ -92,8 +126,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Repository</h2>
-                        <p>Leave the repository URL empty for a blank workspace bootstrap; set it to clone the repo automatically when the project is opened on a machine.</p>
+                        <h2>Source</h2>
+                        <p>Leave the repository URL empty for a blank workspace; set it to clone automatically when opened on a machine.</p>
                     </div>
                 </div>
 
@@ -116,8 +150,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Launch profiles</h2>
-                        <p>Add, edit, or delete the exact run/debug profiles the coordinator should expose for this project.</p>
+                        <h2>Ways to run this workspace</h2>
+                        <p>Most projects only need one default run profile. Open advanced details to tune commands, devices, or VS Code behavior.</p>
                     </div>
                     <button class="btn btn-accent" disabled="@_saving" @onclick="AddProfile">Add launch profile</button>
                 </div>
@@ -143,7 +177,9 @@
                                         <button class="btn btn-danger" disabled="@_saving" @onclick="() => RemoveProfile(profileIndex)">Delete profile</button>
                                     </div>
 
-                                    <div class="project-editor__grid">
+                                    <details class="advanced-panel">
+                                        <summary>Advanced launch details</summary>
+                                        <div class="project-editor__grid">
                                         <div class="form-field">
                                             <label>Profile ID</label>
                                             <input class="input" @bind="profile.Id" />
@@ -228,20 +264,21 @@
                                         </div>
                                     </div>
 
-                                    <div class="project-editor__toggles">
-                                        <label class="checkbox-label">
-                                            <input type="checkbox" @bind="profile.RequiresVsCode" />
-                                            <span>Requires VS Code viewer</span>
-                                        </label>
-                                        <label class="checkbox-label">
-                                            <input type="checkbox" @bind="profile.RequiresEmulator" />
-                                            <span>Requires emulator</span>
-                                        </label>
-                                        <label class="checkbox-label">
-                                            <input type="checkbox" @bind="profile.RequiresSimulator" />
-                                            <span>Requires simulator</span>
-                                        </label>
-                                    </div>
+                                        <div class="project-editor__toggles">
+                                            <label class="checkbox-label">
+                                                <input type="checkbox" @bind="profile.RequiresVsCode" />
+                                                <span>Requires VS Code viewer</span>
+                                            </label>
+                                            <label class="checkbox-label">
+                                                <input type="checkbox" @bind="profile.RequiresEmulator" />
+                                                <span>Requires emulator</span>
+                                            </label>
+                                            <label class="checkbox-label">
+                                                <input type="checkbox" @bind="profile.RequiresSimulator" />
+                                                <span>Requires simulator</span>
+                                            </label>
+                                        </div>
+                                    </details>
                                 </div>
                             </article>
                         }
@@ -289,12 +326,19 @@
     private static readonly ProjectLaunchDriver[] LaunchDriverOptions = Enum.GetValues<ProjectLaunchDriver>();
     private static readonly RunnerMachineRole[] MachineRoleOptions = Enum.GetValues<RunnerMachineRole>();
     private static readonly VirtualDeviceCatalogKind[] DeviceCatalogOptions = Enum.GetValues<VirtualDeviceCatalogKind>();
+    private static readonly SimpleProjectTemplate[] SimpleTemplates =
+    [
+        new("Blazor app", "Web app with a browser-friendly run profile", ProjectWorkloadKind.Blazor, "dotnet build", "dotnet run"),
+        new(".NET MAUI app", "Mobile/desktop app with simulator and device targets", ProjectWorkloadKind.Maui, "dotnet build", "dotnet build"),
+        new("Blank workspace", "Start with a generic shell and fill commands later", ProjectWorkloadKind.Blazor, "echo Ready", null)
+    ];
 
     private bool _loading = true;
     private bool _saving;
     private bool _projectNotFound;
     private bool _isExistingProject;
     private string? _coordinatorUrl;
+    private string _quickRepositoryUrl = string.Empty;
     private ProjectEditorModel _editor = ProjectEditorModel.CreateDefault();
     private IReadOnlyList<ProjectTargetDefinition> _existingTargets = [];
 
@@ -356,6 +400,70 @@
     private void AddProfile()
     {
         _editor.LaunchProfiles.Add(ProjectLaunchProfileEditor.CreateDefault(_editor.Workload, _editor.LaunchProfiles.Count + 1));
+    }
+
+    private void ApplyRepositoryUrl()
+    {
+        var parsed = ParseRepositoryInput(_quickRepositoryUrl);
+        if (parsed is null)
+        {
+            Toasts.Show("Paste a GitHub URL, git URL, or owner/repo shorthand.", ToastKind.Warning);
+            return;
+        }
+
+        _editor.RepositoryUrl = parsed.Value.Url;
+        _editor.RepositoryOwner = parsed.Value.Owner;
+        _editor.RepositoryName = parsed.Value.Name;
+        if (string.IsNullOrWhiteSpace(_editor.Name) || _editor.Name == "New Project")
+        {
+            _editor.Name = ToDisplayName(parsed.Value.Name);
+        }
+
+        if (string.IsNullOrWhiteSpace(_editor.ProjectId))
+        {
+            _editor.ProjectId = NormalizeProjectId(parsed.Value.Name, parsed.Value.Name);
+        }
+
+        Toasts.Show("Repository details filled in.", ToastKind.Success);
+    }
+
+    private void ApplySimpleTemplate(SimpleProjectTemplate template)
+    {
+        var projectName = string.IsNullOrWhiteSpace(_editor.Name) || _editor.Name == "New Project"
+            ? template.Name
+            : _editor.Name;
+        var definition = ProjectTemplateCatalog.CreateDefault(template.Workload, projectName);
+        _editor.Workload = definition.Workload;
+        _editor.Name = projectName;
+        if (string.IsNullOrWhiteSpace(_editor.ProjectId))
+        {
+            _editor.ProjectId = NormalizeProjectId(projectName, projectName);
+        }
+
+        _existingTargets = definition.Targets;
+        _editor.LaunchProfiles = definition.LaunchProfiles
+            .Select(ProjectLaunchProfileEditor.FromDefinition)
+            .ToList();
+        if (_editor.LaunchProfiles.Count == 0)
+        {
+            _editor.LaunchProfiles.Add(new ProjectLaunchProfileEditor
+            {
+                Id = NormalizeProjectId(template.Name, template.Name),
+                DisplayName = template.Name,
+                Platform = template.Workload == ProjectWorkloadKind.Maui ? ApplicationTargetPlatform.Android : ApplicationTargetPlatform.Linux,
+                Mode = ProjectLaunchMode.Run,
+                BuildCommand = template.BuildCommand,
+                LaunchCommand = template.LaunchCommand
+            });
+        }
+
+        foreach (var profile in _editor.LaunchProfiles)
+        {
+            profile.BuildCommand = template.BuildCommand;
+            profile.LaunchCommand ??= template.LaunchCommand;
+        }
+
+        Toasts.Show($"Applied {template.Name} template.", ToastKind.Success);
     }
 
     private void RemoveProfile(int index)
@@ -521,6 +629,46 @@
     private static string? NormalizeText(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
+    private static RepositoryParseResult? ParseRepositoryInput(string? input)
+    {
+        var value = NormalizeText(input);
+        if (value is null)
+        {
+            return null;
+        }
+
+        var shorthand = System.Text.RegularExpressions.Regex.Match(value, @"^(?<owner>[A-Za-z0-9_.-]+)/(?<name>[A-Za-z0-9_.-]+?)(?:\.git)?$");
+        if (shorthand.Success)
+        {
+            var owner = shorthand.Groups["owner"].Value;
+            var name = shorthand.Groups["name"].Value;
+            return new RepositoryParseResult(owner, name, $"https://github.com/{owner}/{name}");
+        }
+
+        var ssh = System.Text.RegularExpressions.Regex.Match(value, @"git@[^:]+:(?<owner>[A-Za-z0-9_.-]+)/(?<name>[A-Za-z0-9_.-]+?)(?:\.git)?$");
+        if (ssh.Success)
+        {
+            return new RepositoryParseResult(ssh.Groups["owner"].Value, ssh.Groups["name"].Value, value);
+        }
+
+        if (Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length >= 2)
+            {
+                var name = segments[1].EndsWith(".git", StringComparison.OrdinalIgnoreCase)
+                    ? segments[1][..^4]
+                    : segments[1];
+                return new RepositoryParseResult(segments[0], name, value);
+            }
+        }
+
+        return null;
+    }
+
+    private static string ToDisplayName(string value) =>
+        System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value.Replace('-', ' ').Replace('_', ' '));
+
     private static string NormalizeProjectId(string? id, string? fallbackName)
     {
         var source = NormalizeText(id) ?? NormalizeText(fallbackName);
@@ -547,6 +695,10 @@
 
         return builder.ToString().Trim('-');
     }
+
+    private readonly record struct SimpleProjectTemplate(string Name, string Description, ProjectWorkloadKind Workload, string BuildCommand, string? LaunchCommand);
+
+    private readonly record struct RepositoryParseResult(string Owner, string Name, string Url);
 
     private sealed class ProjectEditorModel
     {

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -100,8 +100,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Surface tabs</h2>
-                        <p>Project-session tabs now combine coordinator-registered surfaces with live runtime surfaces discovered from the selected machine's jobs and viewer sessions for this project.</p>
+                        <h2>Things open for this workspace</h2>
+                        <p>Terminals, app windows, desktops, VS Code, emulators, simulators, logs, and job output for this session.</p>
                     </div>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(_runtimeLoadError))
@@ -114,15 +114,19 @@
                     {
                         <button class="surface-tab @(surface.Id == _activeSurfaceId ? "surface-tab--active" : "")"
                                 @onclick="() => SelectSurface(surface.Id)">
-                            <span>@surface.DisplayName</span>
-                            <span class="surface-tab__kind">@surface.Kind</span>
+                            <span>@GetSurfaceIcon(surface.Kind) @surface.DisplayName</span>
+                            <span class="surface-tab__kind">@GetSurfaceKindLabel(surface.Kind)</span>
                         </button>
                     }
                 </div>
 
                 @if (_activeSurface is null)
                 {
-                    <p>Select a surface to inspect it.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">▣</div>
+                        <h3>Choose something to open</h3>
+                        <p>Select a terminal, desktop, app window, editor, emulator, simulator, log, or job output surface.</p>
+                    </div>
                 }
                 else if (_activeSurface.Kind == ProjectSessionSurfaceKind.Terminal && _attachedTerminalSession is not null)
                 {
@@ -153,8 +157,8 @@
                         </div>
                         <dl class="surface-details-list">
                             <div>
-                                <dt>Kind</dt>
-                                <dd>@_activeSurface.Kind</dd>
+                                <dt>Type</dt>
+                                <dd>@GetSurfaceKindLabel(_activeSurface.Kind)</dd>
                             </div>
                             <div>
                                 <dt>Machine</dt>
@@ -681,12 +685,32 @@
 
     private static string GetSurfaceDescription(SurfaceTab surface) => surface.Kind switch
     {
-        ProjectSessionSurfaceKind.Terminal => "Terminal tabs stay dedicated to shell output and input.",
-        ProjectSessionSurfaceKind.VsCode => "VS Code runtime surfaces are derived from active debug/viewer sessions on this machine.",
-        ProjectSessionSurfaceKind.Simulator => "Simulator runtime surfaces follow the current project job and viewer state.",
-        ProjectSessionSurfaceKind.Emulator => "Emulator runtime surfaces follow the current project job and viewer state.",
-        ProjectSessionSurfaceKind.Viewer => "Viewer tabs capture desktop or window remoting state associated with this project session.",
-        _ => "Coordinator-registered project surface."
+        ProjectSessionSurfaceKind.Terminal => "A shell for commands, agents, builds, and logs.",
+        ProjectSessionSurfaceKind.VsCode => "Editor or debugging window for this workspace.",
+        ProjectSessionSurfaceKind.Simulator => "Apple simulator connected to the current run/debug job.",
+        ProjectSessionSurfaceKind.Emulator => "Android emulator connected to the current run/debug job.",
+        ProjectSessionSurfaceKind.Viewer => "Remote desktop, browser, or app window for this workspace.",
+        _ => "Workspace item opened by the coordinator."
+    };
+
+    private static string GetSurfaceKindLabel(ProjectSessionSurfaceKind kind) => kind switch
+    {
+        ProjectSessionSurfaceKind.Terminal => "Terminal",
+        ProjectSessionSurfaceKind.VsCode => "VS Code",
+        ProjectSessionSurfaceKind.Simulator => "Simulator",
+        ProjectSessionSurfaceKind.Emulator => "Emulator",
+        ProjectSessionSurfaceKind.Viewer => "Screen / app window",
+        _ => "Workspace item"
+    };
+
+    private static string GetSurfaceIcon(ProjectSessionSurfaceKind kind) => kind switch
+    {
+        ProjectSessionSurfaceKind.Terminal => "⌁",
+        ProjectSessionSurfaceKind.VsCode => "⌘",
+        ProjectSessionSurfaceKind.Simulator => "▱",
+        ProjectSessionSurfaceKind.Emulator => "▰",
+        ProjectSessionSurfaceKind.Viewer => "◱",
+        _ => "•"
     };
 
     private static ProjectSessionSurfaceKind? MapViewerKind(RemoteViewerTargetKind kind) => kind switch

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -2414,3 +2414,136 @@ html, body {
         display: inline;
     }
 }
+
+/* Guided setup and first-run polish */
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #93c5fd;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.setup-checklist {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.setup-checklist__intro,
+.setup-step,
+.setup-wizard-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.94), rgba(15, 23, 42, 0.9));
+  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.26);
+}
+
+.setup-checklist__intro {
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+}
+
+.setup-checklist__intro h2 {
+  margin: 0.35rem 0;
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.setup-checklist__intro p,
+.setup-step p,
+.form-hint {
+  color: #cbd5e1;
+}
+
+.setup-checklist__actions,
+.inline-action-field {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.inline-action-field .input {
+  flex: 1 1 18rem;
+}
+
+.setup-checklist__steps {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.setup-step {
+  border-radius: 1rem;
+  padding: 0.9rem;
+}
+
+.setup-step__status {
+  display: inline-flex;
+  margin-bottom: 0.4rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.16);
+  color: #bfdbfe;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.setup-step--complete .setup-step__status {
+  background: rgba(34, 197, 94, 0.16);
+  color: #bbf7d0;
+}
+
+.empty-state--actionable {
+  align-items: flex-start;
+  text-align: left;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.project-template-card--button {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.project-template-card--button:hover,
+.project-template-card--button:focus-visible {
+  border-color: rgba(96, 165, 250, 0.75);
+  transform: translateY(-1px);
+}
+
+.project-template-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.advanced-panel {
+  margin-top: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 1rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.38);
+}
+
+.advanced-panel summary {
+  cursor: pointer;
+  color: #bfdbfe;
+  font-weight: 700;
+}
+
+@media (max-width: 820px) {
+  .setup-checklist {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-checklist__actions .btn,
+  .inline-action-field .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,37 @@ A .NET MAUI + Blazor WebView app that:
 
 ## Getting Started
 
+### Fast local path
+
+From a fresh checkout, the fastest reliable path is:
+
+```bash
+dotnet restore AgentDeck.slnx
+dotnet run --project AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
+```
+
+In a second terminal, start a Linux runner and register it with that coordinator:
+
+```bash
+AGENTDECK_COORDINATOR_URL=http://localhost:5001 \
+AGENTDECK_MACHINE_ID=local-linux \
+AGENTDECK_MACHINE_NAME="Local Linux" \
+dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj
+```
+
+Then run the companion for your platform and set the coordinator URL to `http://localhost:5001` in **Settings → Connection**. Use `localhost` only when the companion is on the same machine as the coordinator; phones/tablets should use a LAN-reachable host name or IP address.
+
+Known-good local verification commands:
+
+```bash
+dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore
+dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
+dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
+dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
+```
+
+A full solution build on Linux also targets Android; install the Android SDK or build a specific framework if you only want the desktop companion.
+
 ### Running the Coordinator API
 
 ```bash


### PR DESCRIPTION
## Summary
- add a guided first-run checklist and next-action dashboard focused on connection, runner creation, tool readiness, and first workspace
- rework dashboard language from implementation terms toward user goals like machines, workspaces, and open items
- add a simple project import flow with repo URL parsing, templates, and collapsed advanced launch details
- improve project/session wording around where to run work and "things open for this workspace"
- add responsive setup/checklist styling and README quickstart/known-good build path

Closes #374

## Validation
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`

## Notes
- Full solution build on this Linux host still requires an Android SDK for the Android target; the README now calls out framework-specific builds for local desktop validation.
