### PR TITLE
fix: polish setup and recovery UX

### DIFF
--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -19,6 +19,10 @@
                 <span class="nav-icon">⌂</span>
                 <span class="nav-label">Projects</span>
             </a>
+            <a class="nav-item @(IsActive("/terminals") ? "active" : "")" href="/terminals">
+                <span class="nav-icon">▣</span>
+                <span class="nav-label">Terminals</span>
+            </a>
 
             <div class="nav-section-header">Project Links</div>
             @foreach (var projectSession in GetProjectSessions())

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -238,8 +238,19 @@
                     </div>
                 </div>
 
-                <div class="viewer-surface-grid">
-                    @foreach (var viewerSurface in _dashboard.ViewerSurfaces)
+                @if (_dashboard.ViewerSurfaces.Count == 0)
+                {
+                    <div class="empty-state empty-state--actionable">
+                        <div class="empty-icon">▣</div>
+                        <h3>No openable surfaces yet</h3>
+                        <p>Create a workspace or add a run option to see terminals, desktops, app windows, emulators, and logs here.</p>
+                        <a class="btn btn-primary" href="/projects/new">Create or import a workspace</a>
+                    </div>
+                }
+                else
+                {
+                    <div class="viewer-surface-grid">
+                        @foreach (var viewerSurface in _dashboard.ViewerSurfaces)
                         {
                             <article class="viewer-surface-card">
                                 <h3>@viewerSurface.Title</h3>
@@ -248,6 +259,7 @@
                             </article>
                         }
                     </div>
+                }
             </section>
         }
     </div>

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -18,6 +18,21 @@
             </div>
         </div>
     }
+    else if (_loadError is not null)
+    {
+        <div class="project-page__content">
+            <div class="empty-state empty-state--actionable">
+                <div class="empty-icon">!</div>
+                <h2>Could not load this workspace</h2>
+                <p>@_loadError</p>
+                <div class="form-actions">
+                    <button class="btn btn-primary" @onclick="LoadAsync">Try again</button>
+                    <a class="btn btn-accent" href="/settings">Check connection</a>
+                    <a class="btn btn-accent" href="/">Dashboard</a>
+                </div>
+            </div>
+        </div>
+    }
     else if (_project is null)
     {
         <div class="project-page__content">
@@ -545,6 +560,7 @@
     private string? _queueingProfileId;
     private string? _cancellingJobId;
     private string? _coordinatorUrl;
+    private string? _loadError;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -554,6 +570,7 @@
     private async Task LoadAsync()
     {
         _loading = true;
+        _loadError = null;
         try
         {
             var settings = await SettingsService.LoadAsync();
@@ -571,6 +588,15 @@
                 await EnsureDeviceCatalogsAsync();
                 await LoadRuntimeStateAsync();
             }
+        }
+        catch (Exception ex)
+        {
+            _loadError = ex.Message;
+            _project = null;
+            _projectSessions = [];
+            _projectJobs = [];
+            _projectViewerSessions = [];
+            _remoteControlByMachineId.Clear();
         }
         finally
         {

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -49,7 +49,7 @@
                 {
                     <a class="btn btn-accent" href="/">Dashboard</a>
                 }
-                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" @onclick="SaveAsync">
+                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" title="@GetSaveButtonTitle()" @onclick="SaveAsync">
                     @(_saving ? "Saving..." : "Save workspace")
                 </button>
             </div>
@@ -318,7 +318,7 @@
                     <strong>@GetReadinessTitle()</strong>
                     <span>@GetReadinessDescription()</span>
                 </div>
-                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" @onclick="SaveAsync">
+                <button class="btn btn-primary" disabled="@(_saving || !IsReadyToSave())" title="@GetSaveButtonTitle()" @onclick="SaveAsync">
                     @(_saving ? "Saving..." : "Save workspace")
                 </button>
             </div>
@@ -538,6 +538,19 @@
         return missing == 0
             ? $"AgentDeck will save {_editor.Name} with {_editor.LaunchProfiles.Count} run option(s)."
             : $"Finish {missing} item(s) before saving this workspace.";
+    }
+
+    private string GetSaveButtonTitle()
+    {
+        if (_saving)
+        {
+            return "Saving workspace...";
+        }
+
+        var nextMissing = GetReadinessItems().FirstOrDefault(item => !item.Complete);
+        return nextMissing == default
+            ? "Save workspace"
+            : $"Finish {nextMissing.Title}: {nextMissing.Description}";
     }
 
     private IReadOnlyList<ReadinessItem> GetReadinessItems()

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -29,6 +29,9 @@
                 <p class="settings-card__description">Connect AgentDeck to the service that keeps your machines, workspaces, and sessions in sync.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
+                <button class="btn btn-primary" @onclick="SaveAndRefreshConnectionAsync" disabled="@(_saving || _registeredMachinesBusy)">
+                    @(_saving || _registeredMachinesBusy ? "Saving..." : "Save and refresh")
+                </button>
                 <button class="btn btn-accent" @onclick="RefreshCoordinatorDirectoryAsync" disabled="@_registeredMachinesBusy">
                     @(_registeredMachinesBusy ? "Refreshing..." : "Refresh machines")
                 </button>
@@ -180,6 +183,7 @@
                 @foreach (var template in _runnerOrchestrationCatalog.Templates.OrderBy(template => template.Name, StringComparer.OrdinalIgnoreCase))
                 {
                     var provider = GetRunnerProvider(template.ProviderId);
+                    var canCreateRunner = CanCreateRunnerFromTemplate(template, provider);
                     <article class="project-template-card">
                         <div class="project-template-card__header">
                             <div>
@@ -193,16 +197,55 @@
                         @if (provider is not null && !provider.Configured)
                         {
                             <p class="error-message">@provider.StatusMessage</p>
+                            <p class="project-template-target__note">Configure @provider.Name before creating this runner.</p>
                         }
                         <div class="project-machine-card__actions">
                             <button class="btn btn-primary"
-                                    disabled="@(_creatingRunnerTemplateId == template.Id || provider is null || !provider.Enabled)"
-                                    @onclick="() => CreateRunnerFromTemplateAsync(template)">
-                                @(_creatingRunnerTemplateId == template.Id ? "Creating..." : "Create runner")
+                                    disabled="@(_creatingRunnerTemplateId == template.Id || !canCreateRunner)"
+                                    @onclick="() => OpenRunnerCreatePreview(template)">
+                                @GetCreateRunnerButtonLabel(template, provider)
                             </button>
                         </div>
                     </article>
                 }
+            </div>
+        }
+
+        @if (SelectedRunnerTemplateDraft is not null)
+        {
+            var template = SelectedRunnerTemplateDraft;
+            var provider = GetRunnerProvider(template.ProviderId);
+            <div class="settings-callout settings-callout--actionable">
+                <strong>Review runner before creating</strong>
+                <span>@template.Name on @(provider?.Name ?? template.ProviderId) • @template.HostPlatform • port @template.RunnerPort</span>
+                <div class="project-editor__grid">
+                    <div class="form-field">
+                        <label for="runner-create-name">Runner name</label>
+                        <input id="runner-create-name" class="input" @bind="_runnerCreateName" />
+                    </div>
+                    <div class="form-field">
+                        <label for="runner-create-lifecycle">Lifecycle</label>
+                        <select id="runner-create-lifecycle" class="input" @bind="_runnerCreateLifecyclePolicy">
+                            @foreach (var policy in Enum.GetValues<RunnerInstanceLifecyclePolicy>())
+                            {
+                                <option value="@policy">@policy</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="form-field project-editor__field--full">
+                        <label for="runner-create-coordinator">Coordinator URL</label>
+                        <input id="runner-create-coordinator" class="input" @bind="_runnerCreateCoordinatorUrl" />
+                        <p class="settings-card__description">Use a URL the new runner can reach, not necessarily the client-local URL.</p>
+                    </div>
+                </div>
+                <div class="form-actions form-actions--settings">
+                    <button class="btn btn-primary"
+                            disabled="@(_creatingRunnerTemplateId == template.Id || string.IsNullOrWhiteSpace(_runnerCreateName) || string.IsNullOrWhiteSpace(_runnerCreateCoordinatorUrl))"
+                            @onclick="() => CreateRunnerFromTemplateAsync(template)">
+                        @(_creatingRunnerTemplateId == template.Id ? "Creating..." : "Create runner")
+                    </button>
+                    <button class="btn btn-accent" disabled="@(_creatingRunnerTemplateId == template.Id)" @onclick="ClearRunnerCreatePreview">Cancel</button>
+                </div>
             </div>
         }
 
@@ -836,6 +879,10 @@
     private IReadOnlyList<RegisteredRunnerMachine> _registeredMachines = [];
     private RunnerOrchestratorCatalog _runnerOrchestrationCatalog = new();
     private string? _creatingRunnerTemplateId;
+    private string? _runnerCreateTemplateId;
+    private string _runnerCreateName = string.Empty;
+    private string _runnerCreateCoordinatorUrl = string.Empty;
+    private RunnerInstanceLifecyclePolicy _runnerCreateLifecyclePolicy = RunnerInstanceLifecyclePolicy.Ephemeral;
     private bool _registeredMachinesBusy;
     private string? _registeredMachinesErrorMessage;
     private bool _coordinatorReachable;
@@ -844,6 +891,11 @@
     private string? _workflowPackRetryMachineId;
 
     private RunnerMachineSettings? SelectedMachine => _settings.FindMachine(_selectedMachineId);
+    private RunnerOrchestratorTemplate? SelectedRunnerTemplateDraft =>
+        string.IsNullOrWhiteSpace(_runnerCreateTemplateId)
+            ? null
+            : _runnerOrchestrationCatalog.Templates.FirstOrDefault(template =>
+                string.Equals(template.Id, _runnerCreateTemplateId, StringComparison.OrdinalIgnoreCase));
     private MachineCapabilitiesSnapshot? _machineCapabilities =>
         SelectedMachine is not null && _machineCapabilitiesByMachine.TryGetValue(SelectedMachine.Id, out var snapshot)
             ? snapshot
@@ -878,7 +930,7 @@
         {
             _settings.Normalize();
             await SettingsService.SaveAsync(_settings);
-            ToastService.Show("Machine settings saved", ToastKind.Success);
+            ToastService.Show("Settings saved", ToastKind.Success);
         }
         catch (Exception ex)
         {
@@ -887,6 +939,15 @@
         finally
         {
             _saving = false;
+        }
+    }
+
+    private async Task SaveAndRefreshConnectionAsync()
+    {
+        await SaveAsync();
+        if (_errorMessage is null)
+        {
+            await RefreshCoordinatorDirectoryAsync();
         }
     }
 
@@ -1144,11 +1205,61 @@
     private RunnerOrchestratorProvider? GetRunnerProvider(string providerId) =>
         _runnerOrchestrationCatalog.Providers.FirstOrDefault(provider => string.Equals(provider.Id, providerId, StringComparison.OrdinalIgnoreCase));
 
+    private bool CanCreateRunnerFromTemplate(RunnerOrchestratorTemplate template, RunnerOrchestratorProvider? provider) =>
+        provider is not null && provider.Enabled && provider.Configured;
+
+    private string GetCreateRunnerButtonLabel(RunnerOrchestratorTemplate template, RunnerOrchestratorProvider? provider)
+    {
+        if (_creatingRunnerTemplateId == template.Id)
+        {
+            return "Creating...";
+        }
+
+        if (provider is null)
+        {
+            return "Provider unavailable";
+        }
+
+        if (!provider.Configured)
+        {
+            return "Configure provider first";
+        }
+
+        if (!provider.Enabled)
+        {
+            return "Provider disabled";
+        }
+
+        return "Review and create";
+    }
+
+    private void OpenRunnerCreatePreview(RunnerOrchestratorTemplate template)
+    {
+        _runnerCreateTemplateId = template.Id;
+        _runnerCreateName = $"{template.Name} {DateTimeOffset.Now:HHmm}";
+        _runnerCreateLifecyclePolicy = template.DefaultLifecyclePolicy;
+        _runnerCreateCoordinatorUrl = _settings.CoordinatorUrl;
+    }
+
+    private void ClearRunnerCreatePreview()
+    {
+        _runnerCreateTemplateId = null;
+        _runnerCreateName = string.Empty;
+        _runnerCreateCoordinatorUrl = string.Empty;
+        _runnerCreateLifecyclePolicy = RunnerInstanceLifecyclePolicy.Ephemeral;
+    }
+
     private async Task CreateRunnerFromTemplateAsync(RunnerOrchestratorTemplate template)
     {
         if (string.IsNullOrWhiteSpace(_settings.CoordinatorUrl))
         {
             ToastService.Show("Set a coordinator URL before creating a runner.", ToastKind.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_runnerCreateCoordinatorUrl) || string.IsNullOrWhiteSpace(_runnerCreateName))
+        {
+            ToastService.Show("Review the runner name and coordinator URL before creating.", ToastKind.Warning);
             return;
         }
 
@@ -1160,9 +1271,9 @@
                 new CreateRunnerOrchestratorInstanceRequest
                 {
                     TemplateId = template.Id,
-                    Name = $"{template.Name} {DateTimeOffset.Now:HHmm}",
-                    LifecyclePolicy = template.DefaultLifecyclePolicy,
-                    CoordinatorUrl = _settings.CoordinatorUrl
+                    Name = _runnerCreateName.Trim(),
+                    LifecyclePolicy = _runnerCreateLifecyclePolicy,
+                    CoordinatorUrl = _runnerCreateCoordinatorUrl.Trim()
                 });
 
             if (instance is null)
@@ -1172,6 +1283,7 @@
             }
 
             ToastService.Show($"Runner {instance.Name} is {instance.State}. Refresh the directory once it registers.", instance.State == RunnerInstanceLifecycleState.Failed ? ToastKind.Warning : ToastKind.Success);
+            ClearRunnerCreatePreview();
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)

--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -39,7 +39,7 @@
                     }
                     else
                     {
-                        <span>Tap <strong>New</strong> to create your first terminal.</span>
+                        <span>Tap <strong>New terminal</strong> to create your first terminal.</span>
                     }
                 </p>
             </div>

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ dotnet restore AgentDeck.slnx
 dotnet run --project AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
 ```
 
-In a second terminal, start a Linux runner and register it with that coordinator:
+In a second terminal, start a Linux runner and register it with that coordinator. Coordinator registration uses .NET configuration environment keys with double underscores:
 
 ```bash
-AGENTDECK_COORDINATOR_URL=http://localhost:5001 \
-AGENTDECK_MACHINE_ID=local-linux \
-AGENTDECK_MACHINE_NAME="Local Linux" \
+Coordinator__CoordinatorUrl=http://localhost:5001 \
+Coordinator__MachineId=local-linux \
+Coordinator__MachineName="Local Linux" \
 dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj
 ```
 
@@ -117,12 +117,15 @@ Build the image from the repository root:
 docker build -t agentdeck-runner -f AgentDeck.Runner/Dockerfile .
 ```
 
-Run the container with a mounted workspace:
+Run the container with a mounted workspace and coordinator registration settings. On Docker Desktop, `host.docker.internal` reaches the host coordinator; on native Linux, replace it with a LAN-reachable host name/IP or add Docker's host-gateway mapping for that name.
 
 ```bash
 docker run --rm \
   -p 5000:5000 \
   -e AGENTDECK_WORKSPACE=/workspace \
+  -e Coordinator__CoordinatorUrl=http://host.docker.internal:5001 \
+  -e Coordinator__MachineId=local-docker \
+  -e Coordinator__MachineName="Local Docker Runner" \
   -v "$(pwd):/workspace" \
   agentdeck-runner
 ```
