### PR TITLE
fix: guide empty viewer sessions

### DIFF
--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -358,7 +358,15 @@
 
                 @if (_projectViewerSessions.Count == 0)
                 {
-                    <p>No viewer sessions are currently registered for this project.</p>
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">◫</div>
+                        <h3>No viewer sessions yet</h3>
+                        <p>Open a desktop or launch a profile with a remote surface to see viewer links and control status here.</p>
+                        <div class="setup-checklist__actions">
+                            <a class="btn btn-primary" href="#workspace-machines">Open desktop</a>
+                            <a class="btn btn-accent" href="#run-debug">Run or debug</a>
+                        </div>
+                    </div>
                 }
                 else
                 {


### PR DESCRIPTION
$## Summary\nMake the empty Viewer session entry points section explain how viewer sessions appear.\n\n## Changes\n- Replace the plain no-viewers sentence with an actionable empty state.\n- Explain that desktops or remote-surface profiles create viewer sessions.\n- Link back to the machine picker and Run/debug controls.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#400