### PR TITLE
Replace implementation vocabulary in workspace flows

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -67,7 +67,7 @@
         {
             <section class="dashboard-section-card">
                 <h2>Coordinator required</h2>
-                <p>Set a coordinator URL in <a href="/settings">Settings</a> to load project, machine, and session state.</p>
+                <p>Connect AgentDeck in <a href="/settings">Settings</a> to load workspaces, machines, and open sessions.</p>
             </section>
         }
         else if (!_dashboard.CoordinatorReachable)
@@ -283,7 +283,7 @@
         yield return new SetupStep(
             "Connect",
             _dashboard.CoordinatorReachable ? "Done" : _dashboard.CoordinatorConfigured ? "Fix" : "Start",
-            _dashboard.CoordinatorReachable ? "Coordinator is reachable." : "Connect to a coordinator so AgentDeck can load projects and machines.",
+            _dashboard.CoordinatorReachable ? "AgentDeck is connected." : "Connect AgentDeck so it can load workspaces and machines.",
             _dashboard.CoordinatorReachable ? "complete" : "todo");
         yield return new SetupStep(
             "Create a runner",
@@ -322,8 +322,8 @@
         if (!_dashboard.CoordinatorReachable)
         {
             return _dashboard.CoordinatorConfigured
-                ? "The saved coordinator URL did not respond. Check the URL or start the coordinator."
-                : "Add the coordinator URL once, then AgentDeck can discover runners and projects for you.";
+                ? "The saved connection did not respond. Check the URL or start the AgentDeck service."
+                : "Add the service URL once, then AgentDeck can discover runners and workspaces for you.";
         }
 
         if (!_dashboard.Machines.Any(machine => machine.IsOnline))
@@ -396,7 +396,7 @@
     {
         if (!_dashboard.CoordinatorConfigured)
         {
-            return "Add a coordinator URL in Settings";
+            return "Add the AgentDeck service URL in Settings";
         }
 
         return _dashboard.CoordinatorReachable

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -23,7 +23,7 @@
         <div class="project-page__content">
             <div class="empty-state">
                 <div class="empty-icon">⌂</div>
-                <h2>Project not found</h2>
+                <h2>Workspace not found</h2>
                 <p>Return to the <a href="/">dashboard</a> to pick another workspace.</p>
             </div>
         </div>
@@ -323,7 +323,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Viewer session entry points</h2>
-                        <p>Viewer sessions created by runner execution, surfaced here through the coordinator rather than direct machine access.</p>
+                        <p>Remote screens created by runs and debug sessions. AgentDeck routes them safely through the app connection.</p>
                     </div>
                 </div>
 
@@ -704,7 +704,7 @@
             var result = await CoordinatorClient.OpenProjectOnMachineAsync(_coordinatorUrl, _project.Definition.Id, machineId);
             if (result is null)
             {
-                Toasts.Show("The coordinator could not open that project on the selected machine.", ToastKind.Error);
+                Toasts.Show("AgentDeck could not open that workspace on the selected machine. Refresh machines or choose another ready machine.", ToastKind.Error);
                 return;
             }
 
@@ -816,7 +816,7 @@
             var job = await CoordinatorClient.QueueMachineOrchestrationJobAsync(_coordinatorUrl, machineId, request);
             if (job is null)
             {
-                Toasts.Show("The coordinator could not queue that launch.", ToastKind.Error);
+                Toasts.Show("AgentDeck could not start that run. Check the selected machine and run option, then try again.", ToastKind.Error);
                 return;
             }
 
@@ -863,7 +863,7 @@
             });
             if (session is null)
             {
-                Toasts.Show("The coordinator could not create that viewer session.", ToastKind.Error);
+                Toasts.Show("AgentDeck could not open that remote screen. Check the machine is online, then try again.", ToastKind.Error);
                 return;
             }
 
