### PR TITLE
Polish machine setup and control guidance

### DIFF
--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -35,6 +35,10 @@
                         <span class="setup-step__status">@step.StatusLabel</span>
                         <strong>@step.Title</strong>
                         <p>@step.Description</p>
+                        @if (!string.IsNullOrWhiteSpace(step.ActionHref) && !string.IsNullOrWhiteSpace(step.ActionLabel))
+                        {
+                            <a class="btn btn-accent" href="@step.ActionHref">@step.ActionLabel</a>
+                        }
                     </article>
                 }
             </div>
@@ -157,6 +161,12 @@
                                         </span>
                                     }
                                 </div>
+                                @if (MachineNeedsToolSetup(machine))
+                                {
+                                    <div class="project-machine-card__actions">
+                                        <a class="btn btn-accent" href="/settings#setup-capabilities">Check and install tools</a>
+                                    </div>
+                                }
                             </article>
                         }
                     </div>
@@ -305,8 +315,10 @@
         yield return new SetupStep(
             "Verify tools",
             _dashboard.Machines.Any(machine => machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)) ? "Done" : "Check",
-            "AgentDeck will call out missing tools before you open a workspace.",
-            _dashboard.Machines.Any(machine => machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)) ? "complete" : "todo");
+            MachineNeedsToolSetup() ? "Some machines need tools before they can open every workspace." : "AgentDeck will call out missing tools before you open a workspace.",
+            _dashboard.Machines.Any(machine => machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.Supported)) ? "complete" : "todo",
+            MachineNeedsToolSetup() ? "/settings#setup-capabilities" : null,
+            MachineNeedsToolSetup() ? "Check and install tools" : null);
         yield return new SetupStep(
             "Open a workspace",
             _dashboard.Projects.Count > 0 ? "Done" : "Next",
@@ -369,6 +381,12 @@
             ? "Ready"
             : "Needs setup";
     }
+
+    private bool MachineNeedsToolSetup() =>
+        _dashboard.Machines.Any(MachineNeedsToolSetup);
+
+    private static bool MachineNeedsToolSetup(CompanionMachineSummary machine) =>
+        machine.IsOnline && machine.SupportedTargets.Any(target => target.Status == MachineTargetSupportStatus.RequiresSetup);
 
     private static string GetMachineReadinessSummary(CompanionMachineSummary machine)
     {
@@ -500,8 +518,8 @@
 
     private static string GetWorkflowCatalogStateLabel(RunnerWorkflowCatalogState state) => state switch
     {
-        RunnerWorkflowCatalogState.Matched => "Matched",
-        RunnerWorkflowCatalogState.Mismatched => "Mismatched",
+        RunnerWorkflowCatalogState.Matched => "Current",
+        RunnerWorkflowCatalogState.Mismatched => "Out of date",
         _ => "Unknown"
     };
 
@@ -564,7 +582,7 @@
     private void OnSettingsChanged(object? sender, ConnectionSettings settings) =>
         _ = RefreshDashboardAsync();
 
-    private sealed record SetupStep(string Title, string StatusLabel, string Description, string StateClass);
+    private sealed record SetupStep(string Title, string StatusLabel, string Description, string StateClass, string? ActionHref = null, string? ActionLabel = null);
 
     public async ValueTask DisposeAsync()
     {

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -172,7 +172,7 @@
                                     <button class="btn btn-danger"
                                             disabled="@(!machine.IsOnline || _viewerActionMachineId == machine.MachineId)"
                                             @onclick="() => OpenDesktopViewerAsync(machine, forceTakeover: true)">
-                                        Force take over
+                                        Take control from them
                                     </button>
                                 }
                                 else if (remoteControlState is not null && IsCurrentRemoteController(remoteControlState))
@@ -443,7 +443,7 @@
                                             <button class="btn btn-danger"
                                                     disabled="@(_viewerActionViewerId == viewer.Id)"
                                                     @onclick="() => UpdateExistingViewerControlAsync(viewer, ProjectSessionControlRequestMode.ForceTakeover)">
-                                                Force take over
+                                                Take control from them
                                             </button>
                                         }
                                         else
@@ -1501,7 +1501,7 @@
 
         return IsCurrentRemoteController(state)
             ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote screen."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking control will stop their input control, but they can still view.";
     }
 
     private static bool CanControlViewer(RemoteViewerSession viewer) =>

--- a/AgentDeck.Core/Pages/ProjectSession.razor
+++ b/AgentDeck.Core/Pages/ProjectSession.razor
@@ -91,7 +91,7 @@
                 else
                 {
                     <button class="btn btn-accent" @onclick="RequestControlAsync">Request control</button>
-                    <button class="btn btn-danger" @onclick="ForceTakeoverAsync">Force take over</button>
+                    <button class="btn btn-danger" @onclick="ForceTakeoverAsync">Take control from them</button>
                 }
             </div>
         </div>
@@ -255,7 +255,7 @@
                                     <button class="btn btn-danger"
                                             disabled="@_viewerActionInProgress"
                                             @onclick="() => UpdateActiveViewerControlAsync(ProjectSessionControlRequestMode.ForceTakeover)">
-                                        Force take over
+                                        Take control from them
                                     </button>
                                 }
                                 else
@@ -1026,7 +1026,7 @@
 
         return IsCurrentRemoteController(_remoteControlState)
             ? $"You currently control {activeTarget} on this machine. Taking control here will switch the active remote screen."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking control will stop their input control, but they can still view.";
     }
 
     private bool CanControlActiveViewer() =>

--- a/AgentDeck.Core/Pages/RemoteViewer.razor
+++ b/AgentDeck.Core/Pages/RemoteViewer.razor
@@ -58,7 +58,7 @@
                     }
                     else if (HasAnotherCompanionControllingMachine())
                     {
-                        <button class="btn btn-danger" @onclick="ForceTakeoverAsync" disabled="@_busy">Force take over</button>
+                        <button class="btn btn-danger" @onclick="ForceTakeoverAsync" disabled="@_busy">Take control from them</button>
                     }
                     else if (ViewerClient.CanTakeControlCurrentViewer)
                     {
@@ -479,7 +479,7 @@
         var activeTarget = state.TargetDisplayName ?? state.TargetKind.ToString();
         return IsCurrentRemoteController(state)
             ? $"You currently control {activeTarget} on this machine. Input here is allowed, and Take control will switch the active remote screen."
-            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking this remote screen requires force takeover.";
+            : $"{controllerLabel} currently controls {activeTarget} on this machine. Taking control will stop their input control, but they can still view.";
     }
 
     private async Task RunBusyAsync(Func<Task> action)

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -11,13 +11,13 @@
     <div class="page-header settings-page__header">
         <div>
             <h1>Settings</h1>
-            <p>Connect AgentDeck, create machines, check required tools, manage updates, and keep advanced diagnostics in one place.</p>
+            <p>Connect AgentDeck, manage machines, check required tools, manage updates, and keep advanced diagnostics in one place.</p>
         </div>
     </div>
 
     <nav class="settings-nav" aria-label="Settings sections">
         <a href="#connection">Connection</a>
-        <a href="#machines">Create machines</a>
+        <a href="#machines">Machines</a>
         <a href="#setup-capabilities">Tools</a>
         <a href="#runner-updates">Updates</a>
         <a href="#advanced">Advanced diagnostics</a>
@@ -80,7 +80,7 @@
         }
         else if (_registeredMachines.Count == 0)
         {
-            <p>No machines are visible yet. Create a machine below or start an existing machine and refresh.</p>
+            <p>No machines are visible yet. Provision a machine below or start a machine agent manually and refresh.</p>
         }
         else
         {
@@ -159,11 +159,11 @@
     <div id="machines" class="settings-card settings-page__card settings-card--anchored">
         <div class="settings-card__header settings-page__section-header">
             <div>
-                <h2>Create machines</h2>
-                <p class="settings-card__description">Create new machine capacity, connect existing machines, and choose your default place to open work.</p>
+                <h2>Machines</h2>
+                <p class="settings-card__description">Provision new machine capacity, save existing machine connections, and choose your default place to open work.</p>
             </div>
             <div class="form-actions form-actions--toolbar">
-                <button class="btn btn-accent" @onclick="AddMachine">Add machine</button>
+                <button class="btn btn-accent" @onclick="AddMachine">Add machine profile</button>
                 <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
                     @(_saving ? "Saving..." : "Save")
                 </button>
@@ -176,8 +176,13 @@
         }
 
         <div class="settings-callout">
-            <strong>Create machine capacity</strong>
+            <strong>Provision a new machine</strong>
             <span>Use configured provider templates to create Linux/Windows/macOS machines on demand. Portainer is the first adapter; unsupported OS/provider combinations stay visible as planning targets instead of becoming dead-end buttons.</span>
+        </div>
+
+        <div class="settings-callout">
+            <strong>Start a machine agent manually</strong>
+            <span>On an existing machine, run <code>Coordinator__CoordinatorUrl=http://SERVICE-HOST:5001 dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj</code>, then refresh this page. Use a LAN host/IP when the machine is not the same device as the service.</span>
         </div>
 
         @if (_runnerOrchestrationCatalog.Templates.Count == 0)
@@ -281,6 +286,11 @@
             </div>
         }
 
+        <div class="settings-callout">
+            <strong>Saved machine connections</strong>
+            <span>These profiles are for machines you connect to directly or use as defaults. Shared machines usually appear automatically after they check in with the AgentDeck service.</span>
+        </div>
+
         <div class="machine-layout">
             <div class="machine-list machine-list--settings">
                 @foreach (var machine in _settings.Machines)
@@ -288,7 +298,7 @@
                     <button class="machine-card @(IsSelectedMachine(machine) ? "machine-card--selected" : "")"
                             @onclick="() => SelectMachine(machine.Id)">
                         <span class="machine-card__title">@machine.Name</span>
-                        <span class="machine-card__url">@machine.RunnerUrl</span>
+                        <span class="machine-card__url">@(string.IsNullOrWhiteSpace(machine.RunnerUrl) ? "Uses AgentDeck service discovery" : machine.RunnerUrl)</span>
                         <span class="machine-card__meta">
                             <span class="machine-badge">@GetMachineRoleLabel(machine.Role)</span>
                             @if (string.Equals(_settings.PreferredMachineId, machine.Id, StringComparison.OrdinalIgnoreCase))
@@ -311,12 +321,15 @@
                         <input id="machine-name" type="text" class="input" @bind="SelectedMachine.Name" />
                     </div>
 
-                    <div class="form-field">
-                        <label for="runner-url">Advertised machine agent URL</label>
-                        <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
-                               placeholder="@GetRunnerUrlPlaceholder()" />
-                        <p class="settings-card__description">Informational only. The app does not connect directly to this URL.</p>
-                    </div>
+                    <details class="advanced-panel advanced-panel--compact">
+                        <summary>Advanced direct diagnostics</summary>
+                        <div class="form-field">
+                            <label for="runner-url">Direct machine-agent URL, optional</label>
+                            <input id="runner-url" type="text" class="input" @bind="SelectedMachine.RunnerUrl"
+                                   placeholder="@GetRunnerUrlPlaceholder()" />
+                            <p class="settings-card__description">Usually filled by the machine when it registers. Only edit this for direct diagnostics or standalone development.</p>
+                        </div>
+                    </details>
 
                     <div class="form-field">
                         <label for="machine-role">Machine role</label>
@@ -374,8 +387,8 @@
                     </div>
                 </div>
                     <div class="settings-callout">
-                        <strong>Update lane</strong>
-                        <span>Use this section when AgentDeck has an update or tool pack ready for this machine. General machine editing stays above; setup tools stay below.</span>
+                        <strong>Updates available</strong>
+                        <span>Use this section when AgentDeck has an app update or tool setup update ready for this machine. General machine editing stays above; setup tools stay below.</span>
                     </div>
                     <div class="settings-status-list">
                     <div class="settings-status-row">
@@ -393,7 +406,7 @@
                     @if (SelectedRegisteredMachine?.UpdateRollout is { } rollout)
                     {
                         <div class="settings-status-row">
-                            <span class="settings-status-row__label">Update rollout</span>
+                            <span class="settings-status-row__label">Machine update</span>
                             <strong class="settings-status-row__value">@GetUpdateRolloutLabel(rollout.State)</strong>
                         </div>
                         <div class="settings-status-row">
@@ -408,28 +421,28 @@
                             </div>
                         }
                         <div class="settings-status-row">
-                            <span class="settings-status-row__label">Apply intent</span>
+                            <span class="settings-status-row__label">Install setting</span>
                             <span class="settings-status-row__value">@GetApplyIntentLabel(rollout)</span>
                         </div>
                         <div class="settings-status-row">
-                            <span class="settings-status-row__label">Rollout summary</span>
+                            <span class="settings-status-row__label">Update summary</span>
                             <span class="settings-status-row__value">@rollout.StatusMessage</span>
                         </div>
                         <div class="form-actions form-actions--settings">
                             <button class="btn btn-accent"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.RequestApply)">
-                                Apply update
+                                Install now
                             </button>
                             <button class="btn btn-primary"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.StageOnly)">
-                                Stage only
+                                Download only
                             </button>
                             <button class="btn"
                                     disabled="@(_updateIntentMachineId == SelectedMachine?.Id)"
                                     @onclick="() => UpdateMachineApplyIntentAsync(SelectedMachine!.Id, MachineUpdateApplyIntentMode.Inherit)">
-                                Use service default
+                                Follow service setting
                             </button>
                         </div>
                         @if (!string.IsNullOrWhiteSpace(rollout.BlockingReason))
@@ -471,7 +484,7 @@
                         @if (!string.IsNullOrWhiteSpace(SelectedRegisteredMachine?.DesiredWorkflowPackId))
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Desired tool pack</span>
+                                <span class="settings-status-row__label">Tool setup package</span>
                                 <span class="settings-status-row__value">@GetDesiredWorkflowPackLabel(SelectedRegisteredMachine)</span>
                             </div>
                         }
@@ -479,27 +492,27 @@
                              workflowPackStatus.State != RunnerWorkflowPackState.None)
                         {
                             <div class="settings-status-row">
-                                <span class="settings-status-row__label">Tool pack state</span>
+                                <span class="settings-status-row__label">Tool setup state</span>
                                 <span class="settings-status-row__value">@GetWorkflowPackStateLabel(workflowPackStatus.State)</span>
                             </div>
                             @if (!string.IsNullOrWhiteSpace(workflowPackStatus.StatusMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Tool pack summary</span>
+                                    <span class="settings-status-row__label">Tool setup summary</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.StatusMessage</span>
                                 </div>
                             }
                             @if (!string.IsNullOrWhiteSpace(workflowPackStatus.FailureMessage))
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Tool pack failure</span>
+                                    <span class="settings-status-row__label">Tool setup failure</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.FailureMessage</span>
                                 </div>
                             }
                             @if (workflowPackStatus.FetchedAt is not null)
                             {
                                 <div class="settings-status-row">
-                                    <span class="settings-status-row__label">Tool pack fetched</span>
+                                    <span class="settings-status-row__label">Tool setup downloaded</span>
                                     <span class="settings-status-row__value">@workflowPackStatus.FetchedAt.Value.ToLocalTime().ToString("g")</span>
                                 </div>
                             }
@@ -509,7 +522,7 @@
                                     <button class="btn btn-accent"
                                             disabled="@(_workflowPackRetryMachineId == SelectedMachine.Id)"
                                             @onclick="() => RetryWorkflowPackAsync(SelectedMachine.Id)">
-                                        @(_workflowPackRetryMachineId == SelectedMachine.Id ? "Retrying..." : "Retry tool pack")
+                                        @(_workflowPackRetryMachineId == SelectedMachine.Id ? "Retrying..." : "Retry tool setup")
                                     </button>
                                 </div>
                             }
@@ -853,7 +866,7 @@
                         <code class="settings-status-row__value">@GetServiceDiagnosticBundleUrl()</code>
                     </div>
                     <div class="settings-status-row">
-                        <span class="settings-status-row__label">Advertised machine agent URL</span>
+                        <span class="settings-status-row__label">Direct machine-agent URL</span>
                         <code class="settings-status-row__value">@(!string.IsNullOrWhiteSpace(SelectedMachine.RunnerUrl) ? SelectedMachine.RunnerUrl : "Not advertised")</code>
                     </div>
                     <div class="settings-status-row">
@@ -1083,7 +1096,7 @@
     private static string GetMachineRoleDescription(RunnerMachineRole role) => role switch
     {
         RunnerMachineRole.Worker => "Use this machine as shared capacity that checks in with the AgentDeck service.",
-        _ => "Use this machine independently without assigning it to shared machine orchestration yet."
+        _ => "Use this machine independently without assigning it to shared AgentDeck capacity yet."
     };
 
     private static string GetHostPlatformLabel(RunnerHostPlatform platform) => platform switch
@@ -1115,20 +1128,20 @@
     {
         if (rollout.ApplyEligible)
         {
-            return "Apply requested and eligible";
+            return "Install now when ready";
         }
 
         if (rollout.ApplyRequested && rollout.ApplyPermitted)
         {
-            return "Apply requested";
+            return "Install requested";
         }
 
         if (rollout.ApplyRequested)
         {
-            return "Apply requested but blocked by policy";
+            return "Install requested but blocked";
         }
 
-        return rollout.ApplyPermitted ? "Stage only" : "Apply disabled by policy";
+        return rollout.ApplyPermitted ? "Download only" : "Install disabled by policy";
     }
 
     private static string GetDesiredManifestLabel(RunnerUpdateRolloutStatus rollout) =>
@@ -1166,22 +1179,22 @@
 
     private static string GetWorkflowCatalogStateLabel(RunnerWorkflowCatalogState state) => state switch
     {
-        RunnerWorkflowCatalogState.Matched => "Matched",
-        RunnerWorkflowCatalogState.Mismatched => "Mismatched",
+        RunnerWorkflowCatalogState.Matched => "Current",
+        RunnerWorkflowCatalogState.Mismatched => "Out of date",
         _ => "Unknown"
     };
 
     private static string GetCapabilityCatalogStateLabel(RunnerCapabilityCatalogState state) => state switch
     {
-        RunnerCapabilityCatalogState.Matched => "Matched",
-        RunnerCapabilityCatalogState.Mismatched => "Mismatched",
+        RunnerCapabilityCatalogState.Matched => "Current",
+        RunnerCapabilityCatalogState.Mismatched => "Out of date",
         RunnerCapabilityCatalogState.Failed => "Failed",
         _ => "Unknown"
     };
 
     private static string GetSetupCatalogStateLabel(RunnerSetupCatalogState state) => state switch
     {
-        RunnerSetupCatalogState.Matched => "Matched",
+        RunnerSetupCatalogState.Matched => "Current",
         RunnerSetupCatalogState.Failed => "Failed",
         _ => "Unknown"
     };
@@ -1386,11 +1399,11 @@
 
             var actionLabel = mode switch
             {
-                MachineUpdateApplyIntentMode.RequestApply => "requested apply",
-                MachineUpdateApplyIntentMode.StageOnly => "switched to stage-only",
-                _ => "restored the service default"
+                MachineUpdateApplyIntentMode.RequestApply => "will install now when ready",
+                MachineUpdateApplyIntentMode.StageOnly => "will download only",
+                _ => "will follow the service setting"
             };
-            ToastService.Show($"AgentDeck service {actionLabel} for {rollout.MachineName}.", ToastKind.Success);
+            ToastService.Show($"Machine update for {rollout.MachineName} {actionLabel}.", ToastKind.Success);
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)
@@ -1422,7 +1435,7 @@
                 return;
             }
 
-            ToastService.Show("Tool-pack retry requested. The machine will retry on its next check-in.", ToastKind.Success);
+            ToastService.Show("Tool setup retry requested. The machine will retry on its next check-in.", ToastKind.Success);
             await RefreshCoordinatorDirectoryAsync();
         }
         catch (Exception ex)
@@ -1438,7 +1451,7 @@
 
     private static string GetCoordinatorUrlPlaceholder() => "https://agentdeck-service:5001";
 
-    private static string GetRunnerUrlPlaceholder() => "https://machine-host:5000 (informational)";
+    private static string GetRunnerUrlPlaceholder() => "https://machine-host:5000 (direct diagnostics only)";
 
     private void ClearCoordinatorDirectory()
     {

--- a/AgentDeck.Core/Services/AppInitializer.cs
+++ b/AgentDeck.Core/Services/AppInitializer.cs
@@ -33,7 +33,7 @@ public sealed class AppInitializer
         _connections.SessionCreated += (_, s) =>
         {
             _sessionState.AddOrUpdate(s);
-            _toast.Show($"Session '{s.Name}' started on {s.MachineName ?? "runner"}", ToastKind.Success);
+            _toast.Show($"Session '{s.Name}' started on {s.MachineName ?? "machine"}", ToastKind.Success);
         };
         _connections.OutputReceived += (_, output) => _sessionState.AppendOutput(output);
         _connections.SessionUpdated += (_, s) => _sessionState.AddOrUpdate(s);

--- a/AgentDeck.Core/Services/CompanionDashboardStateService.cs
+++ b/AgentDeck.Core/Services/CompanionDashboardStateService.cs
@@ -186,8 +186,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                         new CompanionViewerSurfaceSummary
                         {
                             Id = $"{project.Definition.Id}-android-emulator",
-                            Title = "Android emulator viewer",
-                            Description = $"{project.Definition.Name} can expose an Android emulator surface once orchestration is launched.",
+                            Title = "Android emulator screen",
+                            Description = $"{project.Definition.Name} can show an Android emulator remote screen after you launch a run option.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Ready on {string.Join(", ", target.ReadyMachineNames)}"
                                 : "No Android-ready machine discovered yet",
@@ -202,8 +202,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                         new CompanionViewerSurfaceSummary
                         {
                             Id = $"{project.Definition.Id}-ios-simulator",
-                            Title = "Apple simulator viewer",
-                            Description = $"{project.Definition.Name} can expose an Apple simulator surface once orchestration is launched.",
+                            Title = "Apple simulator screen",
+                            Description = $"{project.Definition.Name} can show an Apple simulator remote screen after you launch a run option.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Ready on {string.Join(", ", target.ReadyMachineNames)}"
                                 : "No Apple simulator-ready machine discovered yet",
@@ -218,8 +218,8 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                         new CompanionViewerSurfaceSummary
                         {
                             Id = $"{project.Definition.Id}-vscode-debugger",
-                            Title = "VS Code debugger surface",
-                            Description = $"{project.Definition.Name} debug sessions are expected to expose a VS Code-backed viewer surface.",
+                            Title = "VS Code debug screen",
+                            Description = $"{project.Definition.Name} debug sessions can show a VS Code remote screen.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Debug-capable target ready on {string.Join(", ", target.ReadyMachineNames)}"
                                 : "No debug-capable machine discovered yet",
@@ -235,7 +235,7 @@ public sealed class CompanionDashboardStateService : ICompanionDashboardStateSer
                         {
                             Id = $"{project.Definition.Id}-{target.Platform}-app-window",
                             Title = $"{target.DisplayName} app window",
-                            Description = $"Desktop/window viewer support for {project.Definition.Name} on {target.DisplayName} is modeled separately from terminals.",
+                            Description = $"{project.Definition.Name} can show a desktop or app-window remote screen on {target.DisplayName}.",
                             Availability = target.ReadyMachineNames.Count > 0
                                 ? $"Potentially hostable on {string.Join(", ", target.ReadyMachineNames)}"
                                 : "No ready machine discovered yet",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AgentDeck is being built to make it easy to:
 - discover what each machine can run, including CLIs, SDKs, IDEs, emulators/simulators, and remote-screen options
 - open a workspace on the best available machine for the requested workflow
 - launch terminals, app/debug workflows, and managed remote screens from one UI
-- keep machine tools, setup catalogs, and updates coordinated from the local AgentDeck service
+- keep machine tools, setup lists, and updates coordinated from the local AgentDeck service
 - support collaboration where one user controls a session while others can observe or request control
 
 ## Non-goals for Now
@@ -93,7 +93,7 @@ From a fresh checkout, the fastest reliable path is:
 
 3. Run the companion app for your platform and paste the AgentDeck service URL in **Settings → Connection**.
 
-Use `http://localhost:5001` only when the companion is running on the same machine as the service. For a phone, tablet, VM, or another laptop, paste a LAN-reachable host name or IP address such as `http://192.168.1.25:5001`.
+Use `http://localhost:5001` only when the companion is running on the same machine as the service. For a phone, tablet, VM, or another laptop, start the service with `AGENTDECK_COORDINATOR_BIND_ADDRESS=0.0.0.0` on a trusted network and paste a LAN-reachable host name or IP address such as `http://192.168.1.25:5001`.
 
 Known-good local verification commands:
 


### PR DESCRIPTION
Closes #435

## Summary
- reorganize Settings machine copy around Machines, provisioned capacity, saved machine profiles, and manual machine-agent startup
- move the direct machine-agent URL into advanced diagnostics and clarify when to edit it
- soften update/tool setup labels and dashboard setup CTAs around install/download/check-and-install language
- make remote-control takeover copy explicit about stopping input while preserving viewing
- polish dashboard remote-screen summaries, startup toast fallback, and README LAN quickstart guidance

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
- git diff --check