### PR TITLE
Polish diagnostics and setup health language

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -121,7 +121,7 @@
                                         @if (!machine.ProtocolCompatible)
                                         {
                                             <span class="project-target-chip project-target-chip--unsupported">
-                                                Protocol incompatible
+                                                Needs app/machine update
                                             </span>
                                         }
                                         @if (machine.UpdateRollout is { } rollout)
@@ -461,8 +461,8 @@
     {
         RunnerUpdateRolloutState.UpToDate => "Up to date",
         RunnerUpdateRolloutState.UpdateAvailable => "Update available",
-        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
-        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ManifestStaged => "Update details ready",
+        RunnerUpdateRolloutState.PayloadStaged => "Update downloaded",
         RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
         RunnerUpdateRolloutState.Applying => "Applying",
         RunnerUpdateRolloutState.Applied => "Applied",

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -105,7 +105,7 @@
                                     @if (!machine.ProtocolCompatible)
                                     {
                                         <span class="project-target-chip project-target-chip--unsupported">
-                                            Protocol incompatible
+                                            Needs app/machine update
                                         </span>
                                     }
                                     @if (machine.UpdateRollout is { } rollout && ShouldShowUpdateRolloutChip(rollout.State))
@@ -1318,8 +1318,8 @@
     {
         RunnerUpdateRolloutState.UpToDate => "Up to date",
         RunnerUpdateRolloutState.UpdateAvailable => "Update available",
-        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
-        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ManifestStaged => "Update details ready",
+        RunnerUpdateRolloutState.PayloadStaged => "Update downloaded",
         RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
         RunnerUpdateRolloutState.Applying => "Applying",
         RunnerUpdateRolloutState.Applied => "Applied",
@@ -1451,7 +1451,7 @@
             RemoteViewerTargetKind.VsCode => "VS Code",
             RemoteViewerTargetKind.Emulator => "Emulator",
             RemoteViewerTargetKind.Simulator => "Simulator",
-            _ => "Viewer"
+            _ => "Remote screen"
         };
         return $"{label} • {viewer.Provider}";
     }

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -50,7 +50,7 @@
                             @if (!_sessionMachine.ProtocolCompatible)
                             {
                                 <span class="project-target-chip project-target-chip--unsupported">
-                                    Protocol incompatible
+                                    Needs app/machine update
                                 </span>
                             }
                             @if (_sessionMachine.UpdateRollout is { } rollout && ShouldShowUpdateRolloutChip(rollout.State))
@@ -592,8 +592,8 @@
     {
         RunnerUpdateRolloutState.UpToDate => "Up to date",
         RunnerUpdateRolloutState.UpdateAvailable => "Update available",
-        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
-        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ManifestStaged => "Update details ready",
+        RunnerUpdateRolloutState.PayloadStaged => "Update downloaded",
         RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
         RunnerUpdateRolloutState.Applying => "Applying",
         RunnerUpdateRolloutState.Applied => "Applied",
@@ -709,7 +709,7 @@
         ProjectSessionSurfaceKind.VsCode => "VS Code",
         ProjectSessionSurfaceKind.Simulator => "Simulator",
         ProjectSessionSurfaceKind.Emulator => "Emulator",
-        ProjectSessionSurfaceKind.Viewer => "Screen / app window",
+        ProjectSessionSurfaceKind.Viewer => "Remote screen",
         _ => "Workspace item"
     };
 
@@ -769,7 +769,7 @@
             RemoteViewerTargetKind.VsCode => "VS Code",
             RemoteViewerTargetKind.Emulator => "Emulator",
             RemoteViewerTargetKind.Simulator => "Simulator",
-            _ => "Viewer"
+            _ => "Remote screen"
         };
         return $"{label} • {viewer.Provider}";
     }

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -403,7 +403,7 @@
                         @if (!string.IsNullOrWhiteSpace(rollout.DesiredManifestId))
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Desired manifest</span>
+                                <span class="settings-status-row__label">Update package</span>
                                 <span class="settings-status-row__value">@GetDesiredManifestLabel(rollout)</span>
                             </div>
                         }
@@ -518,27 +518,27 @@
                              workflowCatalogStatus.State != RunnerWorkflowCatalogState.Unknown)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Tool catalog state</span>
+                                <span class="settings-status-row__label">Tool list state</span>
                                 <span class="settings-status-row__value">@GetWorkflowCatalogStateLabel(workflowCatalogStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.LocalCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Local tool catalog</span>
+                                    <span class="settings-status-row__label">Installed tool list</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.LocalCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.DesiredCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Desired tool catalog</span>
+                                    <span class="settings-status-row__label">Expected tool list</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.DesiredCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowCatalogStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Tool catalog summary</span>
+                                    <span class="settings-status-row__label">Tool list summary</span>
                                     <span class="settings-status-row__value">@workflowCatalogStatus.StatusMessage</span>
                                 </div>
                             }
