### PR TITLE
Add VS Code setup recipes

### DIFF
--- a/AgentDeck.Coordinator/appsettings.json
+++ b/AgentDeck.Coordinator/appsettings.json
@@ -192,6 +192,22 @@
               "Arguments": [ "--version" ]
             }
           ]
+        },
+        {
+          "CapabilityId": "vscode",
+          "DisplayName": "Visual Studio Code",
+          "Category": "ide",
+          "ProbeKind": "GenericCliVersion",
+          "ProbeCommands": [
+            {
+              "FileName": "code",
+              "Arguments": [ "--version" ]
+            },
+            {
+              "FileName": "code-insiders",
+              "Arguments": [ "--version" ]
+            }
+          ]
         }
       ]
     },
@@ -422,6 +438,60 @@
                   "MatchVersionPattern": "^\\d+\\.\\d+$",
                   "CommandText": "wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && apt-get update && apt-get install -y dotnet-sdk-{requestedVersion}",
                   "RequiredCommands": [ "apt-get", "wget", "dpkg" ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "CapabilityId": "vscode",
+          "DisplayName": "Visual Studio Code",
+          "Actions": [
+            {
+              "Action": "install",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "winget install --id Microsoft.VisualStudioCode -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "apt-get update && apt-get install -y wget gpg apt-transport-https ca-certificates && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/packages.microsoft.gpg && install -D -o root -g root -m 644 /tmp/packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg && echo 'deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main' > /etc/apt/sources.list.d/vscode.list && rm -f /tmp/packages.microsoft.gpg && apt-get update && apt-get install -y code",
+                  "RequiredCommands": [ "apt-get", "wget", "gpg" ]
+                },
+                {
+                  "Platform": "MacOS",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "brew install --cask visual-studio-code",
+                  "RequiredCommands": [ "brew" ],
+                  "RequiredCommandsMessage": "Homebrew is required to install Visual Studio Code automatically on macOS. Install Homebrew first or install VS Code manually from https://code.visualstudio.com/."
+                }
+              ]
+            },
+            {
+              "Action": "update",
+              "Recipes": [
+                {
+                  "Platform": "Windows",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "winget upgrade --id Microsoft.VisualStudioCode -e --accept-package-agreements --accept-source-agreements",
+                  "RequiredCommands": [ "winget" ]
+                },
+                {
+                  "Platform": "Linux",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "apt-get update && apt-get install -y --only-upgrade code",
+                  "RequiredCommands": [ "apt-get" ]
+                },
+                {
+                  "Platform": "MacOS",
+                  "ExecutionKind": "PlatformShell",
+                  "CommandText": "brew upgrade --cask visual-studio-code",
+                  "RequiredCommands": [ "brew" ],
+                  "RequiredCommandsMessage": "Homebrew is required to update Visual Studio Code automatically on macOS."
                 }
               ]
             }


### PR DESCRIPTION
Fixes #481.\n\n## Summary\n- add Visual Studio Code to the default capability catalog\n- add install/update setup recipes for Windows winget, Linux apt/Microsoft repo, and macOS Homebrew cask\n\n## Validation\n- python3 -m json.tool AgentDeck.Coordinator/appsettings.json\n- dotnet build AgentDeck.Coordinator/AgentDeck.Coordinator.csproj --no-restore