### PR TITLE
Keep desktop dropdowns anchored inline

### DIFF
--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -1269,6 +1269,15 @@ main {
 
 .input:focus { border-color: var(--color-accent); }
 
+select.input,
+select.form-input {
+    position: static;
+    inset: auto;
+    display: block;
+    max-width: 100%;
+    appearance: auto;
+}
+
 .checkbox-label { display: flex; align-items: center; gap: 0.5rem; cursor: pointer; color: var(--color-text); font-size: 0.875rem; }
 
 .form-actions { display: flex; gap: 0.75rem; margin-top: 1.25rem; }


### PR DESCRIPTION
Fixes #469.\n\n## Summary\n- normalizes select controls that use AgentDeck input classes\n- forces desktop selects to stay in normal document flow instead of inheriting overlay-like positioning\n\n## Validation\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore