### PR TITLE
fix: guide empty project session surfaces

### DIFF
--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -124,8 +124,17 @@
                 {
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▣</div>
-                        <h3>Choose something to open</h3>
-                        <p>Select a terminal, desktop, app window, editor, emulator, simulator, log, or job output surface.</p>
+                        @if (_surfaceTabs.Count == 0)
+                        {
+                            <h3>No surfaces open yet</h3>
+                            <p>Open this workspace or run/debug a profile from the project page to create terminals, viewers, jobs, and other surfaces.</p>
+                            <a class="btn btn-primary" href="/projects/@Uri.EscapeDataString(_projectSession.ProjectId)">Open project actions</a>
+                        }
+                        else
+                        {
+                            <h3>Choose something to open</h3>
+                            <p>Select a terminal, desktop, app window, editor, emulator, simulator, log, or job output surface.</p>
+                        }
                     </div>
                 }
                 else if (_activeSurface.Kind == ProjectSessionSurfaceKind.Terminal && _attachedTerminalSession is not null)


### PR DESCRIPTION
$## Summary\nMake empty project-session surface containers point users back to project actions.\n\n## Changes\n- Detect when a project session has no surfaces to choose from.\n- Show a no-surfaces empty state instead of asking users to select a nonexistent tab.\n- Link back to the project page where opening/running the workspace creates surfaces.\n\n## Testing\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#408