@@ -131,7 +134,7 @@ The image exposes port `5000`, defaults the workspace to `/workspace`, sets `ASP
 
 The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
 
-If you run the runner inside a container, AgentDeck treats that container as just another machine. Register the runner with the coordinator, then use the companion app through that coordinator to inspect which supported tools are installed and install missing ones inside that machine.
+If you run the runner inside a container, AgentDeck treats that container as just another machine. Keep `Coordinator__CoordinatorUrl` pointed at the coordinator URL the container can reach, then use the companion app through that coordinator to inspect which supported tools are installed and install missing ones inside that machine.
 
 If you override the container user, Linux setup actions still need either `root` or a passwd-backed user with passwordless `sudo`. Arbitrary numeric UIDs that are not present in `/etc/passwd` can run the runner, but they cannot perform privileged package installs through the setup flow.
 


### PR DESCRIPTION
$## Summary\nPolish the setup, navigation, and recovery friction found in the full UI/UX review.\n\n## Changes\n- Correct README runner registration examples to use working .NET configuration env vars.\n- Add Docker runner coordinator registration guidance.\n- Add Settings Connection save-and-refresh action.\n- Disable unconfigured runner provider templates and add a review/edit step before provisioning.\n- Add desktop Terminals navigation.\n- Add dashboard empty state for unavailable openable surfaces.\n- Add workspace detail load-error recovery actions.\n- Clarify terminal empty-state copy.\n- Surface the next blocking readiness item on disabled workspace save buttons.\n\n## Validation\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n\nFixes DapperMickie/AgentDeck#410