### PR TITLE
fix: polish dashboard and terminal UX copy

### DIFF
--- a/AgentDeck.Core/Components/NewTerminalDialog.razor
+++ b/AgentDeck.Core/Components/NewTerminalDialog.razor
@@ -4,7 +4,7 @@
 {
     <div class="modal-backdrop" @onclick="HandleBackdropClick">
         <div class="modal" @onclick:stopPropagation="true">
-            <h2 class="modal__title">New Terminal</h2>
+            <h2 class="modal__title">New terminal</h2>
 
             <div class="form-group">
                 <label class="form-label">Machine</label>
@@ -23,12 +23,12 @@
             </div>
 
             <div class="form-group">
-                <label class="form-label">Working Directory</label>
+                <label class="form-label">Working directory</label>
                 <DirectoryPicker Machine="SelectedMachine" @bind-Value="_workingDir" />
             </div>
 
             <div class="form-group">
-                <label class="form-label">CLI Preset</label>
+                <label class="form-label">Command preset</label>
                 <div class="preset-grid">
                     @foreach (var preset in _presets)
                     {
@@ -47,8 +47,8 @@
                     <label class="yolo-toggle">
                         <input type="checkbox" @bind="_yoloMode" />
                         <span class="yolo-toggle__label">
-                            <span class="yolo-toggle__title">⚡ Yolo mode</span>
-                            <span class="yolo-toggle__subtitle">Runs <code>copilot --yolo</code> — auto-approves all actions</span>
+                            <span class="yolo-toggle__title">⚡ Auto-approve Copilot actions</span>
+                            <span class="yolo-toggle__subtitle">Runs <code>copilot --yolo</code>. Use only in workspaces where you trust the changes.</span>
                         </span>
                     </label>
                 </div>
@@ -58,6 +58,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Command</label>
+                    <span class="form-hint">Enter the command to start when this terminal opens.</span>
                     <input class="form-input" type="text" @bind="_command" placeholder="e.g. dotnet test --filter MyTests" />
                 </div>
             }
@@ -143,7 +144,7 @@
         var cmd = ResolveCommandText();
         if (string.IsNullOrWhiteSpace(cmd))
         {
-            _error = "Command is required.";
+            _error = "Enter a command for the custom terminal preset.";
             return;
         }
 

--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -67,7 +67,7 @@
             {
                 <button class="nav-new-terminal" @onclick="OpenNewTerminal">
                     <span>＋</span>
-                    <span>New Terminal</span>
+                    <span>New terminal</span>
                 </button>
             }
 

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -66,15 +66,15 @@
         @if (!_dashboard.CoordinatorConfigured)
         {
             <section class="dashboard-section-card">
-                <h2>Coordinator required</h2>
-                <p>Connect AgentDeck in <a href="/settings">Settings</a> to load workspaces, machines, and open sessions.</p>
+                <h2>Connect the AgentDeck service</h2>
+                <p>Add the AgentDeck service URL in <a href="/settings">Settings</a> to load workspaces, machines, and open sessions.</p>
             </section>
         }
         else if (!_dashboard.CoordinatorReachable)
         {
             <section class="dashboard-section-card">
-                <h2>Coordinator unavailable</h2>
-                <p>@(_dashboard.CoordinatorErrorMessage ?? "The companion could not reach the configured coordinator.")</p>
+                <h2>AgentDeck service unavailable</h2>
+                <p>@(_dashboard.CoordinatorErrorMessage ?? "This companion could not reach the configured AgentDeck service.")</p>
             </section>
         }
         else
@@ -167,7 +167,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Workspaces</h2>
-                        <p>Import a repo, choose where it should run, and open a terminal or app surface.</p>
+                        <p>Import a repo, choose where it should run, and open terminals, apps, or remote screens.</p>
                     </div>
                     <a class="btn btn-primary" href="/projects/new">Import or create workspace</a>
                 </div>
@@ -177,7 +177,7 @@
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">＋</div>
                         <h3>No workspaces yet</h3>
-                        <p>Paste a GitHub URL or start from a template. Advanced project fields can wait.</p>
+                        <p>Paste a GitHub URL or start from a template. Advanced workspace details can wait.</p>
                         <a class="btn btn-primary" href="/projects/new">Create your first workspace</a>
                     </div>
                 }
@@ -233,8 +233,8 @@
             <section class="dashboard-section-card">
                 <div class="dashboard-section-card__header">
                     <div>
-                        <h2>Things AgentDeck can open</h2>
-                        <p>Terminals, desktops, app windows, VS Code, emulators, simulators, logs, and job output appear here when machines support them.</p>
+                        <h2>Available remote screens</h2>
+                        <p>Desktops, app windows, VS Code, emulators, simulators, logs, and job output appear here when machines support them.</p>
                     </div>
                 </div>
 
