### PR TITLE
Add redacted diagnostic bundles

### DIFF
--- a/AgentDeck.Coordinator/Endpoints/CoordinatorEndpointModules.cs
+++ b/AgentDeck.Coordinator/Endpoints/CoordinatorEndpointModules.cs
@@ -1,3 +1,4 @@
+using AgentDeck.Coordinator.Configuration;
 using AgentDeck.Coordinator.Hubs;
 using AgentDeck.Coordinator.Services;
 using System.Runtime.ExceptionServices;
@@ -5,6 +6,8 @@ using System.Text;
 using AgentDeck.Shared;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+using System.Runtime.InteropServices;
 
 namespace AgentDeck.Coordinator.Endpoints;
 
@@ -13,6 +16,88 @@ public static class CoordinatorEndpointModules
     public static WebApplication MapCoordinatorEndpoints(this WebApplication app)
     {
         app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTimeOffset.UtcNow }));
+
+        app.MapGet("/api/diagnostics/bundle", async (
+            IOptions<CoordinatorOptions> coordinatorOptions,
+            ICompanionRegistryService companions,
+            IWorkerRegistryService workers,
+            IProjectRegistryService projects,
+            IProjectSessionRegistryService sessions,
+            IRunnerDefinitionCatalogService definitions,
+            IRunnerOrchestrationService orchestration,
+            CancellationToken cancellationToken) =>
+        {
+            var options = coordinatorOptions.Value;
+            var desiredUpdate = definitions.GetDesiredUpdateManifest();
+            var desiredWorkflowPack = definitions.GetDesiredWorkflowPack();
+            var desiredCapabilityCatalog = definitions.GetDesiredCapabilityCatalog();
+            var desiredSetupCatalog = definitions.GetDesiredSetupCatalog();
+
+            var bundle = new AgentDeckDiagnosticBundle
+            {
+                Component = "coordinator",
+                GeneratedAt = DateTimeOffset.UtcNow.ToString("O"),
+                MachineName = Environment.MachineName,
+                OperatingSystem = RuntimeInformation.OSDescription,
+                ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                FrameworkDescription = RuntimeInformation.FrameworkDescription,
+                Configuration = new Dictionary<string, object?>
+                {
+                    ["coordinator"] = new Dictionary<string, object?>
+                    {
+                        ["port"] = options.Port,
+                        ["bindAddress"] = options.BindAddress,
+                        ["publicBaseUrl"] = options.PublicBaseUrl,
+                        ["desiredRunnerVersion"] = options.DesiredRunnerVersion,
+                        ["minimumSupportedProtocolVersion"] = options.MinimumSupportedProtocolVersion,
+                        ["maximumSupportedProtocolVersion"] = options.MaximumSupportedProtocolVersion,
+                        ["workflowCatalogVersion"] = options.WorkflowCatalogVersion,
+                        ["accessKeyConfigured"] = AgentDeckAccessKey.IsConfigured(options.AccessKey),
+                        ["workerHeartbeatInterval"] = options.WorkerHeartbeatInterval,
+                        ["workerExpiry"] = options.WorkerExpiry,
+                        ["runnerControlMaximumReceiveMessageSize"] = options.RunnerControlMaximumReceiveMessageSize
+                    },
+                    ["securityPolicy"] = options.SecurityPolicy is null
+                        ? null
+                        : new Dictionary<string, object?>
+                        {
+                            ["policyVersion"] = options.SecurityPolicy.PolicyVersion,
+                            ["allowUpdateStaging"] = options.SecurityPolicy.AllowUpdateStaging,
+                            ["requireCoordinatorOriginForArtifacts"] = options.SecurityPolicy.RequireCoordinatorOriginForArtifacts,
+                            ["requireUpdateArtifactChecksum"] = options.SecurityPolicy.RequireUpdateArtifactChecksum,
+                            ["requireSignedUpdateManifest"] = options.SecurityPolicy.RequireSignedUpdateManifest,
+                            ["requireManifestProvenance"] = options.SecurityPolicy.RequireManifestProvenance,
+                            ["trustedManifestSignerIds"] = options.SecurityPolicy.TrustedManifestSigners.Select(static signer => signer.SignerId).ToArray(),
+                            ["allowWorkflowPackExecution"] = options.SecurityPolicy.AllowWorkflowPackExecution,
+                            ["allowUpdateApply"] = options.SecurityPolicy.AllowUpdateApply
+                        },
+                    ["desiredDefinitions"] = new Dictionary<string, object?>
+                    {
+                        ["updateManifest"] = new { desiredUpdate.ManifestId, desiredUpdate.Version, signerId = desiredUpdate.Signature?.SignerId, signed = desiredUpdate.Signature is not null },
+                        ["workflowPack"] = new { desiredWorkflowPack.PackId, desiredWorkflowPack.Version, signerId = desiredWorkflowPack.Signature?.SignerId, signed = desiredWorkflowPack.Signature is not null },
+                        ["capabilityCatalog"] = new { desiredCapabilityCatalog.CatalogId, desiredCapabilityCatalog.Version, signerId = desiredCapabilityCatalog.Signature?.SignerId, signed = desiredCapabilityCatalog.Signature is not null },
+                        ["setupCatalog"] = new { desiredSetupCatalog.CatalogId, desiredSetupCatalog.Version, signerId = desiredSetupCatalog.Signature?.SignerId, signed = desiredSetupCatalog.Signature is not null }
+                    }
+                },
+                State = new Dictionary<string, object?>
+                {
+                    ["companions"] = companions.GetCompanions(),
+                    ["machines"] = await workers.GetMachinesAsync(cancellationToken),
+                    ["projects"] = projects.GetProjects(),
+                    ["projectSessions"] = sessions.GetSessions(),
+                    ["updateRollouts"] = await workers.GetUpdateRolloutsAsync(cancellationToken),
+                    ["runnerOrchestration"] = orchestration.GetCatalog()
+                },
+                KnownLimitations =
+                [
+                    "Coordinator registries are process-local; this bundle is a point-in-time memory snapshot, not durable HA state.",
+                    "Secrets are represented as configured/unconfigured booleans or redacted placeholders, not raw values.",
+                    "Project repository dirty-state tracking, local pairing, and broader coordinator/Core integration tests remain follow-up work."
+                ]
+            };
+
+            return Results.Ok(bundle);
+        });
 
         app.MapGet("/artifacts/{**artifactPath}", (string artifactPath, ICoordinatorArtifactService artifacts) =>
         {

--- a/AgentDeck.Runner.Tests/AgentDeckDiagnosticRedactorTests.cs
+++ b/AgentDeck.Runner.Tests/AgentDeckDiagnosticRedactorTests.cs
@@ -1,0 +1,36 @@
+using AgentDeck.Shared;
+using Xunit;
+
+namespace AgentDeck.Runner.Tests;
+
+public sealed class AgentDeckDiagnosticRedactorTests
+{
+    [Theory]
+    [InlineData("AccessKey")]
+    [InlineData("AGENTDECK_ACCESS_KEY")]
+    [InlineData("PrivateKeyPem")]
+    [InlineData("connectionString")]
+    [InlineData("token")]
+    [InlineData("password")]
+    public void IsSensitiveName_FlagsSecretLikeNames(string name)
+    {
+        Assert.True(AgentDeckDiagnosticRedactor.IsSensitiveName(name));
+    }
+
+    [Theory]
+    [InlineData("BindAddress")]
+    [InlineData("CoordinatorUrl")]
+    [InlineData("MachineName")]
+    public void IsSensitiveName_AllowsOperationalNames(string name)
+    {
+        Assert.False(AgentDeckDiagnosticRedactor.IsSensitiveName(name));
+    }
+
+    [Fact]
+    public void Redact_HidesConfiguredSensitiveValues()
+    {
+        Assert.Equal(AgentDeckDiagnosticRedactor.RedactedValue, AgentDeckDiagnosticRedactor.Redact("AccessKey", "secret"));
+        Assert.Equal("", AgentDeckDiagnosticRedactor.Redact("AccessKey", ""));
+        Assert.Equal("http://localhost:5001", AgentDeckDiagnosticRedactor.Redact("CoordinatorUrl", "http://localhost:5001"));
+    }
+}

--- a/AgentDeck.Runner/Endpoints/RunnerEndpointModules.cs
+++ b/AgentDeck.Runner/Endpoints/RunnerEndpointModules.cs
@@ -1,7 +1,11 @@
 using AgentDeck.Runner.Hubs;
+using AgentDeck.Runner.Configuration;
 using AgentDeck.Runner.Services;
+using AgentDeck.Shared;
 using AgentDeck.Shared.Enums;
 using AgentDeck.Shared.Models;
+using Microsoft.Extensions.Options;
+using System.Runtime.InteropServices;
 
 namespace AgentDeck.Runner.Endpoints;
 
@@ -257,6 +261,102 @@ public static class RunnerEndpointModules
         app.MapGet("/api/workspace", (IWorkspaceService workspace) =>
             Results.Ok(workspace.GetWorkspaceInfo()));
 
+        app.MapGet("/api/diagnostics/bundle", async (
+            IOptions<RunnerOptions> runnerOptions,
+            IOptions<WorkerCoordinatorOptions> coordinatorOptions,
+            IOptions<TrustPolicyOptions> trustPolicyOptions,
+            IOptions<RunnerLocalSecurityPolicyOptions> localSecurityOptions,
+            IWorkspaceService workspace,
+            IAgentSessionStore sessions,
+            IOrchestrationJobService jobs,
+            IRemoteViewerSessionService viewers,
+            IMachineCapabilityService capabilities,
+            IRunnerWorkflowCatalogService workflowCatalog,
+            IRunnerCapabilityCatalogService capabilityCatalog,
+            IRunnerSetupCatalogService setupCatalog,
+            IRunnerUpdateStagingService updateStaging,
+            IRunnerWorkflowPackService workflowPacks,
+            IRunnerAuditService audit,
+            CoordinatorRunnerConnectionState coordinatorConnection,
+            CancellationToken cancellationToken) =>
+        {
+            var runner = runnerOptions.Value;
+            var coordinator = coordinatorOptions.Value;
+            var localSecurity = localSecurityOptions.Value;
+            var trustPolicy = trustPolicyOptions.Value;
+            var capabilitySnapshot = await capabilities.GetSnapshotAsync(cancellationToken);
+
+            var bundle = CreateBaseBundle("runner") with
+            {
+                Configuration = new Dictionary<string, object?>
+                {
+                    ["runner"] = new Dictionary<string, object?>
+                    {
+                        ["workspaceRoot"] = runner.WorkspaceRoot,
+                        ["port"] = runner.Port,
+                        ["bindAddress"] = runner.BindAddress,
+                        ["allowedOrigins"] = runner.AllowedOrigins,
+                        ["accessKeyConfigured"] = AgentDeckAccessKey.IsConfigured(runner.AccessKey),
+                        ["defaultShell"] = runner.DefaultShell
+                    },
+                    ["coordinator"] = new Dictionary<string, object?>
+                    {
+                        ["coordinatorUrl"] = coordinator.CoordinatorUrl,
+                        ["machineId"] = coordinator.MachineId,
+                        ["machineName"] = coordinator.MachineName,
+                        ["protocolVersion"] = coordinator.ProtocolVersion,
+                        ["workflowCatalogVersion"] = coordinator.WorkflowCatalogVersion,
+                        ["controlChannelTransport"] = coordinator.ControlChannelTransport.ToString(),
+                        ["accessKeyConfigured"] = AgentDeckAccessKey.IsConfigured(coordinator.AccessKey)
+                    },
+                    ["trustPolicy"] = new Dictionary<string, object?>
+                    {
+                        ["actorHeaderName"] = trustPolicy.ActorHeaderName,
+                        ["requireActorHeaderForPrivilegedActions"] = trustPolicy.RequireActorHeaderForPrivilegedActions,
+                        ["requireLoopbackForMachineSetup"] = trustPolicy.RequireLoopbackForMachineSetup,
+                        ["requireLoopbackForDesktopViewerBootstrap"] = trustPolicy.RequireLoopbackForDesktopViewerBootstrap
+                    },
+                    ["localSecurityPolicy"] = new Dictionary<string, object?>
+                    {
+                        ["requireSignedUpdateManifest"] = localSecurity.RequireSignedUpdateManifest,
+                        ["requireManifestProvenance"] = localSecurity.RequireManifestProvenance,
+                        ["requireSignedWorkflowPacks"] = localSecurity.RequireSignedWorkflowPacks,
+                        ["requireSignedCapabilityCatalogs"] = localSecurity.RequireSignedCapabilityCatalogs,
+                        ["requireSignedSetupCatalogs"] = localSecurity.RequireSignedSetupCatalogs,
+                        ["allowDevSignerInProduction"] = localSecurity.AllowDevSignerInProduction,
+                        ["trustedSignerIds"] = localSecurity.TrustedSignerIds
+                    }
+                },
+                State = new Dictionary<string, object?>
+                {
+                    ["coordinatorConnection"] = new Dictionary<string, object?>
+                    {
+                        ["state"] = coordinatorConnection.Connection?.State.ToString() ?? "Disconnected",
+                        ["connectionId"] = coordinatorConnection.Connection?.ConnectionId
+                    },
+                    ["workspace"] = workspace.GetWorkspaceInfo(),
+                    ["terminalSessions"] = sessions.GetAll(),
+                    ["orchestrationJobs"] = jobs.GetAll(),
+                    ["viewerSessions"] = viewers.GetAll(),
+                    ["capabilities"] = capabilitySnapshot,
+                    ["workflowCatalogStatus"] = await workflowCatalog.GetCurrentStatusAsync(cancellationToken),
+                    ["capabilityCatalogStatus"] = await capabilityCatalog.GetCurrentStatusAsync(cancellationToken),
+                    ["setupCatalogStatus"] = await setupCatalog.GetCurrentStatusAsync(cancellationToken),
+                    ["updateStatus"] = await updateStaging.GetCurrentStatusAsync(cancellationToken),
+                    ["workflowPackStatus"] = await workflowPacks.GetCurrentStatusAsync(cancellationToken),
+                    ["recentAuditEvents"] = audit.GetRecent()
+                },
+                KnownLimitations =
+                [
+                    "Diagnostic bundles are local snapshots and do not include durable terminal scrollback beyond current in-memory session state.",
+                    "Secrets are represented as configured/unconfigured booleans or redacted placeholders, not raw values.",
+                    "Coordinator persistence/HA and full project repository dirty-state tracking remain follow-up work."
+                ]
+            };
+
+            return Results.Ok(bundle);
+        });
+
         app.MapPost("/api/projects/open", async (OpenProjectOnRunnerRequest request, IProjectWorkspaceBootstrapService bootstrap, CancellationToken cancellationToken) =>
         {
             try
@@ -338,4 +438,14 @@ public static class RunnerEndpointModules
             },
             statusCode: StatusCodes.Status403Forbidden);
     }
+
+    private static AgentDeckDiagnosticBundle CreateBaseBundle(string component) => new()
+    {
+        Component = component,
+        GeneratedAt = DateTimeOffset.UtcNow.ToString("O"),
+        MachineName = Environment.MachineName,
+        OperatingSystem = RuntimeInformation.OSDescription,
+        ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+        FrameworkDescription = RuntimeInformation.FrameworkDescription
+    };
 }

--- a/AgentDeck.Shared/AgentDeckDiagnosticRedactor.cs
+++ b/AgentDeck.Shared/AgentDeckDiagnosticRedactor.cs
@@ -1,0 +1,61 @@
+namespace AgentDeck.Shared;
+
+/// <summary>Helpers for exposing diagnostic configuration without leaking local secrets.</summary>
+public static class AgentDeckDiagnosticRedactor
+{
+    public const string RedactedValue = "*** redacted ***";
+
+    private static readonly string[] SensitiveNameFragments =
+    [
+        "accesskey",
+        "access_key",
+        "apikey",
+        "api_key",
+        "token",
+        "secret",
+        "password",
+        "privatekey",
+        "private_key",
+        "certificate",
+        "connectionstring",
+        "connection_string"
+    ];
+
+    public static bool IsSensitiveName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        var normalized = new string(name
+            .Where(static ch => char.IsLetterOrDigit(ch) || ch == '_')
+            .Select(static ch => char.ToLowerInvariant(ch))
+            .ToArray());
+
+        return SensitiveNameFragments.Any(fragment => normalized.Contains(fragment, StringComparison.Ordinal));
+    }
+
+    public static object? Redact(string? name, object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (IsSensitiveName(name))
+        {
+            return IsConfigured(value) ? RedactedValue : "";
+        }
+
+        return value;
+    }
+
+    public static bool IsConfigured(object? value) => value switch
+    {
+        null => false,
+        string text => !string.IsNullOrWhiteSpace(text),
+        IEnumerable<string> values => values.Any(static value => !string.IsNullOrWhiteSpace(value)),
+        _ => true
+    };
+}

--- a/AgentDeck.Shared/Models/AgentDeckDiagnosticBundle.cs
+++ b/AgentDeck.Shared/Models/AgentDeckDiagnosticBundle.cs
@@ -1,0 +1,15 @@
+namespace AgentDeck.Shared.Models;
+
+/// <summary>Redacted local diagnostic snapshot for troubleshooting an AgentDeck component.</summary>
+public sealed record AgentDeckDiagnosticBundle
+{
+    public required string Component { get; init; }
+    public required string GeneratedAt { get; init; }
+    public required string MachineName { get; init; }
+    public required string OperatingSystem { get; init; }
+    public required string ProcessArchitecture { get; init; }
+    public required string FrameworkDescription { get; init; }
+    public IReadOnlyDictionary<string, object?> Configuration { get; init; } = new Dictionary<string, object?>();
+    public IReadOnlyDictionary<string, object?> State { get; init; } = new Dictionary<string, object?>();
+    public IReadOnlyList<string> KnownLimitations { get; init; } = [];
+}

--- a/README.md
+++ b/README.md
@@ -371,6 +371,13 @@ VS Code-backed debug jobs now build first, materialize `.vscode` debug assets pl
 
 Privileged orchestration, viewer, and machine setup actions now also run through a first-pass trust-policy hook and emit bounded audit records at `/api/audit/events`. Audit entries include the action, actor, remote address, target, and success/denied/failed outcome so later authorization work has a stable trail to build on.
 
+For troubleshooting, both services now expose redacted local diagnostic bundles:
+
+- Coordinator: `GET /api/diagnostics/bundle`
+- Runner: `GET /api/diagnostics/bundle`
+
+The coordinator bundle captures a point-in-time snapshot of coordinator configuration, desired runner definitions, companions, machines, projects, project sessions, update rollouts, and runner-orchestration state. The runner bundle captures runtime configuration, coordinator connection state, workspace info, terminal sessions, orchestration jobs, viewer sessions, capability/setup/update/workflow status, and recent audit events. Secret-like values are not emitted; access keys and signer/private-key settings are represented as configured/unconfigured booleans or redacted placeholders. Use these bundles when debugging local setup, firewall/bind issues, stale sessions, runner update problems, viewer bootstrap failures, or workflow-pack state without manually collecting many separate endpoints.
+
 The runner now also exposes a remote viewer API with provider capabilities and viewer-session records distinct from both jobs and terminal sessions. Runtime viewer readiness is now based on the AgentDeck-managed helper transport for supported desktop, VS Code, emulator, simulator, and window targets. Platform-native remoting fallbacks such as Windows RDP, macOS Screen Sharing, and Linux `x11vnc` are no longer part of the default ready path; they only apply when `DesktopViewerTransport:AllowNativeFallbackProviders` is explicitly enabled for compatibility-only scenarios. When a real managed transport is not available, the session fails explicitly instead of silently satisfying readiness through host-native remoting.
 
 Window-, emulator-, simulator-, and VS Code-targeted viewer sessions still remain additive modeling layers above the transport. They keep their distinct target metadata, and the bootstrap path now covers those session types too, but focused capture and transport-specific semantics for those narrower surfaces remain follow-up work on top of the shared helper seam.


### PR DESCRIPTION
Closes #431.

## Audit checklist summary

This pass audited current `main` against #373, #421, `GOAL.md` (read-only), README, product-vision docs, signing docs, implementation, tests, config, Docker, and CI.

Result: AgentDeck is **not yet feature-complete**. Major implemented areas include the local Coordinator/Runner/Companion shape, outbound runner control channel, project/session model, PTY terminals, managed viewer relay, capability/setup/update/workflow catalogs, local-safe binding defaults, optional access-key guard, orchestration job live updates, and CI. Material partial/missing areas remain in discovery/pairing, repo-state tracking, workflow extensibility, durable sessions/logs, companion presence, general destructive-action confirmations, local pairing, full autonomous agent safety metadata, broader integration tests, and diagnostics/exportability.

## Implemented in this PR

Focused on the high-priority diagnostics/observability gap from #421:

- Added shared redacted diagnostic bundle contract: `AgentDeckDiagnosticBundle`.
- Added diagnostic redaction helper/tests so secret-like names are classified consistently.
- Added Coordinator `GET /api/diagnostics/bundle` with:
  - runtime/host metadata
  - redacted coordinator config summary
  - desired runner/update/workflow/capability/setup definition summary
  - companions, machines, projects, project sessions, update rollouts, runner-orchestration state
  - known limitations/follow-up notes
