### PR TITLE
Allow default workflow pack execution

### DIFF
--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -442,7 +442,7 @@
           "PublicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvHQef5gS+TbUFlj5Y6YE\nsfOObha1E3O+I0sxZQJ/+fUJjn842e+kM9vW7qBpd+5oAJaub9nUnslxgujGYEXb\nP8vF4Zo6uVPyLTm8nKo2g4WlwQilJgTHycBxatmY17oRspRC/6BtgFv2uxW8S43Q\n+KnpbReCpvs9o8XAXJNr5Up3Iw+LyqjpOiqucwoJGNUzujxBI+nsAzHXtMV2u1tH\nWTCUFbeTcHMkjcVdeoLynqjdrvDKaEEqw8G8wGSI2/RmkwZfnnW0u7S12mZwnG9G\nExtaR7xuWs/9iesltySe2uuDo7byL2tLNnqNC3bIAN40tfsdCFqePxZIQglreEt/\nTQIDAQAB\n-----END PUBLIC KEY-----"
         }
       ],
-      "AllowWorkflowPackExecution": false,
+      "AllowWorkflowPackExecution": true,
       "AllowUpdateApply": false
     },
     "ApplyStagedUpdate": false,


### PR DESCRIPTION
Fixes #458\n\n## Validation\n- dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore