### PR TITLE
fix: make missing run options actionable

### DIFF
--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -180,7 +180,12 @@
 
                 @if (_editor.LaunchProfiles.Count == 0)
                 {
-                    <p>No run options are configured yet.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">▶</div>
+                        <h3>No run options yet</h3>
+                        <p>Add at least one run option so AgentDeck knows which command and machine type to use when you launch this workspace.</p>
+                        <button type="button" class="btn btn-primary" disabled="@_saving" @onclick="AddProfile">Add run option</button>
+                    </div>
                 }
                 else
                 {


### PR DESCRIPTION
$## Summary\nImprove the workspace editor empty state when a workspace has no run options configured.\n\n## Changes\n- Replace the plain no-run-options sentence with an actionable empty state.\n- Explain why run options matter for launching a workspace.\n- Add an in-context Add run option button in the empty area.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#394