### PR TITLE
Harden AgentDeck local default service exposure

### DIFF
--- a/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
+++ b/AgentDeck.Coordinator/Configuration/CoordinatorOptions.cs
@@ -3,8 +3,12 @@ namespace AgentDeck.Coordinator.Configuration;
 public sealed class CoordinatorOptions
 {
     public const string SectionName = "Coordinator";
+    public const string PortEnvironmentVariable = "AGENTDECK_COORDINATOR_PORT";
+    public const string BindAddressEnvironmentVariable = "AGENTDECK_COORDINATOR_BIND_ADDRESS";
 
     public int Port { get; set; } = 5001;
+
+    public string BindAddress { get; set; } = "127.0.0.1";
 
     public string? PublicBaseUrl { get; set; }
 
@@ -43,4 +47,23 @@ public sealed class CoordinatorOptions
     public TimeSpan RunnerControlHandshakeTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     public long RunnerControlMaximumReceiveMessageSize { get; set; } = 1024 * 1024;
+
+    public static void ApplyEnvironmentOverrides(CoordinatorOptions options)
+    {
+        var portValue = Environment.GetEnvironmentVariable(PortEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(portValue))
+        {
+            if (!int.TryParse(portValue, out var port) || port is < 1 or > 65535)
+            {
+                throw new InvalidOperationException(
+                    $"{PortEnvironmentVariable} must be an integer between 1 and 65535.");
+            }
+
+            options.Port = port;
+        }
+
+        var bindAddress = Environment.GetEnvironmentVariable(BindAddressEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(bindAddress))
+            options.BindAddress = bindAddress.Trim();
+    }
 }

--- a/AgentDeck.Coordinator/Program.cs
+++ b/AgentDeck.Coordinator/Program.cs
@@ -10,10 +10,13 @@ var coordinatorOptions = builder.Configuration
     .GetSection(CoordinatorOptions.SectionName)
     .Get<CoordinatorOptions>() ?? new CoordinatorOptions();
 
-builder.WebHost.UseUrls($"http://0.0.0.0:{coordinatorOptions.Port}");
+CoordinatorOptions.ApplyEnvironmentOverrides(coordinatorOptions);
+
+builder.WebHost.UseUrls($"http://{coordinatorOptions.BindAddress}:{coordinatorOptions.Port}");
 
 builder.Services.AddOptions<CoordinatorOptions>()
-    .Bind(builder.Configuration.GetSection(CoordinatorOptions.SectionName));
+    .Bind(builder.Configuration.GetSection(CoordinatorOptions.SectionName))
+    .Configure(CoordinatorOptions.ApplyEnvironmentOverrides);
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddHttpClient();
 builder.Services.ConfigureHttpJsonOptions(options =>

--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Coordinator": {
     "Port": 5001,
+    "BindAddress": "127.0.0.1",
     "PublicBaseUrl": "http://localhost:5001",
     "ArtifactRoot": "artifacts",
     "DesiredRunnerVersion": "0.1.0-dev",

--- a/AgentDeck.Runner.Tests/RunnerOptionsTests.cs
+++ b/AgentDeck.Runner.Tests/RunnerOptionsTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+using AgentDeck.Runner.Configuration;
+
+namespace AgentDeck.Runner.Tests;
+
+public sealed class RunnerOptionsTests : IDisposable
+{
+    private readonly string? _workspaceRoot = Environment.GetEnvironmentVariable(RunnerOptions.WorkspaceEnvironmentVariable);
+    private readonly string? _port = Environment.GetEnvironmentVariable(RunnerOptions.PortEnvironmentVariable);
+    private readonly string? _bindAddress = Environment.GetEnvironmentVariable(RunnerOptions.BindAddressEnvironmentVariable);
+    private readonly string? _defaultShell = Environment.GetEnvironmentVariable(RunnerOptions.DefaultShellEnvironmentVariable);
+
+    public RunnerOptionsTests()
+    {
+        Environment.SetEnvironmentVariable(RunnerOptions.WorkspaceEnvironmentVariable, null);
+        Environment.SetEnvironmentVariable(RunnerOptions.PortEnvironmentVariable, null);
+        Environment.SetEnvironmentVariable(RunnerOptions.BindAddressEnvironmentVariable, null);
+        Environment.SetEnvironmentVariable(RunnerOptions.DefaultShellEnvironmentVariable, null);
+    }
+
+    [Fact]
+    public void DefaultsKeepRunnerLocalAndCorsClosed()
+    {
+        var options = new RunnerOptions();
+
+        Assert.Equal("127.0.0.1", options.BindAddress);
+        Assert.Empty(options.AllowedOrigins);
+    }
+
+    [Fact]
+    public void ApplyEnvironmentOverrides_AllowsExplicitLanBindOptIn()
+    {
+        Environment.SetEnvironmentVariable(RunnerOptions.BindAddressEnvironmentVariable, "0.0.0.0");
+        var options = new RunnerOptions();
+
+        RunnerOptions.ApplyEnvironmentOverrides(options);
+
+        Assert.Equal("0.0.0.0", options.BindAddress);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(RunnerOptions.WorkspaceEnvironmentVariable, _workspaceRoot);
+        Environment.SetEnvironmentVariable(RunnerOptions.PortEnvironmentVariable, _port);
+        Environment.SetEnvironmentVariable(RunnerOptions.BindAddressEnvironmentVariable, _bindAddress);
+        Environment.SetEnvironmentVariable(RunnerOptions.DefaultShellEnvironmentVariable, _defaultShell);
+    }
+}

--- a/AgentDeck.Runner/Configuration/RunnerOptions.cs
+++ b/AgentDeck.Runner/Configuration/RunnerOptions.cs
@@ -6,6 +6,7 @@ public sealed class RunnerOptions
     public const string SectionName = "Runner";
     public const string WorkspaceEnvironmentVariable = "AGENTDECK_WORKSPACE";
     public const string PortEnvironmentVariable = "AGENTDECK_PORT";
+    public const string BindAddressEnvironmentVariable = "AGENTDECK_BIND_ADDRESS";
     public const string DefaultShellEnvironmentVariable = "AGENTDECK_DEFAULT_SHELL";
 
     /// <summary>Root directory under which new project directories are created. Defaults to ~/AgentDeck if not set.</summary>
@@ -15,8 +16,11 @@ public sealed class RunnerOptions
     /// <summary>Port the Kestrel server listens on. Default 5000.</summary>
     public int Port { get; set; } = 5000;
 
-    /// <summary>Origins allowed for CORS. Use ["*"] for development.</summary>
-    public string[] AllowedOrigins { get; set; } = ["*"];
+    /// <summary>Address the Kestrel server listens on. Defaults to loopback; use 0.0.0.0 or a LAN IP only when intentionally exposing the runner.</summary>
+    public string BindAddress { get; set; } = "127.0.0.1";
+
+    /// <summary>Origins allowed for browser CORS. Empty denies browser origins; use ["*"] only for explicit development scenarios.</summary>
+    public string[] AllowedOrigins { get; set; } = [];
 
     /// <summary>Default shell command when no command is specified in CreateTerminalRequest. Auto-detected from OS if null.</summary>
     public string? DefaultShell { get; set; }
@@ -38,6 +42,10 @@ public sealed class RunnerOptions
 
             options.Port = port;
         }
+
+        var bindAddress = Environment.GetEnvironmentVariable(BindAddressEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(bindAddress))
+            options.BindAddress = bindAddress.Trim();
 
         var defaultShell = Environment.GetEnvironmentVariable(DefaultShellEnvironmentVariable);
         if (!string.IsNullOrWhiteSpace(defaultShell))

--- a/AgentDeck.Runner/Dockerfile
+++ b/AgentDeck.Runner/Dockerfile
@@ -30,9 +30,9 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/agentdeck \
     && rm -rf /var/lib/apt/lists/*
 
-ENV ASPNETCORE_URLS=http://0.0.0.0:5000
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV AGENTDECK_WORKSPACE=/workspace
+ENV AGENTDECK_BIND_ADDRESS=0.0.0.0
 
 EXPOSE 5000
 VOLUME ["/workspace"]

--- a/AgentDeck.Runner/Program.cs
+++ b/AgentDeck.Runner/Program.cs
@@ -31,17 +31,32 @@ builder.Services.AddOptions<TrustPolicyOptions>()
 builder.Services.AddOptions<RunnerLocalSecurityPolicyOptions>()
     .Bind(builder.Configuration.GetSection(RunnerLocalSecurityPolicyOptions.SectionName));
 
-builder.WebHost.UseUrls($"http://0.0.0.0:{runnerOptions.Port}");
+builder.WebHost.UseUrls($"http://{runnerOptions.BindAddress}:{runnerOptions.Port}");
 
 builder.Services.AddCors(cors => cors.AddDefaultPolicy(policy =>
 {
-    if (runnerOptions.AllowedOrigins is ["*"])
+    var allowedOrigins = runnerOptions.AllowedOrigins
+        .Where(static origin => !string.IsNullOrWhiteSpace(origin))
+        .Select(static origin => origin.Trim())
+        .ToArray();
+
+    if (allowedOrigins is ["*"])
+    {
         policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
-    else
-        policy.WithOrigins(runnerOptions.AllowedOrigins)
+    }
+    else if (allowedOrigins.Length > 0)
+    {
+        policy.WithOrigins(allowedOrigins)
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();
+    }
+    else
+    {
+        policy.SetIsOriginAllowed(static _ => false)
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    }
 }));
 
 builder.Services.AddSignalR(opts =>

--- a/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
+++ b/AgentDeck.Runner/Services/RunnerUpdateApplyWorker.cs
@@ -242,7 +242,7 @@ internal static class RunnerUpdateApplyWorker
         var root = document.RootElement;
         var overlay = new Dictionary<string, object?>();
 
-        CopySectionProperties(root, overlay, "Runner", ["WorkspaceRoot", "Port", "AllowedOrigins"]);
+        CopySectionProperties(root, overlay, "Runner", ["WorkspaceRoot", "Port", "BindAddress", "AllowedOrigins"]);
         CopySectionProperties(root, overlay, "Coordinator",
         [
             "MachineId",

--- a/AgentDeck.Runner/appsettings.json
+++ b/AgentDeck.Runner/appsettings.json
@@ -2,7 +2,8 @@
   "Runner": {
     "WorkspaceRoot": "",
     "Port": 5000,
-    "AllowedOrigins": ["*"]
+    "BindAddress": "127.0.0.1",
+    "AllowedOrigins": []
   },
   "DesktopViewerTransport": {
     "Managed": {

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cd AgentDeck.Coordinator
 dotnet run
 ```
 
-The coordinator starts on `http://localhost:5001` by default.
+The coordinator starts on `http://localhost:5001` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Use `AGENTDECK_COORDINATOR_PORT` and `AGENTDECK_COORDINATOR_BIND_ADDRESS` to override those startup defaults; for example, set `AGENTDECK_COORDINATOR_BIND_ADDRESS=0.0.0.0` only when you intend to expose the coordinator to other devices on a trusted network.
 
 ### Running the Runner
 
@@ -118,10 +118,13 @@ cd AgentDeck.Runner
 dotnet run
 ```
 
-The runner starts on `http://localhost:5000` by default. Use these environment variables to override its runtime defaults:
+The runner starts on `http://localhost:5000` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Browser CORS origins are denied by default; configure `AllowedOrigins` only for trusted companion origins, or use `["*"]` for local development experiments.
+
+Use these environment variables to override runtime defaults:
 
 - `AGENTDECK_WORKSPACE` sets the workspace root (defaults to `~/AgentDeck`)
 - `AGENTDECK_PORT` sets the HTTP port (defaults to `5000`)
+- `AGENTDECK_BIND_ADDRESS` sets the listening address (defaults to `127.0.0.1`; use `0.0.0.0` only for intentional LAN/container exposure)
 - `AGENTDECK_DEFAULT_SHELL` sets the default shell command
 
 The companion now starts with an empty coordinator URL plus auto-connect disabled by default. Configure a network-reachable coordinator explicitly instead of assuming `localhost`, which is only valid when the coordinator is actually running on the same device as the client.
@@ -147,7 +150,7 @@ docker run --rm \
   agentdeck-runner
 ```
 
-The image exposes port `5000`, defaults the workspace to `/workspace`, sets `ASPNETCORE_ENVIRONMENT=Production` so detailed error responses are off, and falls back to `/bin/sh` if `/bin/bash` is unavailable. Override with `-e ASPNETCORE_ENVIRONMENT=Development` if you want development-only diagnostics (verbose SignalR errors, dev-only middleware, etc.) — never in a deployment exposed to untrusted networks.
+The image exposes port `5000`, defaults the workspace to `/workspace`, explicitly sets `AGENTDECK_BIND_ADDRESS=0.0.0.0` so Docker port publishing works, sets `ASPNETCORE_ENVIRONMENT=Production` so detailed error responses are off, and falls back to `/bin/sh` if `/bin/bash` is unavailable. Override with `-e ASPNETCORE_ENVIRONMENT=Development` if you want development-only diagnostics (verbose SignalR errors, dev-only middleware, etc.) — never in a deployment exposed to untrusted networks.
 
 The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
 
@@ -186,6 +189,7 @@ Coordinator configuration (`AgentDeck.Coordinator/appsettings.json`):
 {
   "Coordinator": {
     "Port": 5001,
+    "BindAddress": "127.0.0.1",
     "PublicBaseUrl": "http://localhost:5001",
     "DesiredRunnerVersion": "0.1.0-dev",
     "MinimumSupportedProtocolVersion": 1,
@@ -225,7 +229,8 @@ Runner configuration (`AgentDeck.Runner/appsettings.json`):
   "Runner": {
     "WorkspaceRoot": "/workspace",
     "Port": 5000,
-    "AllowedOrigins": ["*"]
+    "BindAddress": "127.0.0.1",
+    "AllowedOrigins": []
   },
   "DesktopViewerTransport": {
     "Managed": {


### PR DESCRIPTION
Closes #414.

## Audit checklist summary

### Implemented / evidence
- Private/local control-plane direction is documented in `README.md` and issue #373.
- Coordinator exists as the local hub/broker for companions and runners (`AgentDeck.Coordinator/Program.cs`, coordinator hubs/services).
- Runner exposes terminal, setup/capability, update, workflow-pack, orchestration, and managed viewer surfaces (`AgentDeck.Runner/Endpoints`, `TerminalSessionService`, `MachineCapabilityService`, `MachineSetupService`, `RunnerUpdateStagingService`, `RunnerWorkflowPackService`, `OrchestrationExecutionService`, `ManagedViewerRelayService`).
- Companion/Core UI exposes projects, machines, settings, terminals, project sessions, and viewers (`AgentDeck.Core/Pages`, `AgentDeck.Core/Services`).
- Multi-machine registration/discovery, project launch orchestration, managed viewer relay, and controller/viewer collaboration semantics are present.

### Material gaps found
- Feasible now: default service exposure was too broad for the local/private control-plane goal. Coordinator and runner bound HTTP to all interfaces by default, and runner CORS allowed every origin by default.
- Deferred / owner-input required: shared auth primitive, TLS/cert setup, durable coordinator persistence, terminal/workflow allowlist policy, broader signed executable catalog enforcement, richer native child-window inventory, and extensible user-managed workflow/launch models.

## Implemented in this pass

- Coordinator now defaults to `127.0.0.1` binding, with `Coordinator:BindAddress` plus `AGENTDECK_COORDINATOR_BIND_ADDRESS`/`AGENTDECK_COORDINATOR_PORT` explicit opt-ins.
- Runner now defaults to `127.0.0.1` binding and keeps LAN exposure behind `Runner:BindAddress` or `AGENTDECK_BIND_ADDRESS`.
- Runner browser CORS is now closed by default (`AllowedOrigins: []`); explicit trusted origins or `["*"]` remain opt-in.
- Runner update migration preserves legacy `Runner:BindAddress` when creating user-settings overlays.
- Docker runner image explicitly sets `AGENTDECK_BIND_ADDRESS=0.0.0.0` so container port publishing remains functional.
- README/config docs now describe loopback defaults, LAN opt-in, CORS behavior, and Docker exposure.
- Added runner option tests for local-by-default and explicit LAN bind override.

## Deferred / blocked

- Auth/TLS/trust identity: needs owner-approved protocol and certificate/setup decisions before implementation.
- Durable coordinator storage: needs storage model decision.
- Terminal/workflow allowlist defaults: needs policy decision to avoid breaking flexible local-agent workflows.
- Broader catalog/signing enforcement and extensible workflow/launch models: larger follow-up work beyond this coherent readiness pass.

## Validation

- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore` ✅
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore` ✅
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build` ✅ (10 passed)
