### PR TITLE
fix: polish setup and workspace recovery UX

### DIFF
--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -105,11 +105,14 @@
                     <ErrorContent Context="exception">
                         <div class="app-error-backdrop">
                             <div class="app-error-modal">
-                                <h2>Application error</h2>
-                                <p>The app hit an unhandled exception. The full stack trace is below.</p>
-                                <pre class="app-error-stacktrace">@exception.ToString()</pre>
+                                <h2>Something went wrong</h2>
+                                <p>AgentDeck hit a problem on this screen. Try reloading the app; if it keeps happening, copy the technical details for support.</p>
+                                <details class="advanced-panel advanced-panel--compact">
+                                    <summary>Technical details</summary>
+                                    <pre class="app-error-stacktrace">@exception.ToString()</pre>
+                                </details>
                                 <div class="modal__footer">
-                                    <button class="btn btn-accent" @onclick="RecoverFromError">Dismiss modal</button>
+                                    <button class="btn btn-accent" @onclick="RecoverFromError">Close message</button>
                                     <button class="btn btn-primary" @onclick="ReloadApp">Reload app</button>
                                 </div>
                             </div>

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -344,7 +344,7 @@
         }
 
         return _dashboard.Projects.Count == 0
-            ? "Paste a GitHub URL or choose a template. You can keep advanced launch profile details collapsed."
+            ? "Paste a GitHub URL or choose a template. You can keep advanced run-option details collapsed."
             : "Pick up where you left off or open a project on a ready machine.";
     }
 

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -299,8 +299,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Live orchestration jobs</h2>
-                        <p>Real runner-backed run and debug jobs, including session IDs, viewer links, and current lifecycle state.</p>
+                        <h2>Live runs</h2>
+                        <p>Recent run/debug activity for this workspace, including terminal links, remote screens, and current status.</p>
                     </div>
                 </div>
 
@@ -309,8 +309,8 @@
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▶</div>
                         <h3>No run or debug jobs yet</h3>
-                        <p>Queue a run/debug profile to see job progress, logs, sessions, and viewer links here.</p>
-                        <a class="btn btn-primary" href="#run-debug">Choose a run profile</a>
+                        <p>Choose a run option to see progress, logs, sessions, and remote-screen links here.</p>
+                        <a class="btn btn-primary" href="#run-debug">Choose a run option</a>
                     </div>
                 }
                 else
@@ -366,8 +366,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Viewer session entry points</h2>
-                        <p>Remote screens created by runs and debug sessions. AgentDeck routes them safely through the app connection.</p>
+                        <h2>Remote screens</h2>
+                        <p>Remote screens created by workspace runs and debug sessions. AgentDeck routes them safely through the app connection.</p>
                     </div>
                 </div>
 
@@ -375,8 +375,8 @@
                 {
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">◫</div>
-                        <h3>No viewer sessions yet</h3>
-                        <p>Open a desktop or launch a profile with a remote surface to see viewer links and control status here.</p>
+                        <h3>No remote screens yet</h3>
+                        <p>Open a desktop or launch a run option with a remote screen to see links and control status here.</p>
                         <div class="setup-checklist__actions">
                             <a class="btn btn-primary" href="#workspace-machines">Open desktop</a>
                             <a class="btn btn-accent" href="#run-debug">Run or debug</a>
@@ -502,7 +502,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Live sessions</h2>
-                        <p>Each project session becomes a tab container for terminals and future VS Code, simulator, emulator, and viewer surfaces.</p>
+                        <p>Each workspace session groups terminals, remote screens, and future VS Code, simulator, or emulator surfaces.</p>
                     </div>
                 </div>
 
@@ -511,7 +511,7 @@
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▣</div>
                         <h3>No live sessions yet</h3>
-                        <p>Open this workspace on a runner or queue a run/debug profile to create the first live session.</p>
+                        <p>Open this workspace on a machine or choose a run option to create the first live session.</p>
                         <div class="setup-checklist__actions">
                             <a class="btn btn-primary" href="#workspace-machines">Open workspace</a>
                             <a class="btn btn-accent" href="#run-debug">Run or debug</a>
@@ -526,7 +526,7 @@
                             <a class="project-session-card project-session-card--link" href="/project-sessions/@Uri.EscapeDataString(session.Id)">
                                 <div class="project-session-card__header">
                                     <div>
-                                        <h3>@(session.MachineName ?? "Coordinator session")</h3>
+                                        <h3>@(session.MachineName ?? "Workspace session")</h3>
                                         <p>@GetControllerSummary(session)</p>
                                     </div>
                                     <span class="machine-badge">@session.Surfaces.Count tabs</span>
@@ -822,14 +822,14 @@
         var machineId = GetSelectedMachineId(profile, availableMachines);
         if (string.IsNullOrWhiteSpace(machineId))
         {
-            Toasts.Show("Select a machine before launching this profile.", ToastKind.Warning);
+            Toasts.Show("Select a machine before launching this run option.", ToastKind.Warning);
             return;
         }
 
         var machine = GetMachine(machineId);
         if (machine is null || !CanOpenProjectOnMachine(machine) || !MachineSupportsProfile(machine, profile))
         {
-            Toasts.Show("That machine is not currently eligible for this launch profile's required viewer surfaces.", ToastKind.Warning);
+            Toasts.Show("That machine is not currently eligible for this run option's required remote screens.", ToastKind.Warning);
             return;
         }
 
@@ -1055,7 +1055,7 @@
         var selectedValue = GetSelectedDeviceChoice(profile, GetDeviceChoices(profile, machineId));
         if (string.IsNullOrWhiteSpace(selectedValue) || profile.DeviceCatalog is null)
         {
-            throw new InvalidOperationException("Select a device or profile before launching this target.");
+            throw new InvalidOperationException("Select a device before launching this run option.");
         }
 
         var selection = selectedValue.StartsWith("device:", StringComparison.OrdinalIgnoreCase)
@@ -1210,7 +1210,7 @@
     private string GetMachineStatusMessage(ProjectLaunchProfile profile, int machineCount) =>
         machineCount == 0
             ? GetUnavailableMachineStatusMessage(profile)
-            : $"{machineCount} ready machine(s) can host this profile and expose its required viewer surfaces.";
+            : $"{machineCount} ready machine(s) can host this run option and expose its required remote screens.";
 
     private string GetDeviceStatusMessage(ProjectLaunchProfile profile, string? machineId, int deviceChoiceCount)
     {
@@ -1238,7 +1238,7 @@
 
         return requiredTargets.Length == 0
             ? null
-            : $"Required viewer surfaces: {string.Join(", ", requiredTargets)}.";
+            : $"Required remote screens: {string.Join(", ", requiredTargets)}.";
     }
 
     private static string GetRequiredViewerSurfaceSummary(ProjectLaunchProfile profile)
@@ -1248,7 +1248,7 @@
             .ToArray();
 
         return requiredTargets.Length == 0
-            ? "required viewer surfaces"
+            ? "required remote screens"
             : string.Join(", ", requiredTargets);
     }
 
@@ -1380,12 +1380,12 @@
 
         if (incompatibleCount > 0)
         {
-            return $"No protocol-compatible machine currently advertises {profile.Platform} with {viewerSurfaceSummary}. {incompatibleCount} matching machine(s) are blocked by protocol compatibility.";
+            return $"No compatible machine currently advertises {profile.Platform} with {viewerSurfaceSummary}. {incompatibleCount} matching machine(s) need an AgentDeck compatibility update.";
         }
 
         if (missingViewerSurfaceCount > 0)
         {
-            return $"No ready machine currently advertises {profile.Platform} with {viewerSurfaceSummary}. {missingViewerSurfaceCount} matching machine(s) are missing at least one required viewer surface.";
+            return $"No ready machine currently advertises {profile.Platform} with {viewerSurfaceSummary}. {missingViewerSurfaceCount} matching machine(s) are missing at least one required remote screen.";
         }
 
         return $"No ready machine currently advertises {profile.Platform}.";

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -173,7 +173,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Ways to run this workspace</h2>
-                        <p>Most projects only need one default run profile. Open advanced details to tune commands, devices, or VS Code behavior.</p>
+                        <p>Most workspaces only need one default run option. Open advanced details to tune commands, devices, or VS Code behavior.</p>
                     </div>
                     <button class="btn btn-accent" disabled="@_saving" @onclick="AddProfile">Add run option</button>
                 </div>
@@ -329,7 +329,7 @@
                     <div class="dashboard-section-card__header">
                         <div>
                             <h2>Existing workspaces</h2>
-                            <p>Workspace mappings stay attached to the project when you save metadata/profile changes.</p>
+                            <p>Saved machine paths stay attached to the workspace when you update details or run options.</p>
                         </div>
                     </div>
 
@@ -365,7 +365,7 @@
     private static readonly VirtualDeviceCatalogKind[] DeviceCatalogOptions = Enum.GetValues<VirtualDeviceCatalogKind>();
     private static readonly SimpleProjectTemplate[] SimpleTemplates =
     [
-        new("Blazor app", "Web app with a browser-friendly run profile", ProjectWorkloadKind.Blazor, "dotnet build", "dotnet run"),
+        new("Blazor app", "Web app with a browser-friendly run option", ProjectWorkloadKind.Blazor, "dotnet build", "dotnet run"),
         new(".NET MAUI app", "Mobile/desktop app with simulator and device targets", ProjectWorkloadKind.Maui, "dotnet build", "dotnet build"),
         new("Blank workspace", "Start with a generic shell and fill commands later", ProjectWorkloadKind.Blazor, "echo Ready", null, AllowBlankSource: true)
     ];
@@ -928,8 +928,8 @@
             return template is null
                 ? new ProjectLaunchProfileEditor
                 {
-                    Id = $"{workload.ToString().ToLowerInvariant()}-profile-{index}",
-                    DisplayName = $"Launch profile {index}",
+                    Id = $"{workload.ToString().ToLowerInvariant()}-run-{index}",
+                    DisplayName = $"Run option {index}",
                     Platform = defaultTarget.Platform,
                     Mode = ProjectLaunchMode.Run,
                     LaunchDriver = ProjectLaunchDriver.DirectCommand,

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -15,7 +15,7 @@
         <div class="project-page__content">
             <div class="empty-state">
                 <div class="empty-icon">◌</div>
-                <h2>Loading project session</h2>
+                <h2>Loading workspace session</h2>
             </div>
         </div>
     }
@@ -24,7 +24,7 @@
         <div class="project-page__content">
             <div class="empty-state">
                 <div class="empty-icon">⌂</div>
-                <h2>Project session not found</h2>
+                <h2>Workspace session not found</h2>
                 <p>Return to the <a href="/">dashboard</a> to choose another session.</p>
             </div>
         </div>
@@ -127,8 +127,8 @@
                         @if (_surfaceTabs.Count == 0)
                         {
                             <h3>No surfaces open yet</h3>
-                            <p>Open this workspace or run/debug a profile from the project page to create terminals, viewers, jobs, and other surfaces.</p>
-                            <a class="btn btn-primary" href="/projects/@Uri.EscapeDataString(_projectSession.ProjectId)">Open project actions</a>
+                            <p>Open this workspace or choose a run option from the workspace page to create terminals, remote screens, jobs, and other live items.</p>
+                            <a class="btn btn-primary" href="/projects/@Uri.EscapeDataString(_projectSession.ProjectId)">Open workspace actions</a>
                         }
                         else
                         {
@@ -225,7 +225,7 @@
                         }
                         else if (_activeSurface.Job is not null || _activeSurface.Viewer is not null)
                         {
-                            <p class="surface-details-card__note">This runtime tab is derived from the current machine orchestration/viewer state for this project session.</p>
+                            <p class="surface-details-card__note">This live item reflects the current machine job and remote-screen state for this workspace session.</p>
                         }
                         @if (_activeSurface.Viewer is not null && CanControlActiveViewer())
                         {
@@ -555,7 +555,7 @@
         }
 
         return IsController()
-            ? "You control this project session"
+            ? "You control this workspace session"
             : $"View-only while {_projectSession.CompanionId} controls this session";
     }
 
@@ -661,22 +661,22 @@
 
         if (_sessionMachine.WorkflowPackStatus?.State == RunnerWorkflowPackState.Failed)
         {
-            return "The host runner's assigned workflow pack last failed.";
+            return "This machine's assigned tool pack last failed.";
         }
 
         if (_sessionMachine.WorkflowPackStatus?.State == RunnerWorkflowPackState.Blocked)
         {
-            return "The host runner's assigned workflow pack is currently blocked.";
+            return "This machine's assigned tool pack is currently blocked.";
         }
 
         if (_sessionMachine.UpdateRollout is { State: RunnerUpdateRolloutState.Blocked })
         {
-            return "Host runner update rollout is currently blocked.";
+            return "This machine's update is currently blocked.";
         }
 
         if (_sessionMachine.UpdateRollout is { State: RunnerUpdateRolloutState.Failed })
         {
-            return "Host runner update rollout last failed.";
+            return "This machine's update last failed.";
         }
 
         return null;
@@ -855,7 +855,7 @@
         }
         catch (Exception ex)
         {
-            return $"Project-session control updated, but syncing viewer control for {viewer.Target.DisplayName} failed: {ex.Message}";
+            return $"Workspace control updated, but syncing remote-screen control for {viewer.Target.DisplayName} failed: {ex.Message}";
         }
     }
 

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -99,7 +99,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Session details</h2>
-                        <p>Coordinator-managed viewer metadata for this live relay session.</p>
+                        <p>Technical details for this live remote-screen connection.</p>
                     </div>
                 </div>
                 <dl class="surface-details-list">
@@ -437,7 +437,7 @@
 
         if (!ViewerClient.SupportsInAppViewer)
         {
-            return "This viewer is not using the managed relay transport required for in-app viewing.";
+            return "This remote screen is not using the managed transport required for in-app viewing.";
         }
 
         return ViewerClient.StatusMessage;

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -36,7 +36,7 @@
                     @(_registeredMachinesBusy ? "Refreshing..." : "Refresh machines")
                 </button>
                 <button class="btn btn-danger" @onclick="ClearCoordinatorDirectory" disabled="@(!_coordinatorReachable && _registeredMachines.Count == 0 && _registeredMachinesErrorMessage is null)">
-                    Clear Status
+                    Clear status
                 </button>
             </div>
         </div>
@@ -156,7 +156,7 @@
                 <p class="settings-card__description">Create new runner capacity, connect existing machines, and choose your default place to open work.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
-                <button class="btn btn-accent" @onclick="AddMachine">Add Machine</button>
+                <button class="btn btn-accent" @onclick="AddMachine">Add machine</button>
                 <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
                     @(_saving ? "Saving..." : "Save")
                 </button>
@@ -300,19 +300,19 @@
             {
                 <div class="machine-editor machine-editor--settings">
                     <div class="form-field">
-                        <label for="machine-name">Machine Name</label>
+                        <label for="machine-name">Machine name</label>
                         <input id="machine-name" type="text" class="input" @bind="SelectedMachine.Name" />
                     </div>
 
                     <div class="form-field">
-                        <label for="runner-url">Advertised Runner URL</label>
+                        <label for="runner-url">Advertised runner URL</label>
                         <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
                                placeholder="@GetRunnerUrlPlaceholder()" />
                         <p class="settings-card__description">Informational only. The companion does not connect directly to this URL.</p>
                     </div>
 
                     <div class="form-field">
-                        <label for="machine-role">Machine Role</label>
+                        <label for="machine-role">Machine role</label>
                         <select id="machine-role" class="input" @bind="SelectedMachine.Role">
                             @foreach (var role in _machineRoles)
                             {
@@ -331,7 +331,7 @@
 
                     <div class="form-actions form-actions--settings">
                         <button class="btn btn-accent" @onclick="() => SetPreferredMachine(SelectedMachine.Id)">
-                            Make Default For New Terminals
+                            Use for new terminals
                         </button>
 
                         @if (Connections.GetConnectionState(SelectedMachine.Id) == HubConnectionState.Connected)
@@ -348,7 +348,7 @@
                         <button class="btn btn-danger"
                                 @onclick="() => DeleteMachineAsync(SelectedMachine.Id)"
                                 disabled="@(_settings.Machines.Count == 1)">
-                            Delete Machine
+                            Delete machine
                         </button>
                     </div>
                 </div>
@@ -362,13 +362,13 @@
             <div id="runner-updates" class="settings-card settings-page__card settings-card--status settings-card--anchored">
                 <div class="settings-card__header settings-page__section-header">
                     <div>
-                        <h2>Runner Updates</h2>
-                        <p class="settings-card__description">Rollout intent, catalog reconciliation, and current state for @SelectedMachine?.Name.</p>
+                        <h2>Runner updates</h2>
+                        <p class="settings-card__description">Stage or apply updates for @SelectedMachine?.Name, and see whether tool lists are in sync.</p>
                     </div>
                 </div>
                     <div class="settings-callout">
                         <strong>Update lane</strong>
-                        <span>Use this section when a runner advertises a desired manifest or workflow pack. General machine editing stays above; setup tools stay below.</span>
+                        <span>Use this section when AgentDeck has an update or tool pack ready for this machine. General machine editing stays above; setup tools stay below.</span>
                     </div>
                     <div class="settings-status-list">
                     <div class="settings-status-row">
@@ -380,7 +380,7 @@
                         <strong class="settings-status-row__value">@GetMachineRoleLabel(SelectedMachine!.Role)</strong>
                     </div>
                     <div class="settings-status-row">
-                        <span class="settings-status-row__label">Coordinator hub</span>
+                        <span class="settings-status-row__label">Connection hub</span>
                         <code class="settings-status-row__value">@GetHubUrl(SelectedMachine!)</code>
                     </div>
                     @if (SelectedRegisteredMachine?.UpdateRollout is { } rollout)
@@ -412,17 +412,17 @@
                             <button class="btn btn-accent"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.RequestApply)">
-                                Request Apply
+                                Apply update
                             </button>
                             <button class="btn btn-primary"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.StageOnly)">
-                                Stage Only
+                                Stage only
                             </button>
                             <button class="btn"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.Inherit)">
-                                Use Coordinator Default
+                                Use service default
                             </button>
                         </div>
                         @if (!string.IsNullOrWhiteSpace(rollout.BlockingReason))
@@ -464,7 +464,7 @@
                         @if (!string.IsNullOrWhiteSpace(SelectedRegisteredMachine?.DesiredWorkflowPackId))
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Desired workflow pack</span>
+                                <span class="settings-status-row__label">Desired tool pack</span>
                                 <span class="settings-status-row__value">@GetDesiredWorkflowPackLabel(SelectedRegisteredMachine)</span>
                             </div>
                         }
@@ -472,27 +472,27 @@
                              workflowPackStatus.State != RunnerWorkflowPackState.None)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Workflow pack state</span>
+                                <span class="settings-status-row__label">Tool pack state</span>
                                 <span class="settings-status-row__value">@GetWorkflowPackStateLabel(workflowPackStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(workflowPackStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Workflow pack summary</span>
+                                    <span class="settings-status-row__label">Tool pack summary</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.StatusMessage</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowPackStatus.FailureMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Workflow pack failure</span>
+                                    <span class="settings-status-row__label">Tool pack failure</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.FailureMessage</span>
                                 </div>
                             }
                             @if (workflowPackStatus.FetchedAt is not null)
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Workflow pack fetched</span>
+                                    <span class="settings-status-row__label">Tool pack fetched</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.FetchedAt.Value.ToLocalTime().ToString("g")</span>
                                 </div>
                             }
