### PR TITLE
Polish workspace setup language

### DIFF
--- a/AgentDeck.Core/Components/DirectoryPicker.razor
+++ b/AgentDeck.Core/Components/DirectoryPicker.razor
@@ -50,7 +50,7 @@
         catch (Exception ex)
         {
             _workspace = null;
-            _errorMessage = $"Failed to load workspace folders from {Machine.Name}: {ex.Message}";
+            _errorMessage = $"Couldn’t load workspace folders from {Machine.Name}: {ex.Message}";
         }
     }
 

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -92,8 +92,8 @@
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▣</div>
                         <h3>No machines yet</h3>
-                        <p>Create a runner from Settings, or start one with the quickstart command in the README.</p>
-                        <a class="btn btn-primary" href="/settings">Create or connect a runner</a>
+                        <p>Create or connect a machine from Settings, or start one with the quickstart command in the README.</p>
+                        <a class="btn btn-primary" href="/settings">Create or connect a machine</a>
                     </div>
                 }
                 else
@@ -287,8 +287,8 @@
 
     private string GetProjectSessionControllerLabel(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.CompanionId)
-            ? "No controller companion recorded"
-            : $"Controller {session.CompanionId}";
+            ? "No active controller recorded"
+            : $"Controlled by {session.CompanionId}";
 
     private IEnumerable<SetupStep> GetSetupSteps()
     {
@@ -298,9 +298,9 @@
             _dashboard.CoordinatorReachable ? "AgentDeck is connected." : "Connect AgentDeck so it can load workspaces and machines.",
             _dashboard.CoordinatorReachable ? "complete" : "todo");
         yield return new SetupStep(
-            "Create a runner",
+            "Create a machine",
             _dashboard.Machines.Any(machine => machine.IsOnline) ? "Done" : "Next",
-            _dashboard.Machines.Any(machine => machine.IsOnline) ? "At least one machine is online." : "Create or connect somewhere for projects to run.",
+            _dashboard.Machines.Any(machine => machine.IsOnline) ? "At least one machine is online." : "Create or connect a machine for workspaces to run.",
             _dashboard.Machines.Any(machine => machine.IsOnline) ? "complete" : "todo");
         yield return new SetupStep(
             "Verify tools",
@@ -323,7 +323,7 @@
 
         if (!_dashboard.Machines.Any(machine => machine.IsOnline))
         {
-            return "Create your first runner";
+            return "Create your first machine";
         }
 
         return _dashboard.Projects.Count == 0 ? "Import your first workspace" : "Resume or open a workspace";
@@ -340,7 +340,7 @@
 
         if (!_dashboard.Machines.Any(machine => machine.IsOnline))
         {
-            return "Use the runner templates in Settings to create capacity, or connect an existing runner. No raw IDs required.";
+            return "Use the machine templates in Settings to create capacity, or connect an existing machine. No raw IDs required.";
         }
 
         return _dashboard.Projects.Count == 0
@@ -355,7 +355,7 @@
 
     private string GetNextActionLabel() =>
         !_dashboard.CoordinatorReachable ? "Open connection setup" :
-        !_dashboard.Machines.Any(machine => machine.IsOnline) ? "Create or connect a runner" :
+        !_dashboard.Machines.Any(machine => machine.IsOnline) ? "Create or connect a machine" :
         _dashboard.Projects.Count == 0 ? "Import workspace" : "View workspaces";
 
     private static string GetMachineHealthLabel(CompanionMachineSummary machine)
@@ -386,12 +386,12 @@
                 : $"Ready for {readyTargets} target(s)";
         }
 
-        return setupTargets > 0 ? "Tools need setup before this machine can run projects" : "No supported project targets advertised yet";
+        return setupTargets > 0 ? "Tools need setup before this machine can open workspaces" : "No supported workspace targets advertised yet";
     }
 
     private static string GetProjectSessionLocationLabel(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.MachineName)
-            ? "Coordinator-managed session"
+            ? "Workspace service session"
             : $"Hosted on {session.MachineName}";
 
     private string GetCoordinatorSummary()

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -71,9 +71,9 @@
                 {
                     <div class="empty-state empty-state--actionable">
                         <div class="empty-icon">▣</div>
-                        <h3>No runner machines yet</h3>
-                        <p>Create or connect a runner in Settings, then return here to open this workspace.</p>
-                        <a class="btn btn-primary" href="/settings#machines">Create or connect a runner</a>
+                        <h3>No machines yet</h3>
+                        <p>Create or connect a machine in Settings, then return here to open this workspace.</p>
+                        <a class="btn btn-primary" href="/settings#machines">Create or connect a machine</a>
                     </div>
                 }
                 else
@@ -503,7 +503,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Live sessions</h2>
-                        <p>Each workspace session groups terminals, remote screens, and future VS Code, simulator, or emulator surfaces.</p>
+                        <p>Each workspace session groups terminals, remote screens, and future VS Code, simulator, or emulator tabs.</p>
                     </div>
                 </div>
 
@@ -530,7 +530,7 @@
                                         <h3>@(session.MachineName ?? "Workspace session")</h3>
                                         <p>@GetControllerSummary(session)</p>
                                     </div>
-                                    <span class="machine-badge">@session.Surfaces.Count tabs</span>
+                                    <span class="machine-badge">@session.Surfaces.Count open item(s)</span>
                                 </div>
                                 <p class="project-session-card__meta">@GetProjectSessionMeta(session)</p>
                             </a>
@@ -955,7 +955,7 @@
 
             Toasts.Show(
                 !string.IsNullOrWhiteSpace(session.ConnectionUri)
-                    ? $"Viewer ready: {session.ConnectionUri}"
+                    ? $"Remote screen ready: {session.ConnectionUri}"
                     : session.StatusMessage ?? $"Opened desktop remote screen on {machine.MachineName}.",
                 session.Status == RemoteViewerSessionStatus.Ready ? ToastKind.Success : ToastKind.Info);
             await LoadAsync();
@@ -1274,10 +1274,10 @@
 
     private string GetControllerSummary(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.CompanionId)
-            ? "No controller companion recorded"
+            ? "No one is controlling this workspace right now"
             : IsCurrentCompanionController(session)
-                ? "You control this session"
-                : $"Controller {session.CompanionId}";
+                ? "You control this workspace"
+                : $"Controlled by {session.CompanionId}";
 
     private string GetProjectSessionMeta(ProjectSessionRecord session)
     {
@@ -1430,7 +1430,7 @@
 
         if (machine.UpdateRollout is { State: RunnerUpdateRolloutState.Failed })
         {
-            return "The runner update last failed on this machine.";
+            return "The machine update last failed.";
         }
 
         return null;
@@ -1550,12 +1550,12 @@
 
         if (string.IsNullOrWhiteSpace(session.CompanionId))
         {
-            return $"Live session {GetShortId(session.Id)} exists on this machine, but no controller companion is currently recorded.";
+            return $"Live workspace {GetShortId(session.Id)} exists on this machine, but no one is controlling it right now.";
         }
 
         return IsCurrentCompanionController(session)
-            ? $"You control live session {GetShortId(session.Id)} on this machine."
-            : $"View-only while {session.CompanionId} controls live session {GetShortId(session.Id)} on this machine.";
+            ? $"You control live workspace {GetShortId(session.Id)} on this machine."
+            : $"View-only while {session.CompanionId} controls live workspace {GetShortId(session.Id)} on this machine.";
     }
 
     private ProjectSessionRecord? GetLatestProjectSessionForMachine(string? machineId) =>
