### PR TITLE
Polish machine setup and remote screen language

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -74,7 +74,7 @@
         {
             <section class="dashboard-section-card">
                 <h2>AgentDeck service unavailable</h2>
-                <p>@(_dashboard.CoordinatorErrorMessage ?? "This companion could not reach the configured AgentDeck service.")</p>
+                <p>@(_dashboard.CoordinatorErrorMessage ?? "This app could not reach the configured AgentDeck service.")</p>
             </section>
         }
         else
@@ -83,7 +83,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Your machines</h2>
-                        <p>Where AgentDeck can run projects right now, with plain-language setup blockers.</p>
+                        <p>Where AgentDeck can open workspaces right now, with plain-language setup blockers.</p>
                     </div>
                 </div>
 
@@ -335,7 +335,7 @@
         {
             return _dashboard.CoordinatorConfigured
                 ? "The saved connection did not respond. Check the URL or start the AgentDeck service."
-                : "Add the service URL once, then AgentDeck can discover runners and workspaces for you.";
+                : "Add the service URL once, then AgentDeck can discover machines and workspaces for you.";
         }
 
         if (!_dashboard.Machines.Any(machine => machine.IsOnline))
@@ -344,8 +344,8 @@
         }
 
         return _dashboard.Projects.Count == 0
-            ? "Paste a GitHub URL or choose a template. You can keep advanced run-option details collapsed."
-            : "Pick up where you left off or open a project on a ready machine.";
+            ? "Paste a GitHub URL or choose a template. You can keep advanced run-option settings collapsed."
+            : "Pick up where you left off or open a workspace on a ready machine.";
     }
 
     private string GetNextActionHref() =>

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -139,7 +139,7 @@
                         <dd>@(ViewerClient.LastInputActivity ?? "No input dispatched yet.")</dd>
                     </div>
                     <div>
-                        <dt>Viewer status</dt>
+                        <dt>Remote-screen status</dt>
                         <dd>@(_lastInteropStatus ?? "Waiting for the screen to report readiness.")</dd>
                     </div>
                 </dl>
@@ -437,7 +437,7 @@
 
         if (!ViewerClient.SupportsInAppViewer)
         {
-            return "This remote screen is not using the managed transport required for in-app viewing.";
+            return "This remote screen is not using the managed connection required for in-app viewing.";
         }
 
         return ViewerClient.StatusMessage;
@@ -459,11 +459,11 @@
         {
             return ViewerClient.CanSendInput
                 ? "You can interact with this remote screen."
-                : "This remote screen is currently view-only.";
+                : "This remote screen is currently view-only. Take control when you need to interact.";
         }
 
         var controllerLabel = string.IsNullOrWhiteSpace(state.ControllerDisplayName)
-            ? "Another companion"
+            ? "Another user"
             : state.ControllerDisplayName;
 
         if (string.Equals(state.ViewerSessionId, ViewerClient.CurrentSession.Id, StringComparison.OrdinalIgnoreCase))
@@ -475,8 +475,8 @@
 
         var activeTarget = state.TargetDisplayName ?? state.TargetKind.ToString();
         return IsCurrentRemoteController(state)
-            ? $"You currently control {activeTarget} on this machine. Input here is allowed, and Take control will switch the active remote target."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this remote screen requires force takeover.";
+            ? $"You currently control {activeTarget} on this machine. Input here is allowed, and Take control will switch the active remote screen."
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
     }
 
     private async Task RunBusyAsync(Func<Task> action)

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -11,13 +11,13 @@
     <div class="page-header settings-page__header">
         <div>
             <h1>Settings</h1>
-            <p>Connect AgentDeck, create runner machines, check required tools, manage updates, and keep advanced diagnostics in one place.</p>
+            <p>Connect AgentDeck, create machines, check required tools, manage updates, and keep advanced diagnostics in one place.</p>
         </div>
     </div>
 
     <nav class="settings-nav" aria-label="Settings sections">
         <a href="#connection">Connection</a>
-        <a href="#machines">Create runners</a>
+        <a href="#machines">Create machines</a>
         <a href="#setup-capabilities">Tools</a>
         <a href="#runner-updates">Updates</a>
         <a href="#advanced">Advanced diagnostics</a>
@@ -80,7 +80,7 @@
         }
         else if (_registeredMachines.Count == 0)
         {
-            <p>No machines are visible yet. Create a runner below or start an existing runner and refresh.</p>
+            <p>No machines are visible yet. Create a machine below or start an existing machine and refresh.</p>
         }
         else
         {
@@ -104,7 +104,7 @@
                             }
                             @if (!machine.ProtocolCompatible)
                             {
-                                <span> • needs app/runner compatibility fix</span>
+                                <span> • needs app/machine compatibility fix</span>
                             }
                             @if (machine.Platform is not null)
                             {
@@ -142,7 +142,7 @@
                                 }
                                 @if (!string.IsNullOrWhiteSpace(machine.RunnerUrl))
                                 {
-                                    <span> • runner URL @machine.RunnerUrl</span>
+                                    <span> • machine agent URL @machine.RunnerUrl</span>
                                 }
                             </span>
                         </details>
@@ -159,8 +159,8 @@
     <div id="machines" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
-                <h2>Create runners</h2>
-                <p class="settings-card__description">Create new runner capacity, connect existing machines, and choose your default place to open work.</p>
+                <h2>Create machines</h2>
+                <p class="settings-card__description">Create new machine capacity, connect existing machines, and choose your default place to open work.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
                 <button class="btn btn-accent" @onclick="AddMachine">Add machine</button>
@@ -176,13 +176,13 @@
         }
 
         <div class="settings-callout">
-            <strong>Create runner capacity</strong>
-            <span>Use configured provider templates to create Linux/Windows/macOS runners on demand. Portainer is the first adapter; unsupported OS/provider combinations stay visible as planning targets instead of becoming dead-end buttons.</span>
+            <strong>Create machine capacity</strong>
+            <span>Use configured provider templates to create Linux/Windows/macOS machines on demand. Portainer is the first adapter; unsupported OS/provider combinations stay visible as planning targets instead of becoming dead-end buttons.</span>
         </div>
 
         @if (_runnerOrchestrationCatalog.Templates.Count == 0)
         {
-            <p class="settings-card__description">No runner templates are published by the AgentDeck service yet.</p>
+            <p class="settings-card__description">No machine templates are published by the AgentDeck service yet.</p>
         }
         else
         {
@@ -199,12 +199,12 @@
                             </div>
                             <span class="machine-badge">@template.DefaultLifecyclePolicy</span>
                         </div>
-                        <p class="project-template-target__note">@(template.Description ?? $"Creates an AgentDeck runner from {template.Image}.")</p>
+                        <p class="project-template-target__note">@(template.Description ?? $"Creates an AgentDeck machine from {template.Image}.")</p>
                         <p class="project-template-target__note">Capabilities: @string.Join(", ", template.CapabilityProfile)</p>
                         @if (provider is not null && !provider.Configured)
                         {
                             <p class="error-message">@provider.StatusMessage</p>
-                            <p class="project-template-target__note">Configure @provider.Name before creating this runner.</p>
+                            <p class="project-template-target__note">Configure @provider.Name before creating this machine.</p>
                         }
                         <div class="project-machine-card__actions">
                             <button class="btn btn-primary"
@@ -223,11 +223,11 @@
             var template = SelectedRunnerTemplateDraft;
             var provider = GetRunnerProvider(template.ProviderId);
             <div class="settings-callout settings-callout--actionable">
-                <strong>Review runner before creating</strong>
+                <strong>Review machine before creating</strong>
                 <span>@template.Name on @(provider?.Name ?? template.ProviderId) • @template.HostPlatform • port @template.RunnerPort</span>
                 <div class="project-editor__grid">
                     <div class="form-field">
-                        <label for="runner-create-name">Runner name</label>
+                        <label for="runner-create-name">Machine name</label>
                         <input id="runner-create-name" class="input" @bind="_runnerCreateName" />
                     </div>
                     <div class="form-field">
@@ -242,14 +242,14 @@
                     <div class="form-field project-editor__field--full">
                         <label for="runner-create-coordinator">AgentDeck service URL</label>
                         <input id="runner-create-coordinator" class="input" @bind="_runnerCreateCoordinatorUrl" />
-                        <p class="settings-card__description">Use a service URL the new runner can reach. For a runner in a container or on another machine, use a LAN host/IP instead of this client's localhost.</p>
+                        <p class="settings-card__description">Use a service URL the new machine can reach. For a container or another device, use a LAN host/IP instead of this client's localhost.</p>
                     </div>
                 </div>
                 <div class="form-actions form-actions--settings">
                     <button class="btn btn-primary"
                             disabled="@(_creatingRunnerTemplateId == template.Id || string.IsNullOrWhiteSpace(_runnerCreateName) || string.IsNullOrWhiteSpace(_runnerCreateCoordinatorUrl))"
                             @onclick="() => CreateRunnerFromTemplateAsync(template)">
-                        @(_creatingRunnerTemplateId == template.Id ? "Creating..." : "Create runner")
+                        @(_creatingRunnerTemplateId == template.Id ? "Creating..." : "Create machine")
                     </button>
                     <button class="btn btn-accent" disabled="@(_creatingRunnerTemplateId == template.Id)" @onclick="ClearRunnerCreatePreview">Cancel</button>
                 </div>
@@ -312,10 +312,10 @@
                     </div>
 
                     <div class="form-field">
-                        <label for="runner-url">Advertised runner URL</label>
+                        <label for="runner-url">Advertised machine agent URL</label>
                         <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
                                placeholder="@GetRunnerUrlPlaceholder()" />
-                        <p class="settings-card__description">Informational only. The companion does not connect directly to this URL.</p>
+                        <p class="settings-card__description">Informational only. The app does not connect directly to this URL.</p>
                     </div>
 
                     <div class="form-field">
@@ -369,7 +369,7 @@
             <div id="runner-updates" class="settings-card settings-page__card settings-card--status settings-card--anchored">
                 <div class="settings-card__header settings-page__section-header">
                     <div>
-                        <h2>Runner updates</h2>
+                        <h2>Machine updates</h2>
                         <p class="settings-card__description">Stage or apply updates for @SelectedMachine?.Name, and see whether tool lists are in sync.</p>
                     </div>
                 </div>
@@ -624,14 +624,14 @@
                         @if (_machineCapabilities.SupportedTargets.Count > 0)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Target readiness</span>
+                                <span class="settings-status-row__label">Workspace readiness</span>
                                 <span class="settings-status-row__value">@string.Join(", ", _machineCapabilities.SupportedTargets.Select(FormatTargetSummary))</span>
                             </div>
                         }
                         @if (_machineCapabilities.RemoteViewerProviders.Count > 0)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Viewer transports</span>
+                                <span class="settings-status-row__label">Remote-screen options</span>
                                 <span class="settings-status-row__value">@string.Join(", ", _machineCapabilities.RemoteViewerProviders.Select(GetViewerProviderSummary))</span>
                             </div>
                         }
@@ -653,7 +653,7 @@
                 </div>
 
                 <p class="settings-card__description">
-                    AgentDeck now treats each runner target as a machine to inspect and prepare in place. Detect which supported tools are already installed and install missing ones directly on this machine.
+                    AgentDeck inspects this machine in place, shows which supported workspace types are ready, and can install missing tools directly on it.
                 </p>
 
                 @if (_capabilitiesErrorMessage is not null)
@@ -694,7 +694,7 @@
                                     <div class="capability-card__header">
                                         <div>
                                             <h3>@provider.DisplayName</h3>
-                                            <p>VIEWER TRANSPORT</p>
+                                            <p>REMOTE SCREEN OPTION</p>
                                         </div>
                                         <span class="capability-status capability-status--installed">
                                             @provider.Provider
@@ -835,7 +835,7 @@
                 <div class="settings-card__header settings-page__section-header">
                     <div>
                         <h2>Advanced</h2>
-                        <p class="settings-card__description">Low-level service and runner identifiers useful for debugging support issues.</p>
+                        <p class="settings-card__description">Low-level service and machine identifiers useful for debugging support issues.</p>
                     </div>
                 </div>
 
@@ -849,7 +849,7 @@
                         <code class="settings-status-row__value">@_settings.CoordinatorUrl</code>
                     </div>
                     <div class="settings-status-row">
-                        <span class="settings-status-row__label">Advertised runner URL</span>
+                        <span class="settings-status-row__label">Advertised machine agent URL</span>
                         <code class="settings-status-row__value">@(!string.IsNullOrWhiteSpace(SelectedMachine.RunnerUrl) ? SelectedMachine.RunnerUrl : "Not advertised")</code>
                     </div>
                     @if (SelectedRegisteredMachine is not null)
