### PR TITLE
Polish remaining user-facing setup language

### DIFF
--- a/AgentDeck.Core/Layout/MainLayout.razor
+++ b/AgentDeck.Core/Layout/MainLayout.razor
@@ -60,7 +60,7 @@
             {
                 <a class="nav-new-terminal" href="/settings#machines">
                     <span>＋</span>
-                    <span>Set up runner</span>
+                    <span>Set up machine</span>
                 </a>
             }
             else

--- a/AgentDeck.Core/Models/ConnectionSettings.cs
+++ b/AgentDeck.Core/Models/ConnectionSettings.cs
@@ -2,16 +2,16 @@ using AgentDeck.Shared.Enums;
 
 namespace AgentDeck.Core.Models;
 
-/// <summary>User-configured runner machine profiles for the companion app.</summary>
+/// <summary>User-configured machine profiles for the companion app.</summary>
 public sealed class ConnectionSettings
 {
-    /// <summary>Base URL of the central coordinator API.</summary>
+    /// <summary>Base URL of the local AgentDeck service API.</summary>
     public string CoordinatorUrl { get; set; } = string.Empty;
 
-    /// <summary>Optional shared access key sent to protected coordinator/runner endpoints.</summary>
+    /// <summary>Optional shared access key sent to protected service and machine endpoints.</summary>
     public string? AccessKey { get; set; }
 
-    /// <summary>Configured runner machines.</summary>
+    /// <summary>Configured machines.</summary>
     public List<RunnerMachineSettings> Machines { get; set; } = [CreateMachineTemplate()];
 
     /// <summary>Machine selected by default when creating a new terminal.</summary>
@@ -112,5 +112,5 @@ public sealed class ConnectionSettings
     }
 
     private static string GetDefaultMachineName(int index) =>
-        index == 0 ? "Runner machine" : $"Runner machine {index + 1}";
+        index == 0 ? "AgentDeck machine" : $"AgentDeck machine {index + 1}";
 }

--- a/AgentDeck.Core/Models/RunnerMachineSettings.cs
+++ b/AgentDeck.Core/Models/RunnerMachineSettings.cs
@@ -2,19 +2,19 @@ using AgentDeck.Shared.Enums;
 
 namespace AgentDeck.Core.Models;
 
-/// <summary>Named runner machine profile managed by the companion app.</summary>
+/// <summary>Named machine profile managed by the companion app.</summary>
 public sealed class RunnerMachineSettings
 {
     /// <summary>Stable identifier for the machine profile.</summary>
     public string Id { get; set; } = Guid.NewGuid().ToString("n");
 
     /// <summary>User-facing machine name.</summary>
-    public string Name { get; set; } = "Runner machine";
+    public string Name { get; set; } = "AgentDeck machine";
 
     /// <summary>Intended orchestration role for this machine profile.</summary>
     public RunnerMachineRole Role { get; set; } = RunnerMachineRole.Standalone;
 
-    /// <summary>Advertised base URL of the runner, used by the coordinator when brokering requests.</summary>
+    /// <summary>Advertised base URL of the machine agent, used by the service when brokering requests.</summary>
     public string RunnerUrl { get; set; } = string.Empty;
 
     /// <summary>Whether this machine should connect automatically when the app starts.</summary>

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -1425,7 +1425,7 @@
 
         if (machine.UpdateRollout is { State: RunnerUpdateRolloutState.Blocked })
         {
-            return "Runner update rollout is currently blocked for this machine.";
+            return "Machine update is currently blocked for this machine.";
         }
 
         if (machine.UpdateRollout is { State: RunnerUpdateRolloutState.Failed })
@@ -1471,9 +1471,10 @@
         }
 
         var targetLabel = state.TargetDisplayName ?? "Remote screen";
+        var controllerLabel = string.IsNullOrWhiteSpace(state.ControllerDisplayName) ? "another user" : state.ControllerDisplayName;
         return IsCurrentRemoteController(state)
             ? $"{targetLabel} is currently controlled by you."
-            : $"{targetLabel} is currently controlled by {state.ControllerDisplayName ?? state.ControllerCompanionId}. Open will be rejected unless you force takeover.";
+            : $"{targetLabel} is currently controlled by {controllerLabel}. Take control when you need to interact.";
     }
 
     private string? GetViewerControlNotice(RemoteViewerSession viewer)
@@ -1489,7 +1490,7 @@
             return null;
         }
 
-        var controllerLabel = state.ControllerDisplayName ?? state.ControllerCompanionId;
+        var controllerLabel = string.IsNullOrWhiteSpace(state.ControllerDisplayName) ? "Another user" : state.ControllerDisplayName;
         var activeTarget = state.TargetDisplayName ?? "another remote screen";
         if (string.Equals(state.ViewerSessionId, viewer.Id, StringComparison.OrdinalIgnoreCase))
         {
@@ -1499,8 +1500,8 @@
         }
 
         return IsCurrentRemoteController(state)
-            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote target."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this remote screen requires force takeover.";
+            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote screen."
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
     }
 
     private static bool CanControlViewer(RemoteViewerSession viewer) =>

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -252,8 +252,9 @@
                                             </select>
                                         </div>
                                         <div class="form-field">
-                                            <label>Preferred machine ID (advanced)</label>
-                                            <input class="input" @bind="profile.PreferredMachineId" />
+                                            <label>Preferred machine (advanced)</label>
+                                            <input class="input" @bind="profile.PreferredMachineId" placeholder="Optional machine ID" />
+                                            <span class="form-hint">Leave blank to let AgentDeck choose any ready machine with this run option.</span>
                                         </div>
                                         <div class="form-field">
                                             <label>Default device profile</label>
@@ -277,7 +278,7 @@
                                             <input class="input" @bind="profile.DebugConfigurationName" />
                                         </div>
                                         <div class="form-field">
-                                            <label>Device catalog</label>
+                                            <label>Device list source</label>
                                             <select class="input" @bind="profile.DeviceCatalogText">
                                                 <option value="">None</option>
                                                 @foreach (var catalogKind in DeviceCatalogOptions)
@@ -285,6 +286,7 @@
                                                     <option value="@catalogKind.ToString()">@catalogKind</option>
                                                 }
                                             </select>
+                                            <span class="form-hint">Choose where AgentDeck should look for emulator or simulator devices.</span>
                                         </div>
                                         <div class="form-field project-editor__field--full">
                                             <label>Notes</label>

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -184,7 +184,7 @@
                             @if (_activeSurface.Job is not null)
                             {
                                 <div>
-                                    <dt>Runtime job</dt>
+                                    <dt>Run/debug work</dt>
                                     <dd>@GetJobSummary(_activeSurface.Job)</dd>
                                 </div>
                                 @if (_activeSurface.Job.DeviceSelection is not null)
@@ -198,7 +198,7 @@
                             @if (_activeSurface.Viewer is not null)
                             {
                                 <div>
-                                    <dt>Viewer</dt>
+                                    <dt>Remote screen</dt>
                                     <dd>@GetViewerSummary(_activeSurface.Viewer)</dd>
                                 </div>
                                 @if (GetActiveViewerControlNotice() is { } viewerControlNotice)
@@ -1015,8 +1015,8 @@
             return null;
         }
 
-        var controllerLabel = _remoteControlState.ControllerDisplayName ?? _remoteControlState.ControllerCompanionId;
-        var activeTarget = _remoteControlState.TargetDisplayName ?? "another viewer";
+        var controllerLabel = string.IsNullOrWhiteSpace(_remoteControlState.ControllerDisplayName) ? "Another user" : _remoteControlState.ControllerDisplayName;
+        var activeTarget = _remoteControlState.TargetDisplayName ?? "another remote screen";
         if (string.Equals(_remoteControlState.ViewerSessionId, _activeSurface.Viewer.Id, StringComparison.OrdinalIgnoreCase))
         {
             return IsActiveViewerControlledByCurrentCompanion()
@@ -1025,8 +1025,8 @@
         }
 
         return IsCurrentRemoteController(_remoteControlState)
-            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote target."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Requesting this remote screen requires force takeover.";
+            ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote screen."
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
     }
 
     private bool CanControlActiveViewer() =>

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -127,7 +127,7 @@
                     {
                         <div>
                             <dt>Controller</dt>
-                            <dd>@(IsCurrentRemoteController(remoteControlState) ? "You" : (remoteControlState.ControllerDisplayName ?? remoteControlState.ControllerCompanionId))</dd>
+                            <dd>@(IsCurrentRemoteController(remoteControlState) ? "You" : GetControllerDisplayLabel(remoteControlState))</dd>
                         </div>
                     }
                     <div>
@@ -427,6 +427,9 @@
     private bool IsCurrentRemoteController(MachineRemoteControlState state) =>
         !string.IsNullOrWhiteSpace(AgentClient.CompanionId) &&
         string.Equals(state.ControllerCompanionId, AgentClient.CompanionId, StringComparison.OrdinalIgnoreCase);
+
+    private static string GetControllerDisplayLabel(MachineRemoteControlState state) =>
+        string.IsNullOrWhiteSpace(state.ControllerDisplayName) ? "Another user" : state.ControllerDisplayName;
 
     private string GetViewerPlaceholderMessage()
     {


### PR DESCRIPTION
Closes #429

## Summary
- update the first-run sidebar action and default machine names away from runner terminology
- make workspace and live-session remote-control notices use user-facing remote-screen language
- clarify live-session detail labels and advanced run-option hints

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
- git diff --check