### PR TITLE
Polish workspace source and repo state UX

### DIFF
--- a/AgentDeck.Core/Components/DirectoryPicker.razor
+++ b/AgentDeck.Core/Components/DirectoryPicker.razor
@@ -2,12 +2,12 @@
 
 <div class="form-group">
     <select class="form-input" value="@_selected" @onchange="OnSelectChanged">
-        <option value="">— root —</option>
+        <option value="">— workspace root —</option>
         @if (_workspace is not null)
         {
-            @foreach (var dir in _workspace.Directories)
+            @foreach (var entry in GetDirectoryChoices())
             {
-                <option value="@dir">@dir</option>
+                <option value="@entry.Value">@entry.Label</option>
             }
         }
     </select>
@@ -17,6 +17,10 @@
            value="@Value"
            @oninput="OnInputChanged"
            placeholder="Working directory (empty = workspace root)" />
+    @if (_workspace is not null)
+    {
+        <span class="form-hint">Repository details are best-effort snapshots from the selected machine.</span>
+    }
     @if (!string.IsNullOrWhiteSpace(_errorMessage))
     {
         <div class="error-message">@_errorMessage</div>
@@ -65,4 +69,76 @@
         var val = e.Value?.ToString() ?? "";
         await ValueChanged.InvokeAsync(val);
     }
+
+    private IEnumerable<DirectoryChoice> GetDirectoryChoices()
+    {
+        if (_workspace is null)
+        {
+            yield break;
+        }
+
+        if (_workspace.Entries.Count > 0)
+        {
+            foreach (var entry in _workspace.Entries.OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                yield return new DirectoryChoice(entry.RelativePath, GetDirectoryEntryLabel(entry));
+            }
+
+            yield break;
+        }
+
+        foreach (var directory in _workspace.Directories.OrderBy(directory => directory, StringComparer.OrdinalIgnoreCase))
+        {
+            yield return new DirectoryChoice(directory, directory);
+        }
+    }
+
+    private static string GetDirectoryEntryLabel(WorkspaceDirectoryInfo entry)
+    {
+        if (entry.Repository is not { IsRepository: true } repository)
+        {
+            return entry.Name;
+        }
+
+        var details = new List<string>();
+        if (!string.IsNullOrWhiteSpace(repository.Branch))
+        {
+            details.Add(repository.Branch!);
+        }
+        else if (!string.IsNullOrWhiteSpace(repository.HeadSha))
+        {
+            details.Add(repository.HeadSha![..Math.Min(7, repository.HeadSha.Length)]);
+        }
+
+        if (repository.ModifiedCount > 0)
+        {
+            details.Add($"modified {repository.ModifiedCount}");
+        }
+
+        if (repository.UntrackedCount > 0)
+        {
+            details.Add($"untracked {repository.UntrackedCount}");
+        }
+
+        if (repository.AheadBy > 0)
+        {
+            details.Add($"ahead {repository.AheadBy}");
+        }
+
+        if (repository.BehindBy > 0)
+        {
+            details.Add($"behind {repository.BehindBy}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(repository.ScanError))
+        {
+            details.Add("Git status unavailable");
+        }
+
+        return details.Count == 0
+            ? $"{entry.Name} — Git repo"
+            : $"{entry.Name} — {string.Join(" • ", details)}";
+    }
+
+    private sealed record DirectoryChoice(string Value, string Label);
 }

--- a/AgentDeck.Core/Pages/Index.razor
+++ b/AgentDeck.Core/Pages/Index.razor
@@ -177,7 +177,7 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Workspaces</h2>
-                        <p>Import a repo, choose where it should run, and open terminals, apps, or remote screens.</p>
+                        <p>Import source code, choose where it should run, and open terminals, apps, or remote screens.</p>
                     </div>
                     <a class="btn btn-primary" href="/projects/new">Import or create workspace</a>
                 </div>
@@ -205,7 +205,7 @@
                                     <span class="machine-badge">@GetProjectSessionCount(project.Definition.Id) live sessions</span>
                                 </div>
                                 <p class="project-template-target__note">
-                                    Repo @GetRepositoryLabel(project.Definition)
+                                    Source @GetRepositoryLabel(project.Definition)
                                 </p>
                                 @if (project.Definition.Workspaces.Count > 0)
                                 {
@@ -322,7 +322,7 @@
         yield return new SetupStep(
             "Open a workspace",
             _dashboard.Projects.Count > 0 ? "Done" : "Next",
-            _dashboard.Projects.Count > 0 ? "Projects are ready to open." : "Import a repo or start from a template.",
+            _dashboard.Projects.Count > 0 ? "Projects are ready to open." : "Import source code or start from a template.",
             _dashboard.Projects.Count > 0 ? "complete" : "todo");
     }
 
@@ -356,7 +356,7 @@
         }
 
         return _dashboard.Projects.Count == 0
-            ? "Paste a GitHub URL or choose a template. You can keep advanced run-option settings collapsed."
+            ? "Paste a GitHub source URL or choose a template. You can keep advanced run-option settings collapsed."
             : "Pick up where you left off or open a workspace on a ready machine.";
     }
 
@@ -400,12 +400,15 @@
         if (readyTargets > 0)
         {
             return setupTargets > 0
-                ? $"Ready for {readyTargets} target(s); {setupTargets} need tools"
-                : $"Ready for {readyTargets} target(s)";
+                ? $"Ready for {readyTargets} {Pluralize("workspace target", readyTargets)}; {setupTargets} {Pluralize("target", setupTargets)} need tools"
+                : $"Ready for {readyTargets} {Pluralize("workspace target", readyTargets)}";
         }
 
         return setupTargets > 0 ? "Tools need setup before this machine can open workspaces" : "No supported workspace targets advertised yet";
     }
+
+    private static string Pluralize(string singular, int count) =>
+        count == 1 ? singular : $"{singular}s";
 
     private static string GetProjectSessionLocationLabel(ProjectSessionRecord session) =>
         string.IsNullOrWhiteSpace(session.MachineName)

--- a/AgentDeck.Core/Pages/ProjectDetails.razor
+++ b/AgentDeck.Core/Pages/ProjectDetails.razor
@@ -49,7 +49,7 @@
         <div class="page-header project-page__header">
             <div>
                 <h1>@_project.Definition.Name</h1>
-                <p>@_project.Definition.Workload • Repo @GetRepositoryLabel(_project.Definition)</p>
+                <p>@_project.Definition.Workload • Source @GetRepositoryLabel(_project.Definition)</p>
             </div>
             <div class="project-page__actions">
                 <a class="btn btn-accent" href="/">Dashboard</a>

--- a/AgentDeck.Core/Pages/ProjectEditor.razor
+++ b/AgentDeck.Core/Pages/ProjectEditor.razor
@@ -38,7 +38,7 @@
         <div class="page-header project-editor__header">
             <div>
                 <h1>@(_isExistingProject ? "Edit workspace" : "Import workspace")</h1>
-                <p>Paste a repo, pick a template, and only open advanced run settings if you need them.</p>
+                <p>Paste a source URL, pick a template, and only open advanced run settings if you need them.</p>
             </div>
             <div class="project-page__actions">
                 @if (_isExistingProject)
@@ -60,18 +60,18 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <span class="eyebrow">Simple setup</span>
-                        <h2>Start with a repository or template</h2>
+                        <h2>Start with source code or a template</h2>
                         <p>AgentDeck can fill in the workspace details for you. Advanced IDs and run commands stay editable below.</p>
                     </div>
                 </div>
                 <div class="project-editor__grid">
                     <div class="form-field project-editor__field--full">
-                        <label for="quick-repo-url">GitHub or Git repository URL</label>
+                        <label for="quick-repo-url">GitHub or Git source URL</label>
                         <div class="inline-action-field">
                             <input id="quick-repo-url" class="input" @bind="_quickRepositoryUrl" placeholder="https://github.com/owner/repo" />
-                            <button class="btn btn-primary" type="button" @onclick="ApplyRepositoryUrl">Use repo</button>
+                            <button class="btn btn-primary" type="button" @onclick="ApplyRepositoryUrl">Use source</button>
                         </div>
-                        <span class="form-hint">Supports GitHub HTTPS, SSH, and owner/repo shorthand.</span>
+                        <span class="form-hint">Supports GitHub HTTPS, SSH, and owner/repository shorthand.</span>
                     </div>
                 </div>
                 <div class="project-template-grid project-template-grid--compact">
@@ -149,21 +149,21 @@
                 <div class="dashboard-section-card__header">
                     <div>
                         <h2>Source</h2>
-                        <p>Leave the repository URL empty for a blank workspace; set it to clone automatically when opened on a machine.</p>
+                        <p>Leave the source URL empty for a blank workspace; set it to clone automatically when opened on a machine.</p>
                     </div>
                 </div>
 
                 <div class="project-editor__grid">
                     <div class="form-field">
-                        <label for="repo-name">Repository name</label>
+                        <label for="repo-name">Source name</label>
                         <input id="repo-name" class="input" @bind="_editor.RepositoryName" />
                     </div>
                     <div class="form-field">
-                        <label for="repo-owner">Repository owner</label>
+                        <label for="repo-owner">Source owner</label>
                         <input id="repo-owner" class="input" @bind="_editor.RepositoryOwner" />
                     </div>
                     <div class="form-field project-editor__field--full">
-                        <label for="repo-url">Repository URL</label>
+                        <label for="repo-url">Source URL</label>
                         <input id="repo-url" class="input" @bind="_editor.RepositoryUrl" />
                     </div>
                 </div>
@@ -452,7 +452,7 @@
         var parsed = ParseRepositoryInput(_quickRepositoryUrl);
         if (parsed is null)
         {
-            Toasts.Show("Paste a GitHub URL, git URL, or owner/repo shorthand.", ToastKind.Warning);
+            Toasts.Show("Paste a GitHub URL, Git URL, or owner/repository shorthand.", ToastKind.Warning);
             return;
         }
 
@@ -571,12 +571,12 @@
                 "Source",
                 HasRepositorySource() || _blankSourceMode,
                 !string.IsNullOrWhiteSpace(_editor.RepositoryUrl)
-                    ? "Repository URL is ready."
+                    ? "Source URL is ready."
                     : !string.IsNullOrWhiteSpace(_editor.RepositoryName)
-                        ? "Repository details are ready."
+                        ? "Source details are ready."
                         : _blankSourceMode
                             ? "Blank workspace selected; AgentDeck will use the workspace name for metadata."
-                            : "Paste a repo URL or choose the Blank workspace template for a local/scratch workspace."),
+                            : "Paste a source URL or choose the Blank workspace template for a local/scratch workspace."),
             new ReadinessItem(
                 "Run option",
                 _editor.LaunchProfiles.Any(profile => !string.IsNullOrWhiteSpace(profile.DisplayName) || !string.IsNullOrWhiteSpace(profile.Id)),

--- a/AgentDeck.Core/Pages/Settings.razor
+++ b/AgentDeck.Core/Pages/Settings.razor
@@ -182,7 +182,7 @@
 
         <div class="settings-callout">
             <strong>Start a machine agent manually</strong>
-            <span>On an existing machine, run <code>Coordinator__CoordinatorUrl=http://SERVICE-HOST:5001 dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj</code>, then refresh this page. Use a LAN host/IP when the machine is not the same device as the service.</span>
+            <span>From the repository root on an existing machine, run <code>Coordinator__CoordinatorUrl=http://SERVICE-HOST:5001 Coordinator__MachineId=my-machine Coordinator__MachineName=&quot;My machine&quot; dotnet run --project AgentDeck.Runner/AgentDeck.Runner.csproj</code>, then refresh this page. Use a LAN host/IP when the machine is not the same device as the service.</span>
         </div>
 
         @if (_runnerOrchestrationCatalog.Templates.Count == 0)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ After the secrets are configured, trigger **Build iOS IPA** from the Actions tab
 
 ## Configuration
 
+Most local setups only need the quickstart environment variables above: set the AgentDeck service URL, give each machine a stable name, and add an access key if you enabled one. The detailed files below use the internal project names: `AgentDeck.Coordinator` is the AgentDeck service, and `AgentDeck.Runner` is the machine agent.
+
 Coordinator configuration (`AgentDeck.Coordinator/appsettings.json`):
 
 ```json


### PR DESCRIPTION
Closes #439

## Summary
- show best-effort Git branch/change/ahead/behind details in the terminal working-directory picker using workspace entries
- reword workspace source labels from repo shorthand to source-oriented copy across dashboard, details, and editor
- make machine readiness counts read naturally
- expand the manual machine-agent Settings command with machine id/name and repository-root context
- add a plain-language README preface before internal Coordinator/Runner configuration examples

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore
- dotnet build AgentDeck/AgentDeck.csproj -f net10.0 --no-restore
- dotnet test AgentDeck.Runner.Tests/AgentDeck.Runner.Tests.csproj --no-build
- git diff --check