@@ -943,7 +943,7 @@
         }
         catch (Exception ex)
         {
-            _errorMessage = $"Failed to save settings: {ex.Message}";
+            _errorMessage = $"Couldn’t save settings: {ex.Message}";
         }
         finally
         {
@@ -1068,14 +1068,14 @@
 
     private static string GetMachineRoleLabel(RunnerMachineRole role) => role switch
     {
-        RunnerMachineRole.Worker => "Worker",
+        RunnerMachineRole.Worker => "Shared machine",
         _ => "Standalone"
     };
 
     private static string GetMachineRoleDescription(RunnerMachineRole role) => role switch
     {
-        RunnerMachineRole.Worker => "Use this machine as shared runner capacity that checks in with the AgentDeck service.",
-        _ => "Use this machine independently without assigning it to shared runner orchestration yet."
+        RunnerMachineRole.Worker => "Use this machine as shared capacity that checks in with the AgentDeck service.",
+        _ => "Use this machine independently without assigning it to shared machine orchestration yet."
     };
 
     private static string GetHostPlatformLabel(RunnerHostPlatform platform) => platform switch
@@ -1198,7 +1198,7 @@
 
     private string GetHubUrl(RunnerMachineSettings machine) =>
         string.IsNullOrWhiteSpace(_settings.CoordinatorUrl)
-            ? "(coordinator URL not configured)"
+            ? "(AgentDeck service URL not configured)"
             : $"{_settings.CoordinatorUrl.TrimEnd('/')}/hubs/agent";
 
     private Task RefreshMachineCapabilitiesIfPossibleAsync()
@@ -1262,13 +1262,13 @@
     {
         if (string.IsNullOrWhiteSpace(_settings.CoordinatorUrl))
         {
-            ToastService.Show("Set a coordinator URL before creating a runner.", ToastKind.Warning);
+            ToastService.Show("Set the AgentDeck service URL before creating a machine.", ToastKind.Warning);
             return;
         }
 
         if (string.IsNullOrWhiteSpace(_runnerCreateCoordinatorUrl) || string.IsNullOrWhiteSpace(_runnerCreateName))
         {
-            ToastService.Show("Review the runner name and coordinator URL before creating.", ToastKind.Warning);
+            ToastService.Show("Review the machine name and AgentDeck service URL before creating.", ToastKind.Warning);
             return;
         }
 
@@ -1287,18 +1287,18 @@
 
             if (instance is null)
             {
-                ToastService.Show("AgentDeck could not confirm the new runner. Refresh machines in a moment.", ToastKind.Warning);
+                ToastService.Show("AgentDeck could not confirm the new machine yet. Refresh machines in a moment.", ToastKind.Warning);
                 return;
             }
 
-            ToastService.Show($"Runner {instance.Name} is {instance.State}. Refresh the directory once it registers.", instance.State == RunnerInstanceLifecycleState.Failed ? ToastKind.Warning : ToastKind.Success);
+            ToastService.Show($"Machine {instance.Name} is {instance.State}. Refresh the directory once it registers.", instance.State == RunnerInstanceLifecycleState.Failed ? ToastKind.Warning : ToastKind.Success);
             ClearRunnerCreatePreview();
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to create runner from template {TemplateId}", template.Id);
-            ToastService.Show($"Failed to create runner: {ex.Message}", ToastKind.Error);
+            ToastService.Show($"Couldn’t create machine: {ex.Message}", ToastKind.Error);
         }
         finally
         {
@@ -1338,7 +1338,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to refresh registered machines from coordinator API {CoordinatorUrl}", _settings.CoordinatorUrl);
-            _registeredMachinesErrorMessage = $"Failed to refresh machines: {ex.Message}";
+            _registeredMachinesErrorMessage = $"Couldn’t refresh machines: {ex.Message}";
             _registeredMachines = [];
             _coordinatorReachable = false;
         }
@@ -1378,7 +1378,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to update coordinator apply intent for machine {MachineId}", machineId);
-            ToastService.Show($"Failed to update machine setup preference: {ex.Message}", ToastKind.Error);
+            ToastService.Show($"Couldn’t update machine setup preference: {ex.Message}", ToastKind.Error);
         }
         finally
         {
@@ -1410,7 +1410,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to retry workflow pack for machine {MachineId}", machineId);
-            ToastService.Show($"Failed to retry workflow pack: {ex.Message}", ToastKind.Error);
+            ToastService.Show($"Couldn’t retry tool pack: {ex.Message}", ToastKind.Error);
         }
         finally
         {
@@ -1420,7 +1420,7 @@
 
     private static string GetCoordinatorUrlPlaceholder() => "https://coordinator-host:5001";
 
-    private static string GetRunnerUrlPlaceholder() => "https://runner-host:5000 (informational)";
+    private static string GetRunnerUrlPlaceholder() => "https://machine-host:5000 (informational)";
 
     private void ClearCoordinatorDirectory()
     {
@@ -1492,13 +1492,13 @@
             _machineCapabilitiesByMachine[machine.Id] = capabilities;
             if (capabilities is null)
             {
-                _machineCapabilityErrors[machine.Id] = "The runner did not return machine capability data.";
+                _machineCapabilityErrors[machine.Id] = "This machine did not return capability data.";
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to detect capabilities for machine {MachineId}", machine.Id);
-            _machineCapabilityErrors[machine.Id] = $"Failed to detect capabilities: {ex.Message}";
+            _machineCapabilityErrors[machine.Id] = $"Couldn’t detect capabilities: {ex.Message}";
             _machineCapabilitiesByMachine[machine.Id] = null;
         }
         finally
@@ -1527,7 +1527,7 @@
 
             if (result is null)
             {
-                _machineCapabilityErrors[machine.Id] = $"The runner did not return an installation result for {capability.Name}.";
+                _machineCapabilityErrors[machine.Id] = $"This machine did not return an installation result for {capability.Name}.";
                 return;
             }
 
@@ -1537,7 +1537,7 @@
             }
             else
             {
-                ToastService.Show($"Failed to install {capability.Name}", ToastKind.Error);
+                ToastService.Show($"Couldn’t install {capability.Name}", ToastKind.Error);
             }
 
             await RefreshMachineCapabilitiesAsync();
@@ -1545,7 +1545,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to install capability {CapabilityId} on machine {MachineId}", capability.Id, machine.Id);
-            _machineCapabilityErrors[machine.Id] = $"Failed to install {capability.Name}: {ex.Message}";
+            _machineCapabilityErrors[machine.Id] = $"Couldn’t install {capability.Name}: {ex.Message}";
         }
         finally
         {
@@ -1596,7 +1596,7 @@
 
             if (result is null)
             {
-                _machineCapabilityErrors[machine.Id] = $"The runner did not return an update result for {capability.Name}.";
+                _machineCapabilityErrors[machine.Id] = $"This machine did not return an update result for {capability.Name}.";
                 return;
             }
 
@@ -1606,7 +1606,7 @@
             }
             else
             {
-                ToastService.Show($"Failed to update {capability.Name}", ToastKind.Error);
+                ToastService.Show($"Couldn’t update {capability.Name}", ToastKind.Error);
             }
 
             await RefreshMachineCapabilitiesAsync();
@@ -1614,7 +1614,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to update capability {CapabilityId} on machine {MachineId}", capability.Id, machine.Id);
-            _machineCapabilityErrors[machine.Id] = $"Failed to update {capability.Name}: {ex.Message}";
+            _machineCapabilityErrors[machine.Id] = $"Couldn’t update {capability.Name}: {ex.Message}";
         }
         finally
         {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentDeck
 
-AgentDeck is a private local-network app for running AI-assisted development workflows across the machines you already own. Start one AgentDeck service, connect one or more runner machines, then use the companion app to choose workspaces, discover machine capabilities, launch terminals or app/debug workflows, and open managed remote screens without manually juggling per-machine endpoints.
+AgentDeck is a private local-network app for running AI-assisted development workflows across the machines you already own. Start one AgentDeck service, connect one or more machines, then use the companion app to choose workspaces, discover what each machine can do, launch terminals or app/debug workflows, and open managed remote screens without manually juggling per-machine endpoints.
 
 ---
 
@@ -8,11 +8,11 @@ AgentDeck is a private local-network app for running AI-assisted development wor
 
 AgentDeck is being built to make it easy to:
 - connect multiple local machines into one developer workspace
-- discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and remote-screen transports
-- open a project on the best available runner for the requested workflow
+- discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and remote-screen options
+- open a workspace on the best available machine for the requested workflow
 - launch terminals, app/debug workflows, and managed remote screens from one UI
-- keep runner tools, setup catalogs, and runner updates coordinated from the local AgentDeck service
-- support collaboration where one companion controls a session while other companions can observe or request control
+- keep machine tools, setup catalogs, and updates coordinated from the local AgentDeck service
+- support collaboration where one user controls a session while others can observe or request control
 
 ## Non-goals for Now
 
@@ -62,9 +62,9 @@ A .NET MAUI + Blazor WebView shell plus shared Core UI that:
 | Project | Framework | Purpose |
 |---------|-----------|---------|
 | `AgentDeck` | .NET MAUI 10 | Companion app shell (all platforms) |
-| `AgentDeck.Coordinator` | ASP.NET Core 10 | Central coordinator API |
+| `AgentDeck.Coordinator` | ASP.NET Core 10 | Local AgentDeck service API |
 | `AgentDeck.Core` | Blazor Razor Library | Shared UI pages and services |
-| `AgentDeck.Runner` | ASP.NET Core 10 | Worker runner agent |
+| `AgentDeck.Runner` | ASP.NET Core 10 | Machine agent for terminals, setup, and remote screens |
 | `AgentDeck.Shared` | .NET 10 | Shared contracts, models, hub interfaces |
 
 ---
@@ -82,7 +82,7 @@ From a fresh checkout, the fastest reliable path is:
    dotnet run --project AgentDeck.Coordinator/AgentDeck.Coordinator.csproj
    ```
 
-2. In a second terminal, start a Linux runner and point it at that service. Registration uses .NET configuration environment keys with double underscores:
+2. In a second terminal, start a Linux machine agent and point it at that service. Registration uses .NET configuration environment keys with double underscores:
 
    ```bash
    Coordinator__CoordinatorUrl=http://localhost:5001 \
@@ -91,7 +91,7 @@ From a fresh checkout, the fastest reliable path is:
    dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj
    ```
 
-3. Run the companion for your platform and paste the AgentDeck service URL in **Settings → Connection**.
+3. Run the companion app for your platform and paste the AgentDeck service URL in **Settings → Connection**.
 
 Use `http://localhost:5001` only when the companion is running on the same machine as the service. For a phone, tablet, VM, or another laptop, paste a LAN-reachable host name or IP address such as `http://192.168.1.25:5001`.
 
@@ -104,7 +104,7 @@ dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
 dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
 ```
 
-A full solution build on Linux also targets Android; install the Android SDK or build a specific framework if you only want the desktop companion.
+A full solution build on Linux also targets Android; install the Android SDK or build a specific framework if you only want the desktop companion app.
 
 ### Running the Coordinator API
 
@@ -133,7 +133,7 @@ Use these environment variables to override runtime defaults:
 - `AGENTDECK_COORDINATOR_ACCESS_KEY` sets the optional shared key used when the runner talks to a protected coordinator
 - `AGENTDECK_DEFAULT_SHELL` sets the default shell command
 
-The companion now starts with an empty coordinator URL plus auto-connect disabled by default. Configure a network-reachable coordinator explicitly instead of assuming `localhost`, which is only valid when the coordinator is actually running on the same device as the client. If the coordinator uses an access key, enter the same key in Settings so companion HTTP and hub calls include `X-AgentDeck-Access-Key`.
+The companion app now starts with an empty AgentDeck service URL plus auto-connect disabled by default. Configure a network-reachable service explicitly instead of assuming `localhost`, which is only valid when the service is actually running on the same device as the app. If the service uses an access key, enter the same key in Settings so app HTTP and hub calls include `X-AgentDeck-Access-Key`.
 
 ### Running the Runner in Docker (Linux)
 

--- a/docs/product-vision-alignment.md
+++ b/docs/product-vision-alignment.md
@@ -2,7 +2,7 @@
 
 AgentDeck is being steered toward "any workflow / any CLI / any IDE" rather than a closed .NET-only launcher. The current implementation moves a few surfaces in that direction:
 
-- **Settings IA:** Settings now has first-class lanes for Connection, Machines, Setup & Capabilities, Runner Updates, and Advanced diagnostics.
+- **Settings IA:** Settings now has first-class lanes for Connection, Machines, Setup & Capabilities, Machine Updates, and Advanced diagnostics.
 - **Projects-first navigation:** The main dashboard remains project-led, with mobile navigation explicitly exposing Projects as the primary entry point.
 - **Capability breadth:** The default capability catalog now probes Git, Docker CLI, Java JDK, Go, and PowerShell 7 in addition to the existing GitHub, Copilot, Node, Python, and .NET checks.
 - **Remote-screen lifecycle trust:** Closed, failed, unavailable, stale, or offline-machine remote screens are filtered out of live workspace/process tabs.
@@ -14,6 +14,6 @@ These larger architecture items remain intentionally out of this slice:
 
 1. Replace closed workload/launch-driver enums with extensible models.
 2. User-managed CLI presets and terminal quick actions.
-3. Auth/authz and coordinator persistence.
+3. Auth/authz and AgentDeck service persistence.
 4. Native child-process window inventory per platform for fully automatic managed-terminal window surfacing.
-5. Companion workflow-pack marketplace/discovery UX.
+5. Workflow-pack marketplace/discovery UX in the companion app.


### PR DESCRIPTION
Closes #427\n\n## Summary\n- align Settings machine creation, setup, update, and capability copy around machines instead of runner internals\n- clarify dashboard and remote-screen control/status language\n- soften README/product-vision setup docs toward AgentDeck service, machines, and remote-screen options\n\n## Validation\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore\n- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore\n- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build\n- git diff --check