### PR TITLE
Add terminal shortcut handling

### DIFF
--- a/AgentDeck.Core/wwwroot/js/agentdeck.js
+++ b/AgentDeck.Core/wwwroot/js/agentdeck.js
@@ -151,11 +151,7 @@ export function createTerminal(elementId, sessionId, dotnetRef, theme) {
     addPasteTarget(term.textarea);
     addPasteTarget(container.querySelector('.xterm-helper-textarea'));
 
-    term.attachCustomKeyEventHandler(event => {
-        if (event.type !== 'keydown' || event.key?.toLowerCase() !== 'v' || (!event.ctrlKey && !event.metaKey)) {
-            return true;
-        }
-
+    const pasteFromClipboard = event => {
         if (!navigator.clipboard?.readText) {
             return true;
         }
@@ -165,6 +161,58 @@ export function createTerminal(elementId, sessionId, dotnetRef, theme) {
             .catch(err => console.warn('[AgentDeck] clipboard paste failed:', err));
         event.preventDefault();
         return false;
+    };
+
+    const sendShortcut = (event, data) => {
+        sendTerminalInput(data);
+        event.preventDefault();
+        return false;
+    };
+
+    term.attachCustomKeyEventHandler(event => {
+        if (event.type !== 'keydown') {
+            return true;
+        }
+
+        const key = event.key?.toLowerCase();
+
+        if ((event.ctrlKey || event.metaKey) && key === 'v') {
+            return pasteFromClipboard(event);
+        }
+
+        if (event.shiftKey && event.key === 'Insert') {
+            return pasteFromClipboard(event);
+        }
+
+        if (event.ctrlKey && event.key === 'Backspace') {
+            // Readline-compatible previous-word delete.
+            return sendShortcut(event, '\x17');
+        }
+
+        if (event.ctrlKey && event.key === 'Delete') {
+            // xterm sequence for Ctrl+Delete / delete next word in readline-aware apps.
+            return sendShortcut(event, '\x1b[3;5~');
+        }
+
+        if (event.altKey && event.key === 'Backspace') {
+            // Meta+Backspace is the common terminal binding for backward-kill-word.
+            return sendShortcut(event, '\x1b\x7f');
+        }
+
+        if (event.altKey && key === 'b') {
+            return sendShortcut(event, '\x1bb');
+        }
+
+        if (event.altKey && key === 'f') {
+            return sendShortcut(event, '\x1bf');
+        }
+
+        if (event.shiftKey && event.key === 'Backspace') {
+            // Preserve shifted backspace as an explicit DEL instead of letting the browser decide.
+            return sendShortcut(event, '\x7f');
+        }
+
+        return true;
     });
 }
 


### PR DESCRIPTION
Fixes #479.\n\n## Summary\n- add explicit handling for Ctrl+Backspace, Ctrl+Delete, Alt+Backspace, Alt+B, Alt+F, Shift+Backspace, and Shift+Insert\n- reuse the existing terminal input path for generated shortcut sequences\n- keep Ctrl/Cmd+V and Shift+Insert paste on the clipboard path\n\n## Validation\n- dotnet build AgentDeck.Core/AgentDeck.Core.csproj --no-restore