### PR TITLE
Anchor desktop select controls

### DIFF
--- a/AgentDeck.Core/wwwroot/css/app.css
+++ b/AgentDeck.Core/wwwroot/css/app.css
@@ -1274,7 +1274,9 @@ select.form-input {
     position: static;
     inset: auto;
     display: block;
+    width: 100%;
     max-width: 100%;
+    min-height: 2.35rem;
     appearance: auto;
 }
 


### PR DESCRIPTION
Closes #469
Closes #467

## Summary
- keep native select controls in normal document flow instead of inheriting fixed placement
- ensure select controls fill their field with a stable desktop hit target

## Validation
- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore