### PR TITLE
Improve workspace import readiness

### DIFF
--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -49,8 +49,8 @@
                 {
                     <a class="btn btn-accent" href="/">Dashboard</a>
                 }
-                <button class="btn btn-primary" disabled="@_saving" @onclick="SaveAsync">
-                    @(_saving ? "Saving..." : "Save project")
+                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" @onclick="SaveAsync">
+                    @(_saving ? "Saving..." : "Save workspace")
                 </button>
             </div>
         </div>
@@ -86,6 +86,28 @@
                                 <span class="machine-badge">@template.Workload</span>
                             </div>
                         </button>
+                    }
+                </div>
+            </section>
+
+            <section class="dashboard-section-card readiness-card">
+                <div class="dashboard-section-card__header">
+                    <div>
+                        <span class="eyebrow">Readiness</span>
+                        <h2>@GetReadinessTitle()</h2>
+                        <p>@GetReadinessDescription()</p>
+                    </div>
+                </div>
+                <div class="readiness-list">
+                    @foreach (var item in GetReadinessItems())
+                    {
+                        <div class="readiness-item readiness-item--@(item.Complete ? "complete" : "todo")">
+                            <span>@(item.Complete ? "✓" : "•")</span>
+                            <div>
+                                <strong>@item.Title</strong>
+                                <p>@item.Description</p>
+                            </div>
+                        </div>
                     }
                 </div>
             </section>
@@ -286,6 +308,16 @@
                 }
             </section>
 
+            <div class="sticky-save-bar" role="region" aria-label="Save workspace">
+                <div>
+                    <strong>@GetReadinessTitle()</strong>
+                    <span>@GetReadinessDescription()</span>
+                </div>
+                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" @onclick="SaveAsync">
+                    @(_saving ? "Saving..." : "Save workspace")
+                </button>
+            </div>
+
             @if (_editor.Workspaces.Count > 0)
             {
                 <section class="dashboard-section-card">
@@ -474,6 +506,54 @@
         }
     }
 
+    private bool IsReadyToSave() => GetReadinessItems().All(item => item.Complete);
+
+    private string GetReadinessTitle() => IsReadyToSave()
+        ? "Ready to save"
+        : "A few details are missing";
+
+    private string GetReadinessDescription()
+    {
+        var missing = GetReadinessItems().Count(item => !item.Complete);
+        return missing == 0
+            ? $"AgentDeck will save {_editor.Name} with {_editor.LaunchProfiles.Count} run option(s)."
+            : $"Finish {missing} item(s) before saving this workspace.";
+    }
+
+    private IReadOnlyList<ReadinessItem> GetReadinessItems()
+    {
+        var normalizedId = NormalizeProjectId(_editor.ProjectId, _editor.Name);
+        return
+        [
+            new ReadinessItem(
+                "Workspace name",
+                !string.IsNullOrWhiteSpace(normalizedId),
+                string.IsNullOrWhiteSpace(normalizedId)
+                    ? "Add a name so AgentDeck can create a stable workspace ID."
+                    : $"Will save as {normalizedId}."),
+            new ReadinessItem(
+                "Source",
+                !string.IsNullOrWhiteSpace(_editor.RepositoryUrl) || !string.IsNullOrWhiteSpace(_editor.RepositoryName),
+                !string.IsNullOrWhiteSpace(_editor.RepositoryUrl)
+                    ? "Repository URL is ready."
+                    : !string.IsNullOrWhiteSpace(_editor.RepositoryName)
+                        ? "Repository details are ready."
+                        : "Paste a repo URL or keep this as a blank workspace by naming the repository."),
+            new ReadinessItem(
+                "Run option",
+                _editor.LaunchProfiles.Any(profile => !string.IsNullOrWhiteSpace(profile.DisplayName) || !string.IsNullOrWhiteSpace(profile.Id)),
+                _editor.LaunchProfiles.Count == 0
+                    ? "Add at least one way to run this workspace."
+                    : $"{_editor.LaunchProfiles.Count} run option(s) configured."),
+            new ReadinessItem(
+                "Default branch",
+                !string.IsNullOrWhiteSpace(_editor.RepositoryDefaultBranch),
+                string.IsNullOrWhiteSpace(_editor.RepositoryDefaultBranch)
+                    ? "Set the branch AgentDeck should use when cloning."
+                    : $"Default branch is {_editor.RepositoryDefaultBranch}.")
+        ];
+    }
+
     private async Task SaveAsync()
     {
         if (_saving || string.IsNullOrWhiteSpace(_coordinatorUrl))
@@ -504,7 +584,7 @@
         var projectId = NormalizeProjectId(_editor.ProjectId, _editor.Name);
         if (string.IsNullOrWhiteSpace(projectId))
         {
-            throw new InvalidOperationException("Project ID is required.");
+            throw new InvalidOperationException("Add a workspace name or ID before saving.");
         }
 
         var projectName = NormalizeText(_editor.Name) ?? projectId;
@@ -515,7 +595,7 @@
             .ToArray();
         if (profiles.Length == 0)
         {
-            throw new InvalidOperationException("At least one launch profile is required.");
+            throw new InvalidOperationException("Choose at least one way to run this workspace before saving.");
         }
 
         var duplicateProfileId = profiles
@@ -523,7 +603,7 @@
             .FirstOrDefault(group => group.Count() > 1)?.Key;
         if (!string.IsNullOrWhiteSpace(duplicateProfileId))
         {
-            throw new InvalidOperationException($"Launch profile ID '{duplicateProfileId}' must be unique.");
+            throw new InvalidOperationException($"Two run options are using the same ID ('{duplicateProfileId}'). Open advanced launch details and make them unique.");
         }
 
         return new ProjectDefinition
@@ -549,7 +629,7 @@
         var profileId = NormalizeProjectId(editor.Id, editor.DisplayName);
         if (string.IsNullOrWhiteSpace(profileId))
         {
-            throw new InvalidOperationException("Each launch profile needs an ID or display name.");
+            throw new InvalidOperationException("Each run option needs a display name. Open advanced launch details if you want to set a custom ID.");
         }
 
         var requiresEmulator = editor.RequiresEmulator;
@@ -699,6 +779,8 @@
     private readonly record struct SimpleProjectTemplate(string Name, string Description, ProjectWorkloadKind Workload, string BuildCommand, string? LaunchCommand);
 
     private readonly record struct RepositoryParseResult(string Owner, string Name, string Url);
+
+    private readonly record struct ReadinessItem(string Title, bool Complete, string Description);
 
     private sealed class ProjectEditorModel
     {

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -2557,3 +2557,81 @@ html, body {
 .advanced-panel--compact summary {
   font-size: 0.82rem;
 }
+
+.readiness-card {
+  border-color: rgba(96, 165, 250, 0.28);
+}
+
+.readiness-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.readiness-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.readiness-item > span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  color: #cbd5e1;
+  font-weight: 800;
+}
+
+.readiness-item--complete > span {
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+}
+
+.readiness-item p {
+  margin: 0.15rem 0 0;
+  color: #cbd5e1;
+}
+
+.sticky-save-bar {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(96, 165, 250, 0.32);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.94);
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.32);
+  backdrop-filter: blur(16px);
+}
+
+.sticky-save-bar span {
+  display: block;
+  color: #cbd5e1;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 680px) {
+  .sticky-save-bar {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .sticky-save-bar .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a live workspace-readiness checklist to the import/edit flow
- keep Save reachable with a sticky, mobile-friendly save bar
- disable save until the required workspace fields are ready
- rewrite validation errors around workspace/run-option language

Closes #380

## Validation
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`
