### PR TITLE
fix: align sidebar terminal action with readiness

### DIFF
--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -52,10 +52,20 @@
                 </button>
             }
 
-            <button class="nav-new-terminal" @onclick="OpenNewTerminal">
-                <span>＋</span>
-                <span>New Terminal</span>
-            </button>
+            @if (Connections.ConnectedMachineCount == 0)
+            {
+                <a class="nav-new-terminal" href="/settings#machines">
+                    <span>＋</span>
+                    <span>Set up runner</span>
+                </a>
+            }
+            else
+            {
+                <button class="nav-new-terminal" @onclick="OpenNewTerminal">
+                    <span>＋</span>
+                    <span>New Terminal</span>
+                </button>
+            }
 
             <div class="nav-divider"></div>
 


### PR DESCRIPTION
$## Summary\nMake the desktop sidebar terminal action match runner readiness.\n\n## Changes\n- Show “Set up runner” linking to Settings when no machines are connected.\n- Keep the New Terminal dialog action once runner capacity is available.\n- Avoid a global navigation path into an unavailable-terminal dead end.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#404