@@ -1608,9 +1608,9 @@
 
     private static string GetPlatformLabel(RunnerHostPlatform platform) => platform switch
     {
-        RunnerHostPlatform.Windows => "Windows worker",
-        RunnerHostPlatform.Linux => "Linux worker",
-        RunnerHostPlatform.MacOS => "macOS worker",
+        RunnerHostPlatform.Windows => "Windows machine",
+        RunnerHostPlatform.Linux => "Linux machine",
+        RunnerHostPlatform.MacOS => "macOS machine",
         _ => "Unknown platform"
     };
 

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -38,7 +38,7 @@
         <div class="page-header project-editor__header">
             <div>
                 <h1>@(_isExistingProject ? "Edit workspace" : "Import workspace")</h1>
-                <p>Paste a repo, pick a template, and only open advanced launch details if you need them.</p>
+                <p>Paste a repo, pick a template, and only open advanced run settings if you need them.</p>
             </div>
             <div class="project-page__actions">
                 @if (_isExistingProject)
@@ -61,7 +61,7 @@
                     <div>
                         <span class="eyebrow">Simple setup</span>
                         <h2>Start with a repository or template</h2>
-                        <p>AgentDeck can fill in the workspace details for you. Advanced IDs and launch commands stay editable below.</p>
+                        <p>AgentDeck can fill in the workspace details for you. Advanced IDs and run commands stay editable below.</p>
                     </div>
                 </div>
                 <div class="project-editor__grid">
@@ -173,7 +173,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Ways to run this workspace</h2>
-                        <p>Most workspaces only need one default run option. Open advanced details to tune commands, devices, or VS Code behavior.</p>
+                        <p>Most workspaces only need one default run option. Open advanced run settings to tune commands, devices, or VS Code behavior.</p>
                     </div>
                     <button class="btn btn-accent" disabled="@_saving" @onclick="AddProfile">Add run option</button>
                 </div>
@@ -205,7 +205,7 @@
                                     </div>
 
                                     <details class="advanced-panel">
-                                        <summary>Advanced launch details</summary>
+                                        <summary>Advanced run settings</summary>
                                         <div class="project-editor__grid">
                                         <div class="form-field">
                                             <label>Run option ID</label>
@@ -256,8 +256,9 @@
                                             <input class="input" @bind="profile.PreferredMachineId" />
                                         </div>
                                         <div class="form-field">
-                                            <label>Default device profile ID</label>
-                                            <input class="input" @bind="profile.DefaultDeviceProfileId" />
+                                            <label>Default device profile</label>
+                                            <input class="input" @bind="profile.DefaultDeviceProfileId" placeholder="Optional emulator/simulator profile ID" />
+                                            <span class="form-hint">Leave blank to let AgentDeck choose from available devices.</span>
                                         </div>
                                         <div class="form-field project-editor__field--full">
                                             <label>Build command</label>
@@ -644,7 +645,7 @@
             .FirstOrDefault(group => group.Count() > 1)?.Key;
         if (!string.IsNullOrWhiteSpace(duplicateProfileId))
         {
-            throw new InvalidOperationException($"Two run options are using the same ID ('{duplicateProfileId}'). Open advanced launch details and make them unique.");
+            throw new InvalidOperationException($"Two run options are using the same ID ('{duplicateProfileId}'). Open advanced run settings and make them unique.");
         }
 
         return new ProjectDefinition
@@ -670,7 +671,7 @@
         var profileId = NormalizeProjectId(editor.Id, editor.DisplayName);
         if (string.IsNullOrWhiteSpace(profileId))
         {
-            throw new InvalidOperationException("Each run option needs a display name. Open advanced launch details if you want to set a custom ID.");
+            throw new InvalidOperationException("Each run option needs a display name. Open advanced run settings if you want to set a custom ID.");
         }
 
         var requiresEmulator = editor.RequiresEmulator;

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -63,14 +63,14 @@
                                  workflowPackStatus.State != RunnerWorkflowPackState.None)
                             {
                                 <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowPackChipClass(workflowPackStatus.State))">