@@ -502,7 +502,7 @@
                                     <button class="btn btn-accent"
                                             disabled="@(_workflowPackRetryMachineId == SelectedMachine.Id)"
                                             @onclick="() => RetryWorkflowPackAsync(SelectedMachine.Id)">
-                                        @(_workflowPackRetryMachineId == SelectedMachine.Id ? "Retrying..." : "Retry workflow pack")
+                                        @(_workflowPackRetryMachineId == SelectedMachine.Id ? "Retrying..." : "Retry tool pack")
                                     </button>
                                 </div>
                             }
@@ -511,27 +511,27 @@
                              workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Workflow catalog state</span>
+                                <span class="settings-status-row__label">Tool catalog state</span>
                                 <span class="settings-status-row__value">@GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.LocalCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Local workflow catalog</span>
+                                    <span class="settings-status-row__label">Local tool catalog</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.LocalCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.DesiredCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Desired workflow catalog</span>
+                                    <span class="settings-status-row__label">Desired tool catalog</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.DesiredCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Workflow catalog summary</span>
+                                    <span class="settings-status-row__label">Tool catalog summary</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.StatusMessage</span>
                                 </div>
                             }
@@ -635,12 +635,12 @@
             <div id="setup-capabilities" class="settings-card settings-page__card settings-card--anchored">
                 <div class="settings-card__header settings-page__section-header">
                     <div>
-                        <h2>Setup &amp; Capabilities</h2>
-                        <p class="settings-card__description">Tool/SDK detection and setup actions for @SelectedMachine!.Name.</p>
+                        <h2>Tools and setup</h2>
+                        <p class="settings-card__description">Check installed tools and run setup actions for @SelectedMachine!.Name.</p>
                     </div>
                     <div class="form-actions form-actions--toolbar">
                         <button class="btn btn-accent" @onclick="RefreshMachineCapabilitiesAsync" disabled="@_capabilitiesBusy">
-                            Refresh Capabilities
+                            Check tools again
                         </button>
                     </div>
                 </div>
@@ -770,7 +770,7 @@
                                                     disabled="@(_capabilitiesBusy || IsCapabilityBusy(capability))">
                                                 @(IsCapabilityActionRunning(capability, "install")
                                                     ? "Installing..."
-                                                    : SupportsVersionSelection(capability) ? "Install Version" : "Install")
+                                                    : SupportsVersionSelection(capability) ? "Install version" : "Install")
                                             </button>
                                         }
 
@@ -792,7 +792,7 @@
                     @if (_lastCapabilityInstallResult is not null)
                     {
                         <div class="capability-install-result">
-                            <h3>Last Setup Action</h3>
+                            <h3>Last setup action</h3>
                             <p>
                                 <strong>@_lastCapabilityInstallResult.CapabilityName:</strong>
                                 @(GetCapabilityActionResultLabel(_lastCapabilityInstallResult))
@@ -811,12 +811,12 @@
                             }
                             @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardOutput))
                             {
-                                <h3>Standard Output</h3>
+                                <h3>Command output</h3>
                                 <pre class="command-preview">@_lastCapabilityInstallResult.StandardOutput</pre>
                             }
                             @if (!string.IsNullOrWhiteSpace(_lastCapabilityInstallResult.StandardError))
                             {
-                                <h3>Standard Error</h3>
+                                <h3>Command errors</h3>
                                 <pre class="command-preview">@_lastCapabilityInstallResult.StandardError</pre>
                             }
                         </div>
@@ -828,7 +828,7 @@
                 <div class="settings-card__header settings-page__section-header">
                     <div>
                         <h2>Advanced</h2>
-                        <p class="settings-card__description">Low-level coordinator and runner identifiers useful for debugging support issues.</p>
+                        <p class="settings-card__description">Low-level service and runner identifiers useful for debugging support issues.</p>
                     </div>
                 </div>
 