- Added Runner `GET /api/diagnostics/bundle` with:
  - runtime/host metadata
  - redacted runner/coordinator/trust/local-security config summary
  - coordinator connection state
  - workspace, terminal sessions, orchestration jobs, viewer sessions
  - capability, workflow/setup/update/workflow-pack status
  - recent audit events
  - known limitations/follow-up notes
- Documented the diagnostic bundle endpoints and intended use in README.

Design decision: keep local/trusted-LAN flows simple. The new diagnostics endpoints inherit the existing optional access-key middleware when configured; they do not add enterprise auth or cloud identity.

## Deferred / blocked with rationale

Still intentionally deferred because they are larger than one coherent pass or need a separate design slice:

- Coordinator/Core integration tests across hubs and UI state.
- Full project repo-state tracking: branch/remotes/dirty/untracked state and best-runner ranking.
- Local pairing/setup-code flow beyond optional shared access key.
- Durable coordinator persistence/HA.
- General destructive-action confirmation policy.
- Native child-window inventory and complete viewer recovery flows.
- Full replacement of closed workload/launch enums.
- End-to-end autonomous agent safety policy for branch/validation/PR metadata.

## Validation

Passed:

```text
dotnet build AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
Passed: 23, Failed: 0, Skipped: 0
```

Full solution build blocker on this host:

```text
dotnet build AgentDeck.slnx --no-restore
error XA5300: The Android SDK directory could not be found.
```

`GOAL.md` remained untracked and untouched.
