### PR TITLE
fix: default new terminal session names

### DIFF
--- a/AgentDeck.Core/Components/NewTerminalDialog.razor
+++ b/AgentDeck.Core/Components/NewTerminalDialog.razor
@@ -17,8 +17,9 @@
             </div>
 
             <div class="form-group">
-                <label class="form-label">Session Name</label>
-                <input class="form-input" type="text" @bind="_name" placeholder="Session name" />
+                <label class="form-label">Session name <span class="form-label__optional">optional</span></label>
+                <input class="form-input" type="text" @bind="_name" placeholder="@GetDefaultSessionName()" />
+                <span class="form-hint">Leave blank to use <strong>@GetDefaultSessionName()</strong>.</span>
             </div>
 
             <div class="form-group">
@@ -111,25 +112,28 @@
             _machineId = ResolveDefaultMachineId();
             if (_presets.Count > 0)
                 SelectPreset(_presets[0]);
+            _name = GetDefaultSessionName();
         }
         _wasOpen = IsOpen;
     }
 
     private void SelectPreset(CliPreset preset)
     {
+        var previousDefaultName = GetDefaultSessionName();
+        var shouldRefreshName = string.IsNullOrWhiteSpace(_name) || string.Equals(_name, previousDefaultName, StringComparison.Ordinal);
+
         _selectedPreset = preset;
         _command = preset.Command;
+
+        if (shouldRefreshName)
+        {
+            _name = GetDefaultSessionName();
+        }
     }
 
     private async Task Create()
     {
         _error = "";
-        if (string.IsNullOrWhiteSpace(_name))
-        {
-            _error = "Session name is required.";
-            return;
-        }
-
         if (SelectedMachine is null)
         {
             _error = "Add a machine in Settings before creating a terminal.";
@@ -145,7 +149,7 @@
 
         var req = new CreateTerminalRequest
         {
-            Name = _name.Trim(),
+            Name = ResolveSessionName(),
             WorkingDirectory = _workingDir,
             Command = cmd.Trim(),
             Arguments = ResolveArguments(),
@@ -156,6 +160,26 @@
             MachineId = SelectedMachine.Id,
             Terminal = req
         });
+    }
+
+    private string ResolveSessionName() =>
+        string.IsNullOrWhiteSpace(_name) ? GetDefaultSessionName() : _name.Trim();
+
+    private string GetDefaultSessionName()
+    {
+        var presetName = _selectedPreset?.Name;
+        if (string.IsNullOrWhiteSpace(presetName))
+        {
+            return "Terminal";
+        }
+
+        var baseName = string.Equals(presetName, "Custom", StringComparison.OrdinalIgnoreCase)
+            ? "Terminal"
+            : presetName;
+
+        return SelectedMachine is null || string.IsNullOrWhiteSpace(SelectedMachine.Name)
+            ? baseName
+            : $"{baseName} on {SelectedMachine.Name}";
     }
 
     private string ResolveCommandText()

--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -2458,6 +2458,12 @@ html, body {
   color: #cbd5e1;
 }
 
+.form-label__optional {
+  color: var(--color-subtext);
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
 .setup-checklist__actions,
 .inline-action-field {
   display: flex;


### PR DESCRIPTION
$## Summary\nMake the New Terminal dialog easier to complete by generating useful preset-based session names instead of requiring manual naming first.\n\n## Changes\n- Mark session name as optional and show the generated fallback name in helper copy.\n- Prefill the dialog with a readable default based on the selected preset and machine.\n- Refresh the generated name when switching presets unless the user has customized it.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#386