@@ -1065,8 +1065,8 @@
 
     private static string GetMachineRoleDescription(RunnerMachineRole role) => role switch
     {
-        RunnerMachineRole.Worker => "Use this machine as a remote worker agent that registers outward to the central coordinator API.",
-        _ => "Use this machine independently without assigning it to coordinator/worker orchestration yet."
+        RunnerMachineRole.Worker => "Use this machine as shared runner capacity that checks in with the AgentDeck service.",
+        _ => "Use this machine independently without assigning it to shared runner orchestration yet."
     };
 
     private static string GetHostPlatformLabel(RunnerHostPlatform platform) => platform switch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentDeck
 
-AgentDeck is a private local-network control plane for running AI-assisted development workflows across the machines you already own. It coordinates **Coordinator**, **Runner**, and **Companion/Core UI** pieces so a developer can choose projects, discover machine capabilities, launch terminals or app/debug workflows, and open managed viewer surfaces without manually juggling per-machine endpoints.
+AgentDeck is a private local-network app for running AI-assisted development workflows across the machines you already own. Start one AgentDeck service, connect one or more runner machines, then use the companion app to choose workspaces, discover machine capabilities, launch terminals or app/debug workflows, and open managed remote screens without manually juggling per-machine endpoints.
 
 ---
 
@@ -10,7 +10,7 @@ AgentDeck is being built to make it easy to:
 - connect multiple local machines into one developer workspace
 - discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and viewer transports
 - open a project on the best available runner for the requested workflow
-- launch terminals, app/debug workflows, and managed viewer surfaces from one UI
+- launch terminals, app/debug workflows, and managed remote screens from one UI
 - keep runner capabilities, workflow packs, setup catalogs, and runner updates coordinated from the local control plane
 - support collaboration semantics where one companion actively controls a session while other companions can observe or request control
 
@@ -75,21 +75,25 @@ A .NET MAUI + Blazor WebView shell plus shared Core UI that:
 
 From a fresh checkout, the fastest reliable path is:
 
-```bash
-dotnet restore AgentDeck.slnx
-dotnet run --project AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
-```
+1. Start the AgentDeck service:
 
-In a second terminal, start a Linux runner and register it with that coordinator. Coordinator registration uses .NET configuration environment keys with double underscores:
+   ```bash
+   dotnet restore AgentDeck.slnx
+   dotnet run --project AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
+   ```
 
-```bash
-Coordinator__CoordinatorUrl=http://localhost:5001 \
-Coordinator__MachineId=local-linux \
-Coordinator__MachineName="Local Linux" \
-dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj
-```
+2. In a second terminal, start a Linux runner and point it at that service. Registration uses .NET configuration environment keys with double underscores:
 
-Then run the companion for your platform and set the coordinator URL to `http://localhost:5001` in **Settings → Connection**. Use `localhost` only when the companion is on the same machine as the coordinator; phones/tablets should use a LAN-reachable host name or IP address.
+   ```bash
+   Coordinator__CoordinatorUrl=http://localhost:5001 \
+   Coordinator__MachineId=local-linux \
+   Coordinator__MachineName="Local Linux" \
+   dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj
+   ```
+
+3. Run the companion for your platform and paste the AgentDeck service URL in **Settings → Connection**.
+
+Use `http://localhost:5001` only when the companion is running on the same machine as the service. For a phone, tablet, VM, or another laptop, paste a LAN-reachable host name or IP address such as `http://192.168.1.25:5001`.
 
 Known-good local verification commands:
 


### PR DESCRIPTION
## Summary

Polishes the normal setup and workspace experience after a full UI/UX pass across the app and README.

## Changes

- Makes global crash recovery less alarming and hides stack traces behind technical details.
- Rewords Settings setup/update controls with sentence-case, user-facing labels.
- Replaces more project-session/profile/orchestration/viewer-surface wording in workspace screens with workspace, run option, live run, and remote-screen language.
- Updates the README quickstart to explain what to start first and which service URL to paste.

## Testing

- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`
- `git diff --check`

Fixes DapperMickie/AgentDeck#416