### PR TITLE
fix: guide empty live sessions

### DIFF
--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -174,7 +174,7 @@
                 }
             </section>
 
-            <section class="dashboard-section-card">
+            <section id="run-debug" class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Run or debug</h2>
@@ -480,7 +480,15 @@
 
                 @if (_projectSessions.Count == 0)
                 {
-                    <p>No live sessions are registered for this project yet.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">▣</div>
+                        <h3>No live sessions yet</h3>
+                        <p>Open this workspace on a runner or queue a run/debug profile to create the first live session.</p>
+                        <div class="setup-checklist__actions">
+                            <a class="btn btn-primary" href="#workspace-machines">Open workspace</a>
+                            <a class="btn btn-accent" href="#run-debug">Run or debug</a>
+                        </div>
+                    </div>
                 }
                 else
                 {


### PR DESCRIPTION
$## Summary\nMake the empty Live sessions section on workspace pages explain how to create a session.\n\n## Changes\n- Add an anchor to the Run or debug section.\n- Replace the plain no-sessions sentence with an actionable empty state.\n- Link users back to Open workspace and Run/debug actions.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#396