@@ -939,7 +939,7 @@
             var session = await CoordinatorClient.CloseMachineViewerSessionAsync(_coordinatorUrl, machineId, viewerSessionId);
             if (session is null)
             {
-                Toasts.Show("The coordinator could no longer find that viewer session.", ToastKind.Warning);
+                Toasts.Show("That remote screen is no longer available. Refresh open items and try again.", ToastKind.Warning);
                 await LoadAsync();
                 return;
             }
@@ -1018,7 +1018,7 @@
             var cancelledJob = await CoordinatorClient.CancelMachineOrchestrationJobAsync(_coordinatorUrl, job.TargetMachineId, job.Id);
             if (cancelledJob is null)
             {
-                Toasts.Show("The coordinator could no longer find that job to cancel.", ToastKind.Warning);
+                Toasts.Show("That run is no longer available to cancel. Refresh open items.", ToastKind.Warning);
                 await LoadAsync();
                 return;
             }
@@ -1324,7 +1324,7 @@
 
         if (machine.WorkflowCatalogStatus?.State == RunnerWorkflowCatalogState.Mismatched)
         {
-            return "The runner workflow catalog does not match the coordinator's desired version.";
+            return "This machine's tool list is out of date. Open Settings to refresh or update it.";
         }
 
         if (machine.WorkflowPackStatus?.State == RunnerWorkflowPackState.Failed)

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -19,8 +19,8 @@
     {
         <div class="project-editor__content">
             <div class="dashboard-section-card">
-                <h2>Coordinator required</h2>
-                <p>Set a coordinator URL in <a href="/settings">Settings</a> before editing projects.</p>
+                <h2>Connection required</h2>
+                <p>Connect AgentDeck in <a href="/settings">Settings</a> before editing workspaces.</p>
             </div>
         </div>
     }
@@ -28,8 +28,8 @@
     {
         <div class="project-editor__content">
             <div class="dashboard-section-card">
-                <h2>Project not found</h2>
-                <p>The coordinator does not currently expose project <code>@ProjectId</code>.</p>
+                <h2>Workspace not found</h2>
+                <p>AgentDeck could not find workspace <code>@ProjectId</code>. Refresh the dashboard or check Settings if it should still exist.</p>
             </div>
         </div>
     }
