### PR TITLE
Normalize terminal newline rendering

### DIFF
--- a/AgentDeck.Core/wwwroot/js/agentdeck.js
+++ b/AgentDeck.Core/wwwroot/js/agentdeck.js
@@ -58,6 +58,11 @@ export function createTerminal(elementId, sessionId, dotnetRef, theme) {
         cursorBlink: true,
         cursorStyle: 'bar',
         scrollback: 5000,
+        // PTY output can contain bare LF characters. In a terminal emulator LF
+        // advances the row but does not reset the cursor column, which makes
+        // plain-text output stair-step. Treat LF as CRLF for display so new
+        // lines start at column zero while preserving normal ANSI behavior.
+        convertEol: true,
         theme: theme || {
             background:   '#1e1e2e',
             foreground:   '#cdd6f4',


### PR DESCRIPTION
Fixes #475.\n\n## Summary\n- enable xterm convertEol so bare LF output returns to column zero\n- document why AgentDeck normalizes PTY output for display\n\n## Validation\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore