### PR TITLE
Simplify primary UI language

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -137,14 +137,14 @@
                                              workflowPackStatus.State != RunnerWorkflowPackState.None)
                                         {
                                             <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowPackChipClass(workflowPackStatus.State))">
-                                                Workflow pack @GetWorkflowPackStateLabel(workflowPackStatus.State)
+                                                Tools @GetWorkflowPackStateLabel(workflowPackStatus.State)
                                             </span>
                                         }
                                         @if (machine.WorkflowCatalogStatus is { } workflowCatalogStatus &&
                                              workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
                                         {
                                             <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowCatalogChipClass(workflowCatalogStatus.State))">
-                                                Catalog @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
+                                                Setup @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
                                             </span>
                                         }
                                     </div>
@@ -410,7 +410,7 @@
     {
         if (_dashboard.Machines.Count == 0)
         {
-            return "No workers discovered";
+            return "No machines connected";
         }
 
         var onlineCount = _dashboard.Machines.Count(machine => machine.IsOnline);
@@ -421,9 +421,9 @@
 
     private static string GetPlatformLabel(RunnerHostPlatform platform) => platform switch
     {
-        RunnerHostPlatform.Windows => "Windows worker",
-        RunnerHostPlatform.Linux => "Linux worker",
-        RunnerHostPlatform.MacOS => "macOS worker",
+        RunnerHostPlatform.Windows => "Windows machine",
+        RunnerHostPlatform.Linux => "Linux machine",
+        RunnerHostPlatform.MacOS => "macOS machine",
         _ => "Unknown platform"
     };
 

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -24,7 +24,7 @@
             <div class="empty-state">
                 <div class="empty-icon">⌂</div>
                 <h2>Project not found</h2>
-                <p>Return to the <a href="/">dashboard</a> to pick a coordinator-managed project.</p>
+                <p>Return to the <a href="/">dashboard</a> to pick another workspace.</p>
             </div>
         </div>
     }
@@ -91,14 +91,14 @@
                                          workflowPackStatus.State != RunnerWorkflowPackState.None)
                                     {
                                         <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowPackChipClass(workflowPackStatus.State))">
-                                            Workflow pack @GetWorkflowPackStateLabel(workflowPackStatus.State)
+                                            Tools @GetWorkflowPackStateLabel(workflowPackStatus.State)
                                         </span>
                                     }
                                     @if (machine.WorkflowCatalogStatus is { } workflowCatalogStatus &&
                                          workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
                                     {
                                         <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowCatalogChipClass(workflowCatalogStatus.State))">
-                                            Catalog @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
+                                            Setup @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
                                         </span>
                                     }
                                 </div>
@@ -694,7 +694,7 @@
         var machine = GetMachine(machineId);
         if (machine is null || !CanOpenProjectOnMachine(machine))
         {
-            Toasts.Show("That machine is not currently eligible for coordinator-managed project actions.", ToastKind.Warning);
+            Toasts.Show("That machine is not ready for this workspace yet. Choose a ready machine or open Settings to finish setup.", ToastKind.Warning);
             return;
         }
 

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -120,8 +120,8 @@
                         <dd>@(session.StatusMessage ?? session.Status.ToString())</dd>
                     </div>
                     <div>
-                        <dt>Relay</dt>
-                        <dd>Coordinator-brokered</dd>
+                        <dt>Connection</dt>
+                        <dd>Securely routed through AgentDeck</dd>
                     </div>
                     @if (ViewerClient.RemoteControlState is { } remoteControlState)
                     {
@@ -139,13 +139,13 @@
                         <dd>@(ViewerClient.LastInputActivity ?? "No input dispatched yet.")</dd>
                     </div>
                     <div>
-                        <dt>Viewer hooks</dt>
-                        <dd>@(_lastInteropStatus ?? "No JS hook status reported yet.")</dd>
+                        <dt>Viewer status</dt>
+                        <dd>@(_lastInteropStatus ?? "Waiting for the screen to report readiness.")</dd>
                     </div>
                 </dl>
                 @if (!ViewerClient.SupportsInAppViewer)
                 {
-                    <p class="surface-details-card__note">This viewer session is not backed by the coordinator-managed relay.</p>
+                    <p class="surface-details-card__note">This remote screen cannot be shown in-app yet. Try opening the desktop again from the workspace or machine card.</p>
                 }
             </section>
         </div>

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -16,21 +16,21 @@
 
     <nav class="settings-nav" aria-label="Settings sections">
         <a href="#connection">Connection</a>
-        <a href="#machines">Machines</a>
-        <a href="#setup-capabilities">Setup &amp; Capabilities</a>
-        <a href="#runner-updates">Runner Updates</a>
-        <a href="#advanced">Advanced</a>
+        <a href="#machines">Create runners</a>
+        <a href="#setup-capabilities">Tools</a>
+        <a href="#runner-updates">Updates</a>
+        <a href="#advanced">Advanced diagnostics</a>
     </nav>
 
     <div id="connection" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
                 <h2>Connection</h2>
-                <p class="settings-card__description">Use one coordinator as the only client-facing endpoint. The companion now routes terminal and machine-control traffic through the coordinator instead of connecting to runners directly.</p>
+                <p class="settings-card__description">Connect AgentDeck to the service that keeps your machines, workspaces, and sessions in sync.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
                 <button class="btn btn-accent" @onclick="RefreshCoordinatorDirectoryAsync" disabled="@_registeredMachinesBusy">
-                    @(_registeredMachinesBusy ? "Refreshing..." : "Refresh Directory")
+                    @(_registeredMachinesBusy ? "Refreshing..." : "Refresh machines")
                 </button>
                 <button class="btn btn-danger" @onclick="ClearCoordinatorDirectory" disabled="@(!_coordinatorReachable && _registeredMachines.Count == 0 && _registeredMachinesErrorMessage is null)">
                     Clear Status
@@ -55,7 +55,7 @@
                 </strong>
             </div>
             <div class="settings-status-row">
-                <span class="settings-status-row__label">Directory source</span>
+                <span class="settings-status-row__label">Connected to</span>
                 <code class="settings-status-row__value">@_settings.CoordinatorUrl</code>
             </div>
         </div>
@@ -66,11 +66,11 @@
         }
         else if (_registeredMachinesBusy)
         {
-            <p>Refreshing registered workers from the coordinator...</p>
+            <p>Refreshing your machines...</p>
         }
         else if (_registeredMachines.Count == 0)
         {
-            <p>No worker machines are currently visible through the coordinator.</p>
+            <p>No machines are visible yet. Create a runner below or start an existing runner and refresh.</p>
         }
         else
         {
@@ -79,7 +79,7 @@
                 {
                     <article class="machine-card">
                         <span class="machine-card__title">@machine.MachineName</span>
-                        <span class="machine-card__url">@(!string.IsNullOrWhiteSpace(machine.RunnerUrl) ? machine.RunnerUrl : "(runner URL not advertised)")</span>
+                        <span class="machine-card__url">@(machine.IsOnline ? "Ready to receive work" : "Not currently reachable")</span>
                         <span class="machine-card__meta">
                             <span class="machine-badge">@GetMachineRoleLabel(machine.Role)</span>
                             <span class="machine-state machine-state--@(machine.IsOnline ? "connected" : "disconnected")">
@@ -88,45 +88,54 @@
                         </span>
                         <span class="settings-card__description">
                             Last seen @machine.LastSeenAt.ToLocalTime().ToString("g")
-                            <span> • agent @machine.AgentVersion</span>
-                            <span> • protocol @machine.ProtocolVersion</span>
-                            @if (!string.IsNullOrWhiteSpace(machine.WorkflowCatalogVersion))
+                            @if (machine.UpdateRollout is { } rollout && ShouldShowUpdateRolloutChip(rollout.State))
                             {
-                                <span> • workflow @machine.WorkflowCatalogVersion</span>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(machine.CapabilityCatalogVersion))
-                            {
-                                <span> • capabilities @machine.CapabilityCatalogVersion</span>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(machine.SetupCatalogVersion))
-                            {
-                                <span> • setup @machine.SetupCatalogVersion</span>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
-                            {
-                                <span> • security @machine.SecurityPolicyVersion</span>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(machine.DesiredWorkflowPackId))
-                            {
-                                <span> • pack @machine.DesiredWorkflowPackId</span>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(machine.DesiredUpdateManifestId))
-                            {
-                                <span> • manifest @machine.DesiredUpdateManifestId</span>
-                            }
-                            @if (machine.UpdateRollout is not null)
-                            {
-                                <span> • rollout @GetUpdateRolloutLabel(machine.UpdateRollout.State)</span>
+                                <span> • update @GetUpdateRolloutLabel(rollout.State)</span>
                             }
                             @if (!machine.ProtocolCompatible)
                             {
-                                <span> • protocol mismatch</span>
+                                <span> • needs app/runner compatibility fix</span>
                             }
                             @if (machine.Platform is not null)
                             {
                                 <span> • @GetHostPlatformLabel(machine.Platform.HostPlatform)</span>
                             }
                         </span>
+                        <details class="advanced-panel advanced-panel--compact">
+                            <summary>Advanced machine details</summary>
+                            <span class="settings-card__description">
+                                Agent @machine.AgentVersion
+                                <span> • protocol @machine.ProtocolVersion</span>
+                                @if (!string.IsNullOrWhiteSpace(machine.WorkflowCatalogVersion))
+                                {
+                                    <span> • workflow @machine.WorkflowCatalogVersion</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.CapabilityCatalogVersion))
+                                {
+                                    <span> • capabilities @machine.CapabilityCatalogVersion</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.SetupCatalogVersion))
+                                {
+                                    <span> • setup @machine.SetupCatalogVersion</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.SecurityPolicyVersion))
+                                {
+                                    <span> • security @machine.SecurityPolicyVersion</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.DesiredWorkflowPackId))
+                                {
+                                    <span> • pack @machine.DesiredWorkflowPackId</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.DesiredUpdateManifestId))
+                                {
+                                    <span> • manifest @machine.DesiredUpdateManifestId</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(machine.RunnerUrl))
+                                {
+                                    <span> • runner URL @machine.RunnerUrl</span>
+                                }
+                            </span>
+                        </details>
                         @if (machine.UpdateRollout is not null)
                         {
                             <span class="settings-card__description">@machine.UpdateRollout.StatusMessage</span>
@@ -140,8 +149,8 @@
     <div id="machines" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
-                <h2>Machines</h2>
-                <p class="settings-card__description">Choose coordinator-discovered runner machines, keep local preferences like auto-connect/default terminal, and control how new terminals are created through the coordinator.</p>
+                <h2>Create runners</h2>
+                <p class="settings-card__description">Create new runner capacity, connect existing machines, and choose your default place to open work.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
                 <button class="btn btn-accent" @onclick="AddMachine">Add Machine</button>
@@ -1006,6 +1015,9 @@
         RunnerHostPlatform.MacOS => "macOS",
         _ => "Unknown"
     };
+
+    private static bool ShouldShowUpdateRolloutChip(RunnerUpdateRolloutState state) =>
+        state is not (RunnerUpdateRolloutState.UpToDate or RunnerUpdateRolloutState.Applied);
 
     private static string GetUpdateRolloutLabel(RunnerUpdateRolloutState state) => state switch
     {

--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -24,11 +24,11 @@
                 <p>
                     @if (SessionState.Sessions.Count > 0)
                     {
-                        <span>Project-owned terminals stay inside their project pages. Use Project Links to reopen them.</span>
+                        <span>Workspace terminals stay with their workspace. Open the dashboard to resume them.</span>
                     }
                     else if (Connections.ConnectedMachineCount == 0)
                     {
-                        <span>Connect to a runner in <a href="/settings">Settings</a> to create a terminal.</span>
+                        <span>Create or connect a runner in <a href="/settings">Settings</a> to open a terminal.</span>
                     }
                     else
                     {
@@ -96,8 +96,8 @@
         if (count == 0)
         {
             return SessionState.Sessions.Count > 0
-                ? "Project-owned terminals are available through Project Links."
-                : "Create and switch between active sessions.";
+                ? "Workspace terminals are available from their workspace pages."
+                : "Create and switch between shell sessions.";
         }
 
         return count == 1 ? "1 active session" : $"{count} active sessions";

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -2547,3 +2547,13 @@ html, body {
     justify-content: center;
   }
 }
+
+.advanced-panel--compact {
+  margin-top: 0.65rem;
+  padding: 0.6rem;
+  box-shadow: none;
+}
+
+.advanced-panel--compact summary {
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
## Summary
- simplify primary Settings, dashboard, terminal, project, and remote-viewer language
- hide noisy machine metadata behind advanced machine details disclosures
- replace internal routing/relay phrasing with workspace/remote-screen language
- make machine health chips read as tools/setup/update states instead of workflow/catalog internals

Closes #378

## Validation
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`