@@ -43,7 +43,7 @@
             <div class="project-page__actions">
                 @if (_isExistingProject)
                 {
-                    <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_editor.ProjectId)">Back to project</a>
+                    <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_editor.ProjectId)">Back to workspace</a>
                 }
                 else
                 {
@@ -61,7 +61,7 @@
                     <div>
                         <span class="eyebrow">Simple setup</span>
                         <h2>Start with a repository or template</h2>
-                        <p>AgentDeck can fill in the raw project fields for you. Advanced IDs and launch commands stay editable below.</p>
+                        <p>AgentDeck can fill in the workspace details for you. Advanced IDs and launch commands stay editable below.</p>
                     </div>
                 </div>
                 <div class="project-editor__grid">
@@ -175,12 +175,12 @@
                         <h2>Ways to run this workspace</h2>
                         <p>Most projects only need one default run profile. Open advanced details to tune commands, devices, or VS Code behavior.</p>
                     </div>
-                    <button class="btn btn-accent" disabled="@_saving" @onclick="AddProfile">Add launch profile</button>
+                    <button class="btn btn-accent" disabled="@_saving" @onclick="AddProfile">Add run option</button>
                 </div>
 
                 @if (_editor.LaunchProfiles.Count == 0)
                 {
-                    <p>No launch profiles are configured yet.</p>
+                    <p>No run options are configured yet.</p>
                 }
                 else
                 {
@@ -193,17 +193,17 @@
                                 <div class="project-editor__profile-body">
                                     <div class="project-session-card__header">
                                         <div>
-                                            <h3>@(string.IsNullOrWhiteSpace(profile.DisplayName) ? "Launch profile" : profile.DisplayName)</h3>
+                                            <h3>@(string.IsNullOrWhiteSpace(profile.DisplayName) ? "Run option" : profile.DisplayName)</h3>
                                             <p>@profile.Mode • @profile.Platform • @profile.LaunchDriver</p>
                                         </div>
-                                        <button class="btn btn-danger" disabled="@_saving" @onclick="() => RemoveProfile(profileIndex)">Delete profile</button>
+                                        <button class="btn btn-danger" disabled="@_saving" @onclick="() => RemoveProfile(profileIndex)">Remove run option</button>
                                     </div>
 
                                     <details class="advanced-panel">
                                         <summary>Advanced launch details</summary>
                                         <div class="project-editor__grid">
                                         <div class="form-field">
-                                            <label>Profile ID</label>
+                                            <label>Run option ID</label>
                                             <input class="input" @bind="profile.Id" />
                                         </div>
                                         <div class="form-field">
@@ -247,7 +247,7 @@
                                             </select>
                                         </div>
                                         <div class="form-field">
-                                            <label>Preferred machine ID</label>
+                                            <label>Preferred machine ID (advanced)</label>
                                             <input class="input" @bind="profile.PreferredMachineId" />
                                         </div>
                                         <div class="form-field">

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -212,7 +212,7 @@
                             _attachedTerminalSession is null &&
                             _activeSurface.Job is null)
                         {
-                            <p class="surface-details-card__note">This terminal surface is registered with the coordinator, but this companion is not currently attached to its live terminal stream.</p>
+                            <p class="surface-details-card__note">This terminal belongs to the workspace, but this app is not currently attached to its live stream. Reopen the terminal from the workspace if it should still be running.</p>
                         }
                         else if (_activeSurface.Job is not null || _activeSurface.Viewer is not null)
                         {
@@ -642,12 +642,12 @@
 
         if (!_sessionMachine.ProtocolCompatible)
         {
-            return "This session is hosted on a runner that is currently protocol-incompatible with the coordinator.";
+            return "This workspace is on a machine that needs an AgentDeck compatibility update.";
         }
 
         if (_sessionMachine.WorkflowCatalogStatus?.State == RunnerWorkflowCatalogState.Mismatched)
         {
-            return "The host runner workflow catalog does not match the coordinator's desired version.";
+            return "This machine's tool list is out of date. Open Settings to refresh or update it.";
         }
 
         if (_sessionMachine.WorkflowPackStatus?.State == RunnerWorkflowPackState.Failed)
@@ -690,7 +690,7 @@
         ProjectSessionSurfaceKind.Simulator => "Apple simulator connected to the current run/debug job.",
         ProjectSessionSurfaceKind.Emulator => "Android emulator connected to the current run/debug job.",
         ProjectSessionSurfaceKind.Viewer => "Remote desktop, browser, or app window for this workspace.",
-        _ => "Workspace item opened by the coordinator."
+        _ => "Workspace item opened by AgentDeck."
     };
 
     private static string GetSurfaceKindLabel(ProjectSessionSurfaceKind kind) => kind switch
@@ -970,7 +970,7 @@
             var session = await CoordinatorClient.CloseMachineViewerSessionAsync(_coordinatorUrl, _activeSurface.MachineId, _activeSurface.Viewer.Id);
             if (session is null)
             {
-                Toasts.Show("The coordinator could no longer find that viewer session.", ToastKind.Warning);
+                Toasts.Show("That remote screen is no longer available. Refresh open items and try again.", ToastKind.Warning);
             }
             else
             {

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -24,7 +24,7 @@
             <div class="empty-state">
                 <div class="empty-icon">⌂</div>
                 <h2>Viewer session not found</h2>
-                <p>The coordinator could no longer find that viewer session.</p>
+                <p>That remote screen is no longer available. Go back to the workspace and open it again.</p>
                 <button class="btn btn-accent" @onclick="NavigateBack">Back</button>
             </div>
         </div>
@@ -183,7 +183,7 @@
             _machineHostPlatform = AgentDeck.Shared.Enums.RunnerHostPlatform.Unknown;
             if (string.IsNullOrWhiteSpace(_coordinatorUrl))
             {
-                Toasts.Show("Connect to a coordinator before opening viewers.", ToastKind.Warning);
+                Toasts.Show("Connect AgentDeck in Settings before opening remote screens.", ToastKind.Warning);
                 await ViewerClient.DisconnectAsync();
                 return;
             }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -10,7 +10,7 @@
     <div class="page-header settings-page__header">
         <div>
             <h1>Settings</h1>
-            <p>Connect to a coordinator, choose runner machines, inspect setup capabilities, manage runner updates, and keep advanced machine details in one place.</p>
+            <p>Connect AgentDeck, create runner machines, check required tools, manage updates, and keep advanced diagnostics in one place.</p>
         </div>
     </div>
 
@@ -40,7 +40,7 @@
 
             <div class="machine-editor machine-editor--settings">
                 <div class="form-field">
-                    <label for="coordinator-url">Coordinator URL</label>
+                    <label for="coordinator-url">AgentDeck service URL</label>
                     <input id="coordinator-url" type="text" class="input" @bind="_settings.CoordinatorUrl"
                        placeholder="@GetCoordinatorUrlPlaceholder()" />
                 </div>
@@ -1167,7 +1167,7 @@
 
             if (instance is null)
             {
-                ToastService.Show("The coordinator did not return a runner instance.", ToastKind.Warning);
+                ToastService.Show("AgentDeck could not confirm the new runner. Refresh machines in a moment.", ToastKind.Warning);
                 return;
             }
 
@@ -1196,7 +1196,7 @@
             if (string.IsNullOrWhiteSpace(_settings.CoordinatorUrl))
             {
                 _registeredMachines = [];
-                _registeredMachinesErrorMessage = "Set a coordinator URL before refreshing the directory.";
+                _registeredMachinesErrorMessage = "Set the AgentDeck service URL before refreshing machines.";
                 return;
             }
 
@@ -1204,7 +1204,7 @@
             if (!_coordinatorReachable)
             {
                 _registeredMachines = [];
-                _registeredMachinesErrorMessage = "The coordinator API did not respond successfully.";
+                _registeredMachinesErrorMessage = "The AgentDeck service did not respond successfully.";
                 return;
             }
 
@@ -1215,7 +1215,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to refresh registered machines from coordinator API {CoordinatorUrl}", _settings.CoordinatorUrl);
-            _registeredMachinesErrorMessage = $"Failed to refresh coordinator directory: {ex.Message}";
+            _registeredMachinesErrorMessage = $"Failed to refresh machines: {ex.Message}";
             _registeredMachines = [];
             _coordinatorReachable = false;
         }
@@ -1238,7 +1238,7 @@
             var rollout = await CoordinatorClient.UpdateMachineApplyIntentAsync(_settings.CoordinatorUrl, machineId, mode);
             if (rollout is null)
             {
-                ToastService.Show("The coordinator could no longer find that machine.", ToastKind.Warning);
+                ToastService.Show("AgentDeck could no longer find that machine. Refresh machines and try again.", ToastKind.Warning);
                 await RefreshCoordinatorDirectoryAsync();
                 return;
             }
@@ -1255,7 +1255,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to update coordinator apply intent for machine {MachineId}", machineId);
-            ToastService.Show($"Failed to update coordinator apply intent: {ex.Message}", ToastKind.Error);
+            ToastService.Show($"Failed to update machine setup preference: {ex.Message}", ToastKind.Error);
         }
         finally
         {
@@ -1276,7 +1276,7 @@
             var retried = await CoordinatorClient.RetryMachineWorkflowPackAsync(_settings.CoordinatorUrl, machineId);
             if (!retried)
             {
-                ToastService.Show("The coordinator could no longer find that machine.", ToastKind.Warning);
+                ToastService.Show("AgentDeck could no longer find that machine. Refresh machines and try again.", ToastKind.Warning);
                 await RefreshCoordinatorDirectoryAsync();
                 return;
             }


### PR DESCRIPTION
## Summary
- replace remaining normal-path project/profile/coordinator vocabulary with workspace/run option/app connection language
- update common failure messages to include concrete next actions
- keep diagnostics terminology available only where it is actually diagnostic

Closes #382

## Validation
- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`