@@ -547,27 +547,27 @@
                              capabilityCatalogStatus.State != RunnerCapabilityCatalogState.Unknown)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Capability catalog state</span>
+                                <span class="settings-status-row__label">Capability list state</span>
                                 <span class="settings-status-row__value">@GetCapabilityCatalogStateLabel(capabilityCatalogStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.LocalCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Local capability catalog</span>
+                                    <span class="settings-status-row__label">Installed capability list</span>
                                     <span class="settings-status-row__value">@capabilityCatalogStatus.LocalCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.DesiredCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Desired capability catalog</span>
+                                    <span class="settings-status-row__label">Expected capability list</span>
                                     <span class="settings-status-row__value">@capabilityCatalogStatus.DesiredCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(capabilityCatalogStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Capability catalog summary</span>
+                                    <span class="settings-status-row__label">Capability list summary</span>
                                     <span class="settings-status-row__value">@capabilityCatalogStatus.StatusMessage</span>
                                 </div>
                             }
@@ -576,27 +576,27 @@
                              setupCatalogStatus.State != RunnerSetupCatalogState.Unknown)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Setup catalog state</span>
+                                <span class="settings-status-row__label">Setup list state</span>
                                 <span class="settings-status-row__value">@GetSetupCatalogStateLabel(setupCatalogStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.LocalCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Local setup catalog</span>
+                                    <span class="settings-status-row__label">Installed setup list</span>
                                     <span class="settings-status-row__value">@setupCatalogStatus.LocalCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.DesiredCatalogVersion))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Desired setup catalog</span>
+                                    <span class="settings-status-row__label">Expected setup list</span>
                                     <span class="settings-status-row__value">@setupCatalogStatus.DesiredCatalogVersion</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(setupCatalogStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Setup catalog summary</span>
+                                    <span class="settings-status-row__label">Setup list summary</span>
                                     <span class="settings-status-row__value">@setupCatalogStatus.StatusMessage</span>
                                 </div>
                             }
@@ -849,8 +849,16 @@
                         <code class="settings-status-row__value">@_settings.CoordinatorUrl</code>
                     </div>
                     <div class="settings-status-row">
+                        <span class="settings-status-row__label">Service diagnostic bundle</span>
+                        <code class="settings-status-row__value">@GetServiceDiagnosticBundleUrl()</code>
+                    </div>
+                    <div class="settings-status-row">
                         <span class="settings-status-row__label">Advertised machine agent URL</span>
                         <code class="settings-status-row__value">@(!string.IsNullOrWhiteSpace(SelectedMachine.RunnerUrl) ? SelectedMachine.RunnerUrl : "Not advertised")</code>
+                    </div>
+                    <div class="settings-status-row">
+                        <span class="settings-status-row__label">Machine diagnostic bundle</span>
+                        <code class="settings-status-row__value">@GetMachineDiagnosticBundleUrl(SelectedMachine)</code>
                     </div>
                     @if (SelectedRegisteredMachine is not null)
                     {
@@ -1093,8 +1101,8 @@
     {
         RunnerUpdateRolloutState.UpToDate => "Up to date",
         RunnerUpdateRolloutState.UpdateAvailable => "Update available",
-        RunnerUpdateRolloutState.ManifestStaged => "Manifest staged",
-        RunnerUpdateRolloutState.PayloadStaged => "Payload staged",
+        RunnerUpdateRolloutState.ManifestStaged => "Update details ready",
+        RunnerUpdateRolloutState.PayloadStaged => "Update downloaded",
         RunnerUpdateRolloutState.ReadyToApply => "Ready to apply",
         RunnerUpdateRolloutState.Applying => "Applying",
         RunnerUpdateRolloutState.Applied => "Applied",
@@ -1200,6 +1208,16 @@
         string.IsNullOrWhiteSpace(_settings.CoordinatorUrl)
             ? "(AgentDeck service URL not configured)"
             : $"{_settings.CoordinatorUrl.TrimEnd('/')}/hubs/agent";
+
+    private string GetServiceDiagnosticBundleUrl() =>
+        string.IsNullOrWhiteSpace(_settings.CoordinatorUrl)
+            ? "Set the AgentDeck service URL first"
+            : $"{_settings.CoordinatorUrl.TrimEnd('/')}/api/diagnostics/bundle";
+
+    private static string GetMachineDiagnosticBundleUrl(RunnerMachineSettings machine) =>
+        string.IsNullOrWhiteSpace(machine.RunnerUrl)
+            ? "Machine agent URL not advertised"
+            : $"{machine.RunnerUrl.TrimEnd('/')}/api/diagnostics/bundle";
 
     private Task RefreshMachineCapabilitiesIfPossibleAsync()
     {
@@ -1370,9 +1388,9 @@
             {
                 MachineUpdateApplyIntentMode.RequestApply => "requested apply",
                 MachineUpdateApplyIntentMode.StageOnly => "switched to stage-only",
-                _ => "restored the coordinator default"
+                _ => "restored the service default"
             };
-            ToastService.Show($"Coordinator {actionLabel} for {rollout.MachineName}.", ToastKind.Success);
+            ToastService.Show($"AgentDeck service {actionLabel} for {rollout.MachineName}.", ToastKind.Success);
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)
@@ -1404,7 +1422,7 @@
                 return;
             }
 
-            ToastService.Show("Workflow-pack retry requested. The machine will retry on its next heartbeat.", ToastKind.Success);
+            ToastService.Show("Tool-pack retry requested. The machine will retry on its next check-in.", ToastKind.Success);
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)
@@ -1418,7 +1436,7 @@
         }
     }
 
-    private static string GetCoordinatorUrlPlaceholder() => "https://coordinator-host:5001";
+    private static string GetCoordinatorUrlPlaceholder() => "https://agentdeck-service:5001";
 
     private static string GetRunnerUrlPlaceholder() => "https://machine-host:5000 (informational)";
 

--- a/AgentDeck.Core/Services/RunnerConnectionManager.cs
+++ b/AgentDeck.Core/Services/RunnerConnectionManager.cs
@@ -127,7 +127,7 @@ public sealed class RunnerConnectionManager : IRunnerConnectionManager, IAsyncDi
         var settings = await _settingsService.LoadAsync();
         if (string.IsNullOrWhiteSpace(settings.CoordinatorUrl))
         {
-            throw new InvalidOperationException("Coordinator URL is not configured.");
+            throw new InvalidOperationException("AgentDeck service URL is not configured.");
         }
 
         _client.AccessKey = settings.AccessKey;

--- a/README.md
+++ b/README.md
@@ -106,36 +106,36 @@ dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
 
 A full solution build on Linux also targets Android; install the Android SDK or build a specific framework if you only want the desktop companion app.
 
-### Running the Coordinator API
+### Running the AgentDeck service
 
 ```bash
 cd AgentDeck.Coordinator
 dotnet run
 ```
 
-The coordinator starts on `http://localhost:5001` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Use `AGENTDECK_COORDINATOR_PORT` and `AGENTDECK_COORDINATOR_BIND_ADDRESS` to override those startup defaults; for example, set `AGENTDECK_COORDINATOR_BIND_ADDRESS=0.0.0.0` only when you intend to expose the coordinator to other devices on a trusted network. Set `Coordinator:AccessKey` or `AGENTDECK_COORDINATOR_ACCESS_KEY` to require the same shared key on coordinator API and SignalR calls (health checks stay unauthenticated for local readiness probes).
+The AgentDeck service starts on `http://localhost:5001` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Use `AGENTDECK_COORDINATOR_PORT` and `AGENTDECK_COORDINATOR_BIND_ADDRESS` to override those startup defaults; for example, set `AGENTDECK_COORDINATOR_BIND_ADDRESS=0.0.0.0` only when you intend to expose the service to other devices on a trusted network. Set `Coordinator:AccessKey` or `AGENTDECK_COORDINATOR_ACCESS_KEY` to require the same shared key on service API and SignalR calls (health checks stay unauthenticated for local readiness probes).
 
-### Running the Runner
+### Running a machine agent
 
 ```bash
 cd AgentDeck.Runner
 dotnet run
 ```
 
-The runner starts on `http://localhost:5000` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Browser CORS origins are denied by default; configure `AllowedOrigins` only for trusted companion origins, or use `["*"]` for local development experiments. Set `Runner:AccessKey` or `AGENTDECK_ACCESS_KEY` to require the same shared key on direct runner API and SignalR calls; set `Coordinator:AccessKey` or `AGENTDECK_COORDINATOR_ACCESS_KEY` when this runner registers with a protected coordinator.
+The machine agent starts on `http://localhost:5000` by default and binds to loopback (`127.0.0.1`) unless you explicitly opt into a LAN-facing address. Browser CORS origins are denied by default; configure `AllowedOrigins` only for trusted companion origins, or use `["*"]` for local development experiments. Set `Runner:AccessKey` or `AGENTDECK_ACCESS_KEY` to require the same shared key on direct machine-agent API and SignalR calls; set `Coordinator:AccessKey` or `AGENTDECK_COORDINATOR_ACCESS_KEY` when this machine registers with a protected AgentDeck service.
 
 Use these environment variables to override runtime defaults:
 
 - `AGENTDECK_WORKSPACE` sets the workspace root (defaults to `~/AgentDeck`)
 - `AGENTDECK_PORT` sets the HTTP port (defaults to `5000`)
 - `AGENTDECK_BIND_ADDRESS` sets the listening address (defaults to `127.0.0.1`; use `0.0.0.0` only for intentional LAN/container exposure)
-- `AGENTDECK_ACCESS_KEY` sets the optional shared key for direct runner access
-- `AGENTDECK_COORDINATOR_ACCESS_KEY` sets the optional shared key used when the runner talks to a protected coordinator
+- `AGENTDECK_ACCESS_KEY` sets the optional shared key for direct machine-agent access
+- `AGENTDECK_COORDINATOR_ACCESS_KEY` sets the optional shared key used when the machine agent talks to a protected AgentDeck service
 - `AGENTDECK_DEFAULT_SHELL` sets the default shell command
 
 The companion app now starts with an empty AgentDeck service URL plus auto-connect disabled by default. Configure a network-reachable service explicitly instead of assuming `localhost`, which is only valid when the service is actually running on the same device as the app. If the service uses an access key, enter the same key in Settings so app HTTP and hub calls include `X-AgentDeck-Access-Key`.
 
-### Running the Runner in Docker (Linux)
+### Running a machine agent in Docker (Linux)
 
 Build the image from the repository root:
 
@@ -143,7 +143,7 @@ Build the image from the repository root:
 docker build -t agentdeck-runner -f AgentDeck.Runner/Dockerfile .
 ```
 
-Run the container with a mounted workspace and coordinator registration settings. On Docker Desktop, `host.docker.internal` reaches the host coordinator; on native Linux, replace it with a LAN-reachable host name/IP or add Docker's host-gateway mapping for that name.
+Run the container with a mounted workspace and AgentDeck service registration settings. On Docker Desktop, `host.docker.internal` reaches the host service; on native Linux, replace it with a LAN-reachable host name/IP or add Docker's host-gateway mapping for that name.
 
 ```bash
 docker run --rm \
@@ -151,18 +151,18 @@ docker run --rm \
   -e AGENTDECK_WORKSPACE=/workspace \
   -e Coordinator__CoordinatorUrl=http://host.docker.internal:5001 \
   -e Coordinator__MachineId=local-docker \
-  -e Coordinator__MachineName="Local Docker Runner" \
+  -e Coordinator__MachineName="Local Docker machine" \
   -v "$(pwd):/workspace" \
   agentdeck-runner
 ```
 
 The image exposes port `5000`, defaults the workspace to `/workspace`, explicitly sets `AGENTDECK_BIND_ADDRESS=0.0.0.0` so Docker port publishing works, sets `ASPNETCORE_ENVIRONMENT=Production` so detailed error responses are off, and falls back to `/bin/sh` if `/bin/bash` is unavailable. Override with `-e ASPNETCORE_ENVIRONMENT=Development` if you want development-only diagnostics (verbose SignalR errors, dev-only middleware, etc.) — never in a deployment exposed to untrusted networks.
 
-The checked-in runner image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
+The checked-in machine-agent image now uses a Debian-based self-contained final stage instead of the stock minimal ASP.NET runtime image, includes the native ICU dependency that .NET needs at runtime, and runs as a non-root `agentdeck` user with passwordless `sudo` for machine-setup actions.
 
-If you run the runner inside a container, AgentDeck treats that container as just another machine. Keep `Coordinator__CoordinatorUrl` pointed at the coordinator URL the container can reach, then use the companion app through that coordinator to inspect which supported tools are installed and install missing ones inside that machine.
+If you run the machine agent inside a container, AgentDeck treats that container as just another machine. Keep `Coordinator__CoordinatorUrl` pointed at the AgentDeck service URL the container can reach, then use the companion app through that service to inspect which supported tools are installed and install missing ones inside that machine.
 
-If you override the container user, Linux setup actions still need either `root` or a passwd-backed user with passwordless `sudo`. Arbitrary numeric UIDs that are not present in `/etc/passwd` can run the runner, but they cannot perform privileged package installs through the setup flow.
+If you override the container user, Linux setup actions still need either `root` or a passwd-backed user with passwordless `sudo`. Arbitrary numeric UIDs that are not present in `/etc/passwd` can run the machine agent, but they cannot perform privileged package installs through the setup flow.
 
 ### Running the Companion App (Windows)
 
@@ -338,12 +338,12 @@ The companion app treats all of them the same way: connect to the coordinator, c
 The companion app supports multiple named runner machines.
 
 In **Settings** you can:
-- set the coordinator API URL used for machine discovery and control brokering
-- sync machines from the coordinator directory
+- set the AgentDeck service URL used for machine discovery and control handoff
+- sync machines from the AgentDeck service directory
 - assign each machine a role (`Standalone` or `Worker`)
 - set a default machine for new terminals
 - connect and disconnect each machine independently
-- inspect the coordinator-mediated connection status and hub URL for the selected machine
+- inspect the service-mediated connection status, hub URL, and diagnostic bundle URLs for the selected machine
 
 When you create a new terminal, you choose which machine it should run on.
 
@@ -371,12 +371,12 @@ VS Code-backed debug jobs now build first, materialize `.vscode` debug assets pl
 
 Privileged orchestration, viewer, and machine setup actions now also run through a first-pass trust-policy hook and emit bounded audit records at `/api/audit/events`. Audit entries include the action, actor, remote address, target, and success/denied/failed outcome so later authorization work has a stable trail to build on.
 
-For troubleshooting, both services now expose redacted local diagnostic bundles:
+For troubleshooting, the AgentDeck service and each machine agent expose redacted local diagnostic bundles. The app also shows these URLs in **Settings → Advanced** for the selected machine:
 
-- Coordinator: `GET /api/diagnostics/bundle`
-- Runner: `GET /api/diagnostics/bundle`
+- AgentDeck service: `GET /api/diagnostics/bundle`
+- Machine agent: `GET /api/diagnostics/bundle`
 
-The coordinator bundle captures a point-in-time snapshot of coordinator configuration, desired runner definitions, companions, machines, projects, project sessions, update rollouts, and runner-orchestration state. The runner bundle captures runtime configuration, coordinator connection state, workspace info, terminal sessions, orchestration jobs, viewer sessions, capability/setup/update/workflow status, and recent audit events. Secret-like values are not emitted; access keys and signer/private-key settings are represented as configured/unconfigured booleans or redacted placeholders. Use these bundles when debugging local setup, firewall/bind issues, stale sessions, runner update problems, viewer bootstrap failures, or workflow-pack state without manually collecting many separate endpoints.
+The service bundle captures a point-in-time snapshot of service configuration, desired machine definitions, connected users, machines, workspaces, workspace sessions, update rollouts, and machine-creation state. The machine bundle captures runtime configuration, service connection state, workspace info, terminal sessions, run/debug jobs, remote-screen sessions, capability/setup/update/tool status, and recent audit events. Secret-like values are not emitted; access keys and signer/private-key settings are represented as configured/unconfigured booleans or redacted placeholders. Use these bundles when debugging local setup, firewall/bind issues, stale sessions, machine update problems, remote-screen bootstrap failures, or tool-pack state without manually collecting many separate endpoints.
 
 The runner now also exposes a remote viewer API with provider capabilities and viewer-session records distinct from both jobs and terminal sessions. Runtime viewer readiness is now based on the AgentDeck-managed helper transport for supported desktop, VS Code, emulator, simulator, and window targets. Platform-native remoting fallbacks such as Windows RDP, macOS Screen Sharing, and Linux `x11vnc` are no longer part of the default ready path; they only apply when `DesktopViewerTransport:AllowNativeFallbackProviders` is explicitly enabled for compatibility-only scenarios. When a real managed transport is not available, the session fails explicitly instead of silently satisfying readiness through host-native remoting.
 

--- a/docs/product-vision-alignment.md
+++ b/docs/product-vision-alignment.md
@@ -16,4 +16,4 @@ These larger architecture items remain intentionally out of this slice:
 2. User-managed CLI presets and terminal quick actions.
 3. Auth/authz and AgentDeck service persistence.
 4. Native child-process window inventory per platform for fully automatic managed-terminal window surfacing.
-5. Workflow-pack marketplace/discovery UX in the companion app.
+5. Tool-pack marketplace/discovery UX in the companion app.


### PR DESCRIPTION
Closes #433

## Summary
- surface service and machine diagnostic bundle URLs in Settings advanced details
- replace protocol/manifest/catalog wording in normal setup health with app/machine update and tool-list language
- polish update/tool-pack toasts plus service URL placeholder
- align README setup headings with AgentDeck service and machine-agent wording

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
- git diff --check