-                                    Workflow pack @GetWorkflowPackStateLabel(workflowPackStatus.State)
+                                    Tool pack @GetWorkflowPackStateLabel(workflowPackStatus.State)
                                 </span>
                             }
                             @if (_sessionMachine.WorkflowCatalogStatus is { } workflowCatalogStatus &&
                                  workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
                             {
                                 <span class="project-target-chip project-target-chip--@GetControlPlaneChipClass(GetWorkflowCatalogChipClass(workflowCatalogStatus.State))">
-                                    Catalog @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
+                                    Tool setup @GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)
                                 </span>
                             }
                         </div>
@@ -82,7 +82,7 @@
                 }
             </div>
             <div class="project-page__actions">
-                <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_projectSession.ProjectId)">Project</a>
+                <a class="btn btn-accent" href="/projects/@Uri.EscapeDataString(_projectSession.ProjectId)">Workspace</a>
                 <button class="btn btn-accent" @onclick="RefreshAsync">Refresh live items</button>
                 @if (IsController())
                 {
@@ -552,29 +552,29 @@
 
         if (string.IsNullOrWhiteSpace(_projectSession.CompanionId))
         {
-            return "No controller companion recorded";
+            return "No one is controlling this workspace right now";
         }
 
         return IsController()
             ? "You control this workspace session"
-            : $"View-only while {_projectSession.CompanionId} controls this session";
+            : $"View-only while {_projectSession.CompanionId} controls this workspace";
     }
 
     private string GetViewerSummary()
     {
         if (_projectSession is null)
         {
-            return "No viewers";
+            return "No observers";
         }
 
         return _projectSession.ViewerCompanionIds.Count == 1
-            ? "1 viewer attached"
-            : $"{_projectSession.ViewerCompanionIds.Count} viewers attached";
+            ? "1 observer attached"
+            : $"{_projectSession.ViewerCompanionIds.Count} observers attached";
     }
 
     private string GetLocationLabel() =>
         string.IsNullOrWhiteSpace(_projectSession?.MachineName)
-            ? "Coordinator-managed session"
+            ? "Workspace service session"
             : $"Hosted on {_projectSession.MachineName}";
 
     private static bool HasControlPlaneSignals(CompanionMachineSummary machine) =>

--- a/AgentDeck.Core/Pages/TerminalView.razor
+++ b/AgentDeck.Core/Pages/TerminalView.razor
@@ -107,7 +107,7 @@
             return "Dedicated terminal view";
         }
 
-        var machineLabel = string.IsNullOrWhiteSpace(_session.MachineName) ? "runner" : _session.MachineName;
+        var machineLabel = string.IsNullOrWhiteSpace(_session.MachineName) ? "machine" : _session.MachineName;
         return $"Connected to {machineLabel} • {_session.Status}";
     }
 

--- a/AgentDeck.Core/Pages/Terminals.razor
+++ b/AgentDeck.Core/Pages/Terminals.razor
@@ -14,7 +14,7 @@
         </div>
         @if (Connections.ConnectedMachineCount == 0)
         {
-            <a class="btn btn-primary" href="/settings#machines">Set up runner</a>
+            <a class="btn btn-primary" href="/settings#machines">Set up machine</a>
         }
         else
         {
@@ -35,7 +35,7 @@
                     }
                     else if (Connections.ConnectedMachineCount == 0)
                     {
-                        <span>Create or connect a runner in Settings to open a terminal.</span>
+                        <span>Create or connect a machine in Settings to open a terminal.</span>
                     }
                     else
                     {
@@ -49,7 +49,7 @@
                     }
                     else if (Connections.ConnectedMachineCount == 0)
                     {
-                        <a class="btn btn-primary" href="/settings#machines">Create or connect a runner</a>
+                        <a class="btn btn-primary" href="/settings#machines">Create or connect a machine</a>
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- replace remaining runner/worker and controller-companion labels with workspace/machine language
- clarify live-session, remote-screen, and observer copy across dashboard and workspace pages
- soften directory picker errors and make advanced run settings/device profile guidance clearer

Fixes #425

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
- git diff --check