@@ -242,8 +242,8 @@
                 {
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▣</div>
-                        <h3>No openable surfaces yet</h3>
-                        <p>Create a workspace or add a run option to see terminals, desktops, app windows, emulators, and logs here.</p>
+                        <h3>No remote screens yet</h3>
+                        <p>Create a workspace or add a run option to see desktops, app windows, emulators, and logs here.</p>
                         <a class="btn btn-primary" href="/projects/new">Create or import a workspace</a>
                     </div>
                 }
@@ -415,7 +415,7 @@
             ? (_dashboard.CoordinatorUrl.Length > 48
                 ? $"{_dashboard.CoordinatorUrl[..48]}..."
                 : _dashboard.CoordinatorUrl)
-            : (_dashboard.CoordinatorErrorMessage ?? "Coordinator health check failed");
+            : (_dashboard.CoordinatorErrorMessage ?? "AgentDeck service health check failed");
     }
 
     private string GetMachineSummary()

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -179,7 +179,7 @@
                                     <button class="btn btn-danger"
                                             disabled="@(_viewerActionMachineId == machine.MachineId)"
                                             @onclick="() => CloseViewerAsync(machine.MachineId, remoteControlState.ViewerSessionId)">
-                                        Close viewer
+                                        Close remote screen
                                     </button>
                                 }
                             </div>
@@ -335,11 +335,11 @@
                                     <div class="project-machine-card__targets">
                                         @if (!string.IsNullOrWhiteSpace(job.SessionId))
                                         {
-                                            <span class="project-template-profile">Session @job.SessionId[..Math.Min(job.SessionId.Length, 8)]</span>
+                                            <span class="project-template-profile">Terminal @job.SessionId[..Math.Min(job.SessionId.Length, 8)]</span>
                                         }
                                         @if (!string.IsNullOrWhiteSpace(job.ViewerSessionId))
                                         {
-                                            <span class="project-template-profile">Viewer @job.ViewerSessionId[..Math.Min(job.ViewerSessionId.Length, 8)]</span>
+                                            <span class="project-template-profile">Remote screen @job.ViewerSessionId[..Math.Min(job.ViewerSessionId.Length, 8)]</span>
                                         }
                                         @if (job.DeviceSelection?.HasTarget == true)
                                         {
@@ -417,7 +417,7 @@
                                     {
                                         <button class="btn btn-accent"
                                                 @onclick="() => OpenViewerAsync(viewer)">
-                                            Open viewer
+                                            Open remote screen
                                         </button>
                                     }
                                     @if (!string.IsNullOrWhiteSpace(viewer.MachineId) && CanControlViewer(viewer))
@@ -434,7 +434,7 @@
                                             <button class="btn btn-danger"
                                                     disabled="@(_viewerActionViewerId == viewer.Id)"
                                                     @onclick="() => CloseViewerAsync(viewer.MachineId!, viewer.Id)">
-                                                Close viewer
+                                                Close remote screen
                                             </button>
                                         }
                                         else if (remoteControlState is not null && !IsCurrentRemoteController(remoteControlState))
@@ -465,7 +465,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Workspaces</h2>
-                        <p>Coordinator-known workspace mappings for this project.</p>
+                        <p>Saved machine folders for this workspace.</p>
                     </div>
                 </div>
 
@@ -474,8 +474,8 @@
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">⌂</div>
                         <h3>No machine workspace yet</h3>
-                        <p>Open this workspace on a runner to let AgentDeck prepare the project folder and remember where it lives.</p>
-                        <a class="btn btn-primary" href="#workspace-machines">Choose a runner</a>
+                        <p>Open this workspace on a machine to let AgentDeck prepare the folder and remember where it lives.</p>
+                        <a class="btn btn-primary" href="#workspace-machines">Choose a machine</a>
                     </div>
                 }
                 else
@@ -982,7 +982,7 @@
                 ProjectSessionControlRequestMode.Request => $"You now control {viewer.Target.DisplayName}.",
                 ProjectSessionControlRequestMode.ForceTakeover => $"You took control of {viewer.Target.DisplayName}.",
                 ProjectSessionControlRequestMode.Yield => $"Yielded control of {viewer.Target.DisplayName}.",
-                _ => "Updated viewer control."
+                _ => "Updated remote-screen control."
             }, mode == ProjectSessionControlRequestMode.Yield ? ToastKind.Info : ToastKind.Success);
             await LoadAsync();
         }

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -234,7 +234,7 @@
                                 {
                                     <button class="btn btn-accent"
                                             @onclick="() => OpenViewerAsync(_activeSurface.Viewer)">
-                                        Open viewer
+                                        Open remote screen
                                     </button>
                                 }
                                 @if (IsActiveViewerControlledByCurrentCompanion())
@@ -247,7 +247,7 @@
                                     <button class="btn btn-danger"
                                             disabled="@_viewerActionInProgress"
                                             @onclick="CloseActiveViewerAsync">
-                                        Close viewer
+                                        Close remote screen
                                     </button>
                                 }
                                 else if (HasAnotherCompanionControllingMachine())
@@ -934,7 +934,7 @@
                 ProjectSessionControlRequestMode.Request => $"You now control {_activeSurface.Viewer.Target.DisplayName}.",
                 ProjectSessionControlRequestMode.ForceTakeover => $"You took control of {_activeSurface.Viewer.Target.DisplayName}.",
                 ProjectSessionControlRequestMode.Yield => $"Yielded control of {_activeSurface.Viewer.Target.DisplayName}.",
-                _ => "Updated viewer control."
+                _ => "Updated remote-screen control."
             }, mode == ProjectSessionControlRequestMode.Yield ? ToastKind.Info : ToastKind.Success);
             await LoadAsync();
         }

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -65,7 +65,7 @@
                         <button class="btn btn-accent" @onclick="TakeControlAsync" disabled="@_busy">Take control</button>
                     }
                 }
-                <button class="btn btn-danger" @onclick="CloseViewerAsync" disabled="@_busy">Close viewer</button>
+                <button class="btn btn-danger" @onclick="CloseViewerAsync" disabled="@_busy">Close remote screen</button>
             </div>
         </div>
 

--- a/AgentDeck.Core/Pages/TerminalView.razor
+++ b/AgentDeck.Core/Pages/TerminalView.razor
@@ -41,14 +41,15 @@
                        @bind="_quickCommand"
                        @bind:event="oninput"
                        @onkeydown="OnQuickCommandKey" />
-                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("copilot")'>copilot</button>
-                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("copilot --yolo")'>copilot --yolo</button>
-                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("clear")'>clear</button>
-                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("exit")'>exit</button>
+                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("copilot")'>Copilot</button>
+                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("copilot --yolo")'>Copilot auto-approve</button>
+                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("clear")'>Clear</button>
+                <button class="command-bar__pill" disabled="@(!IsSessionRunning())" @onclick='() => SendQuickCommand("exit")'>Exit</button>
             </div>
             @if (!IsSessionRunning())
             {
-                <p class="project-template-target__note">This terminal has ended. Open a new terminal to send more commands.</p>
+                <p class="project-template-target__note">This terminal has ended. Go back to terminals to open a fresh one.</p>
+                <a class="btn btn-accent" href="/terminals">Open another terminal</a>
             }
 
             <div class="terminal-area terminal-area--single">

--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -35,13 +35,27 @@
                     }
                     else if (Connections.ConnectedMachineCount == 0)
                     {
-                        <span>Create or connect a runner in <a href="/settings">Settings</a> to open a terminal.</span>
+                        <span>Create or connect a runner in Settings to open a terminal.</span>
                     }
                     else
                     {
                         <span>Tap <strong>New terminal</strong> to create your first terminal.</span>
                     }
                 </p>
+                <div class="setup-checklist__actions">
+                    @if (SessionState.Sessions.Count > 0)
+                    {
+                        <a class="btn btn-primary" href="/">Open dashboard</a>
+                    }
+                    else if (Connections.ConnectedMachineCount == 0)
+                    {
+                        <a class="btn btn-primary" href="/settings#machines">Create or connect a runner</a>
+                    }
+                    else
+                    {
+                        <button class="btn btn-primary" @onclick="OpenNewTerminal">New terminal</button>
+                    }
+                </div>
             </div>
         </div>
     }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ AgentDeck is a private local-network app for running AI-assisted development wor
 
 AgentDeck is being built to make it easy to:
 - connect multiple local machines into one developer workspace
-- discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and viewer transports
+- discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and remote-screen transports
 - open a project on the best available runner for the requested workflow
 - launch terminals, app/debug workflows, and managed remote screens from one UI
-- keep runner capabilities, workflow packs, setup catalogs, and runner updates coordinated from the local control plane
-- support collaboration semantics where one companion actively controls a session while other companions can observe or request control
+- keep runner tools, setup catalogs, and runner updates coordinated from the local AgentDeck service
+- support collaboration where one companion controls a session while other companions can observe or request control
 
 ## Non-goals for Now
 


### PR DESCRIPTION
## Summary

Polishes dashboard setup language, terminal flows, workspace detail labels, and remaining remote-screen product copy after a full UI/UX review.

## Changes

- Rewords dashboard service connection failures away from internal Coordinator language.
- Replaces normal-path surface/viewer/project wording with workspace, remote-screen, and AgentDeck service language.
- Improves standalone terminal empty states with direct actions.
- Makes the new terminal dialog more user-facing and clarifies Copilot auto-approval risk.
- Polishes terminal quick-action labels and ended-terminal recovery.
- Updates README product bullets for remote-screen/service language.

## Testing

- `dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore`
- `dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore`
- `dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build`
- `git diff --check`

Fixes DapperMickie/AgentDeck#418