### PR TITLE
fix: align terminal action with runner readiness

### DIFF
--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -12,7 +12,14 @@
             <h1>Terminals</h1>
             <p>@GetHeaderSubtitle()</p>
         </div>
-        <button class="btn btn-primary" @onclick="OpenNewTerminal">New</button>
+        @if (Connections.ConnectedMachineCount == 0)
+        {
+            <a class="btn btn-primary" href="/settings#machines">Set up runner</a>
+        }
+        else
+        {
+            <button class="btn btn-primary" @onclick="OpenNewTerminal">New terminal</button>
+        }
     </div>
 
     @if (GetStandaloneSessions().Count == 0)


### PR DESCRIPTION
$## Summary\nMake the Terminals page primary action route users to setup when no runner is connected.\n\n## Changes\n- Show “Set up runner” linking to Settings when there are no connected machines.\n- Keep “New terminal” available once runner capacity is connected.\n- Avoid opening the new terminal dialog into an unavailable-runner dead end.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#402