### PR TITLE
fix: clarify empty workspace mappings

### DIFF
--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -43,7 +43,7 @@
         </div>
 
         <div class="project-page__content">
-            <section class="dashboard-section-card">
+            <section id="workspace-machines" class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Where do you want to run this?</h2>
@@ -443,7 +443,12 @@
 
                 @if (_project.Definition.Workspaces.Count == 0)
                 {
-                    <p>No machine workspaces have been registered yet.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">⌂</div>
+                        <h3>No machine workspace yet</h3>
+                        <p>Open this workspace on a runner to let AgentDeck prepare the project folder and remember where it lives.</p>
+                        <a class="btn btn-primary" href="#workspace-machines">Choose a runner</a>
+                    </div>
                 }
                 else
                 {


### PR DESCRIPTION
$## Summary\nClarify the Workspaces section on project details when no runner has prepared a project folder yet.\n\n## Changes\n- Add an anchor to the machine picker section.\n- Replace the plain no-workspaces sentence with an actionable empty state.\n- Link users back to the runner picker to create the first machine workspace mapping.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#392